### PR TITLE
Townspeople combat: guards hunt predators, workers fight back

### DIFF
--- a/src/biome.rs
+++ b/src/biome.rs
@@ -462,7 +462,8 @@ pub fn scatter_region(
                         // (capped ≤ the blockers neighbour-scan bound) so you can walk under
                         // the canopy and brush past, but not through the bole. Small props
                         // (bushes/rocks/barrel cacti/ground cover) register nothing.
-                        crate::blockers::add(cx, cz, (0.2 * s).min(0.8));
+                        let trunk_r = (0.2 * s).min(0.8);
+                        crate::blockers::add(cx, cz, trunk_r);
                         let base = cardinal(&mut r);
                         commands.spawn((
                             Mesh3d(mesh),
@@ -476,7 +477,7 @@ pub fn scatter_region(
                             crate::wind::sway_for(cx, cz, base),
                             // Every scattered tree is choppable for wood (1 tree = 1 wood). The
                             // trunk blocker is cleared on fell via `blockers::remove_at`.
-                            crate::verbs::ChopTree::new(),
+                            crate::verbs::ChopTree::new(trunk_r),
                             BiomeEntity,
                         ));
                     }

--- a/src/lumberjack.rs
+++ b/src/lumberjack.rs
@@ -1,0 +1,328 @@
+//! **Woodcutters work the woods for real.** A townsperson posted to a Lumber plot no longer
+//! mimes at the yard: it walks out to an actual scattered tree, chops it down (the tree falls,
+//! banks wood, and regrows later — see `verbs::fell_tree`), then moves on to the next.
+//!
+//! Two hard rails keep this from feeding the orks an endless villager buffet:
+//!   * **Safe ground only** — a tree is workable only inside [`WORK_R`] of the castle and at
+//!     least [`CAMP_AVOID`] from every ork camp (and never inside a camp clearing), so a
+//!     woodcutter never wanders into a warband on its own.
+//!   * **Threat sense** — any ork or predator inside [`DANGER_R`] sends the woodcutter running
+//!     home ([`Fleeing`]) and blacklists that ground for [`DANGER_TTL`] seconds
+//!     ([`DangerSpots`]), so it does NOT trudge straight back under the same shaman's bolt.
+//!
+//! While a woodcutter is actually at a tree it counts as `at_post` — the Lumber plot stays
+//! staffed, so the test-gated `town_store` production keeps its balance; the felled trees' +1
+//! wood is the visible bonus on top. If it's caught anyway, the shared villager self-defence
+//! (`villagers::FightBack`) takes over — it drops the flight and fights.
+
+use bevy::prelude::*;
+
+use tileworld_core::town_store::BuildKind;
+
+use crate::economy::Bank;
+use crate::steer;
+use crate::town::Worker;
+use crate::villagers::{FightBack, Guard, Townsfolk, Villager};
+use crate::worldmap;
+
+/// Trees are only worked this close to the castle origin (the safe heart of the island)…
+const WORK_R: f32 = 45.0;
+/// …and no closer than this to any ork camp centre.
+const CAMP_AVOID: f32 = 22.0;
+/// A hostile (ork / predator) this near a woodcutter triggers the flight home.
+const DANGER_R: f32 = 12.0;
+/// Trees this near a remembered scare are off-limits while it lasts.
+const DANGER_BLACKLIST_R: f32 = 16.0;
+/// How long a scare keeps its ground blacklisted (s).
+const DANGER_TTL: f32 = 120.0;
+/// Axe damage per work swing (TREE_HP 55 → ~5 swings ≈ 10s a tree).
+const CHOP_DMG: f64 = 12.0;
+/// Seconds between work swings — matches the overhead chop loop in `villager_limbs` (~2.1s).
+const CHOP_CD: f32 = 2.1;
+/// Close enough to swing (trunk blockers are ≤ 0.8, body 0.28 — this clears both).
+const CHOP_REACH: f32 = 2.0;
+/// Don't rescan the whole tree set every frame when there's nothing eligible.
+const RETRY_SECS: f32 = 3.0;
+/// A flight home gives up after this long even if the walls weren't reached.
+const FLEE_SECS: f32 = 9.0;
+/// Reaching this close to the castle origin counts as "safe — stop running".
+const FLEE_HOME_R: f32 = 14.0;
+/// No steering progress toward the tree for this long → wedged; abandon + blacklist briefly.
+const STALL_SECS: f32 = 4.0;
+/// Chop SFX is only audible this near the hero (the guards' small-earshot convention).
+const SFX_EARSHOT: f32 = 16.0;
+
+/// The tree a woodcutter is working: walk to it, swing on the cooldown, fell it, pick the next.
+#[derive(Component)]
+pub struct ChopJob {
+    tree: Entity,
+    atk_cd: f32,
+    /// Seconds without steering progress (wedged on a river/prop) — bail at [`STALL_SECS`].
+    stall: f32,
+}
+
+/// A working NPC running for the castle after its threat sense fired (or it was attacked and
+/// the brawl broke off). Removed on reaching home ground or after [`FLEE_SECS`].
+#[derive(Component)]
+pub struct Fleeing {
+    until: f32,
+}
+
+/// Remembered scares: `(world XZ, expires_at)`. Trees near one are skipped while it lasts —
+/// the cap on the "ork farms the same woodcutter forever" loop.
+#[derive(Resource, Default)]
+struct DangerSpots(Vec<(Vec2, f32)>);
+
+pub struct LumberjackPlugin;
+
+impl Plugin for LumberjackPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DangerSpots>().add_systems(
+            Update,
+            (lumber_danger, assign_tree, chop_work, flee_steer)
+                .run_if(in_state(crate::game_state::Modal::None)),
+        );
+    }
+}
+
+/// Threat sense: an ork or a predator prowling inside [`DANGER_R`] of a working woodcutter sends
+/// it running home and blacklists the spot. Also expires old scares.
+#[allow(clippy::type_complexity)]
+fn lumber_danger(
+    time: Res<Time>,
+    mut danger: ResMut<DangerSpots>,
+    mut commands: Commands,
+    workers: Query<
+        (Entity, &Villager),
+        (With<Worker>, With<ChopJob>, Without<Fleeing>, Without<crate::dying::Dying>),
+    >,
+    orks: Query<&crate::orks::Ork, Without<crate::dying::Dying>>,
+    animals: Query<&crate::wildlife::Animal, Without<crate::dying::Dying>>,
+) {
+    let now = time.elapsed_secs();
+    danger.0.retain(|(_, until)| now < *until);
+    if workers.is_empty() {
+        return;
+    }
+    let mut hostiles: Vec<Vec2> = orks.iter().map(|o| o.pos).collect();
+    hostiles.extend(
+        animals.iter().filter(|a| crate::wildlife::is_hostile_species(a.species)).map(|a| a.pos),
+    );
+    for (e, v) in &workers {
+        if let Some(hp) = hostiles.iter().find(|h| h.distance(v.pos) < DANGER_R) {
+            commands.entity(e).try_remove::<ChopJob>().try_insert(Fleeing { until: now + FLEE_SECS });
+            danger.0.push((*hp, now + DANGER_TTL));
+        }
+    }
+}
+
+/// Hand each idle Lumber-plot worker the nearest workable tree (safe ground, not blacklisted).
+/// Throttled to every [`RETRY_SECS`] — the tree set is large and assignment isn't urgent.
+#[allow(clippy::type_complexity)]
+fn assign_tree(
+    time: Res<Time>,
+    town: Res<crate::town::TownRes>,
+    danger: Res<DangerSpots>,
+    mut retry_at: Local<f32>,
+    mut commands: Commands,
+    workers: Query<
+        (Entity, &Worker, &Villager),
+        (
+            With<Townsfolk>,
+            Without<ChopJob>,
+            Without<Fleeing>,
+            Without<FightBack>,
+            Without<crate::dying::Dying>,
+        ),
+    >,
+    trees: Query<(Entity, &Transform), (With<crate::verbs::ChopTree>, Without<crate::verbs::Stump>)>,
+) {
+    let now = time.elapsed_secs();
+    if now < *retry_at {
+        return;
+    }
+    *retry_at = now + RETRY_SECS;
+    let camps: Vec<Vec2> = crate::camps::cage_positions().iter().map(|(_, c)| *c).collect();
+    for (e, worker, v) in &workers {
+        if town.0.plots.get(worker.idx).and_then(|p| p.kind) != Some(BuildKind::Lumber) {
+            continue; // farmers keep their field mime — only woodcutters roam
+        }
+        let mut best: Option<(Entity, f32)> = None;
+        for (te, tf) in &trees {
+            let tp = Vec2::new(tf.translation.x, tf.translation.z);
+            if tp.length() > WORK_R
+                || crate::camps::in_clearing(tp.x, tp.y)
+                || camps.iter().any(|c| c.distance(tp) < CAMP_AVOID)
+                || danger.0.iter().any(|(d, _)| d.distance(tp) < DANGER_BLACKLIST_R)
+            {
+                continue;
+            }
+            let d = v.pos.distance(tp);
+            if best.is_none_or(|(_, bd)| d < bd) {
+                best = Some((te, d));
+            }
+        }
+        if let Some((te, _)) = best {
+            commands.entity(e).try_insert(ChopJob { tree: te, atk_cd: 0.0, stall: 0.0 });
+        }
+    }
+}
+
+/// Walk the woodcutter to its tree and swing the axe on the cooldown; fell on the last blow.
+/// At the tree it counts `at_post` (the plot stays staffed) and the overhead-chop work loop in
+/// `villager_limbs` plays for free.
+#[allow(clippy::type_complexity)]
+fn chop_work(
+    time: Res<Time>,
+    mut commands: Commands,
+    mut bank: ResMut<Bank>,
+    mut floats: ResMut<crate::combat_fx::FloatQueue>,
+    mut cues: MessageWriter<crate::audio::AudioCue>,
+    mut danger: ResMut<DangerSpots>,
+    hero: Res<crate::player::HeroState>,
+    mut workers: Query<
+        (Entity, &mut ChopJob, &mut Worker, &mut Villager, &mut Transform, &mut crate::navgrid::NavPath),
+        (Without<Fleeing>, Without<FightBack>, Without<crate::dying::Dying>),
+    >,
+    mut trees: Query<
+        (&mut crate::verbs::ChopTree, &Transform),
+        (Without<crate::verbs::Stump>, Without<Worker>),
+    >,
+) {
+    let dt = time.delta_secs().min(0.05);
+    let tw = time.elapsed_secs_wrapped();
+    let now = time.elapsed_secs();
+    for (self_e, mut job, mut worker, mut v, mut tf, mut path) in &mut workers {
+        let Ok((mut tree, ttf)) = trees.get_mut(job.tree) else {
+            // Felled (stumped) or gone — back to the pool; `assign_tree` hands out the next one.
+            commands.entity(self_e).try_remove::<ChopJob>();
+            continue;
+        };
+        let tp = Vec2::new(ttf.translation.x, ttf.translation.z);
+        let d = v.pos.distance(tp);
+        job.atk_cd -= dt;
+        if d <= CHOP_REACH {
+            // At the tree: face it, plant the feet, swing on the cooldown.
+            worker.at_post = true;
+            v.moving = false;
+            job.stall = 0.0;
+            let to = tp - v.pos;
+            if to.length_squared() > 1e-4 {
+                v.facing = to.x.atan2(to.y);
+            }
+            if job.atk_cd <= 0.0 {
+                job.atk_cd = CHOP_CD;
+                if hero.pos.distance(v.pos) < SFX_EARSHOT {
+                    cues.write(crate::audio::AudioCue::WoodChop);
+                }
+                if tree.work_chop(CHOP_DMG) {
+                    crate::verbs::fell_tree(
+                        &mut commands,
+                        job.tree,
+                        ttf.translation,
+                        now,
+                        &mut bank.0,
+                        &mut floats,
+                    );
+                    commands.entity(self_e).try_remove::<ChopJob>();
+                }
+            }
+        } else {
+            // March to the tree: A* when far (thread the gates/river), direct steer when close.
+            worker.at_post = false;
+            let step_target = if d > 6.0 {
+                if path.cursor >= path.waypoints.len()
+                    || now >= path.next_replan
+                    || path.goal_cached.distance(tp) > 2.0
+                {
+                    path.waypoints = crate::navgrid::path_to(v.pos, tp);
+                    path.cursor = 0;
+                    path.goal_cached = tp;
+                    path.next_replan = now + 1.0 + (self_e.to_bits() % 16) as f32 * 0.05;
+                }
+                while path.cursor < path.waypoints.len()
+                    && v.pos.distance(path.waypoints[path.cursor]) < 1.2
+                {
+                    path.cursor += 1;
+                }
+                path.waypoints.get(path.cursor).copied().unwrap_or(tp)
+            } else {
+                path.waypoints.clear();
+                path.cursor = 0;
+                tp
+            };
+            let cur_y = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
+            let advanced = steer::advance(
+                v.pos,
+                v.facing,
+                step_target,
+                v.speed * dt,
+                v.body_r,
+                cur_y,
+                3.0 * dt,
+            );
+            match advanced {
+                Some(s) if s.moving => {
+                    v.pos = s.pos;
+                    v.facing = s.facing;
+                    v.moving = true;
+                    job.stall = 0.0;
+                }
+                _ => {
+                    v.moving = false;
+                    job.stall += dt;
+                    if job.stall > STALL_SECS {
+                        // Wedged (river bend, prop knot) — abandon this tree and shun the spot
+                        // briefly so the next pick is a different one.
+                        danger.0.push((tp, now + 45.0));
+                        commands.entity(self_e).try_remove::<ChopJob>();
+                    }
+                }
+            }
+        }
+        // Ground-follow + bob (this system owns the transform while the job is on).
+        let gy = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
+        let bob = if v.moving { (tw * v.gait + v.phase).sin().abs() * v.bob } else { 0.0 };
+        tf.translation = Vec3::new(v.pos.x, gy + bob, v.pos.y);
+        tf.rotation = Quat::from_rotation_y(v.facing);
+    }
+}
+
+/// Run a fleeing NPC home (toward the castle origin), then stand down. A dusk-mustered guard
+/// sheds the flag instead — the guard brain owns it from there.
+#[allow(clippy::type_complexity)]
+fn flee_steer(
+    time: Res<Time>,
+    mut commands: Commands,
+    mut q: Query<
+        (Entity, &Fleeing, &mut Villager, &mut Transform, Option<&mut Worker>, Has<Guard>),
+        Without<crate::dying::Dying>,
+    >,
+) {
+    let dt = time.delta_secs().min(0.05);
+    let tw = time.elapsed_secs_wrapped();
+    let now = time.elapsed_secs();
+    for (e, flee, mut v, mut tf, worker, is_guard) in &mut q {
+        if is_guard || now > flee.until || v.pos.length() < FLEE_HOME_R {
+            commands.entity(e).try_remove::<Fleeing>();
+            continue;
+        }
+        if let Some(mut w) = worker {
+            w.at_post = false;
+        }
+        let cur_y = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
+        // Adrenaline sprint for the walls.
+        match steer::advance(v.pos, v.facing, Vec2::ZERO, v.speed * 1.7 * dt, v.body_r, cur_y, 4.5 * dt) {
+            Some(s) => {
+                v.pos = s.pos;
+                v.facing = s.facing;
+                v.moving = s.moving;
+            }
+            None => v.moving = false,
+        }
+        let gy = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
+        let bob = if v.moving { (tw * v.gait + v.phase).sin().abs() * v.bob } else { 0.0 };
+        tf.translation = Vec3::new(v.pos.x, gy + bob, v.pos.y);
+        tf.rotation = Quat::from_rotation_y(v.facing);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ mod hud;
 mod interaction;
 mod inventory;
 mod landmarks;
+mod lumberjack;
 mod navgrid;
 mod orbs;
 mod orks;
@@ -152,6 +153,7 @@ fn main() {
         ))
         .add_plugins((
             town::TownPlugin, // city-building: plots, build menu, economy, burn/repair
+            lumberjack::LumberjackPlugin, // woodcutters fell real trees (safe zone + threat sense)
             savegame::SaveGamePlugin, // dawn autosave + Continue/New Game (one slot)
         ))
         .run();

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -402,7 +402,7 @@ pub fn player_attack(
             if let Some(mut an) = animal {
                 an.kb = dir * if crit { KNOCKBACK_CRIT } else { KNOCKBACK };
                 an.hit_recoil = now_s;
-                commands.entity(e).try_insert(crate::wildlife::Struck);
+                commands.entity(e).try_insert(crate::wildlife::Struck { by: None });
             }
         }
     }

--- a/src/siege.rs
+++ b/src/siege.rs
@@ -637,15 +637,15 @@ fn invader_brain(
     siege: Res<Siege>,
     mut keep: ResMut<KeepHp>,
     mut pending: ResMut<PendingHeroDamage>,
-    mut guard_dmg: ResMut<crate::villagers::GuardDamage>,
+    mut guard_dmg: ResMut<crate::villagers::NpcDamage>,
     mut bolts: ResMut<BoltSpawns>,
     mut commands: Commands,
     town: Res<crate::town::TownRes>,
     plot_spots: Res<crate::town::PlotSpots>,
     mut building_dmg: ResMut<crate::town::PendingBuildingDamage>,
     guards: Query<
-        (Entity, &Transform, &crate::villagers::Guard),
-        (Without<WaveInvader>, Without<crate::dying::Dying>),
+        (Entity, &Transform),
+        (With<crate::villagers::Guard>, Without<WaveInvader>, Without<crate::dying::Dying>),
     >,
     mut q: Query<
         (
@@ -666,11 +666,10 @@ fn invader_brain(
     let now = game.0; // pause-aware clock for logic (replan throttle, stuck-net)
     let rnow = time.elapsed_secs(); // raw clock for visuals/corpse-fade (matches ork_limbs & dying.rs)
 
-    // Living guards this frame (downed ones aren't worth diverting onto).
+    // Living guards this frame (the dying are already filtered out — death is permanent now).
     let live_guards: Vec<(Entity, Vec2)> = guards
         .iter()
-        .filter(|(_, _, g)| !g.is_downed())
-        .map(|(e, tf, _)| (e, Vec2::new(tf.translation.x, tf.translation.z)))
+        .map(|(e, tf)| (e, Vec2::new(tf.translation.x, tf.translation.z)))
         .collect();
     let guard_positions: Vec<Vec2> = live_guards.iter().map(|(_, p)| *p).collect();
 
@@ -765,7 +764,11 @@ fn invader_brain(
                         if o.shaman { orks::SHAMAN_CAST_CD } else { orks::ORK_ATTACK_CD * frenzy_cd };
                     if let Some((ge, _)) = guard_tgt {
                         let dmg = orks::variant_melee(o.variant) * crate::villagers::GUARD_ARMOR_MULT;
-                        guard_dmg.0.push((ge, dmg));
+                        guard_dmg.0.push(crate::villagers::NpcHit {
+                            victim: ge,
+                            amount: dmg,
+                            attacker: Some(e),
+                        });
                     }
                 } else {
                     // Hammering the keep.

--- a/src/town.rs
+++ b/src/town.rs
@@ -196,10 +196,16 @@ fn production_system(time: Res<Time>, mut town: ResMut<TownRes>, mut bank: ResMu
 /// here — [`sync_population_bodies`] reconciles them to `town.population` next frame.
 fn population_system(
     time: Res<Time>,
+    siege: Option<Res<crate::siege::Siege>>,
     mut town: ResMut<TownRes>,
     mut lives: ResMut<Lives>,
     mut floats: ResMut<crate::combat_fx::FloatQueue>,
 ) {
+    // Growing a new peasant is a daytime thing: while the night wave is on, the food→population
+    // flow pauses entirely — losses to the horde can't be replaced until dawn.
+    if siege.is_some_and(|s| s.phase == crate::siege::GamePhase::Wave) {
+        return;
+    }
     let dt = time.delta_secs() as f64;
     match town.0.population_tick(dt) {
         PopEvent::Grew => {
@@ -234,8 +240,10 @@ fn sync_population_bodies(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    folk: Query<Entity, With<Townsfolk>>,
-    idle_guards: Query<Entity, (With<Townsfolk>, With<Guard>, Without<Worker>)>,
+    // The dying are already subtracted from `population` (see `villagers::npc_damage_apply`) —
+    // counting their still-fading bodies would make this reaper cull a second, living villager.
+    folk: Query<Entity, (With<Townsfolk>, Without<crate::dying::Dying>)>,
+    idle_guards: Query<Entity, (With<Townsfolk>, With<Guard>, Without<Worker>, Without<crate::dying::Dying>)>,
     mut next_seed: Local<u32>,
 ) {
     let want = town.0.population as i64;

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -60,6 +60,7 @@ impl Plugin for VerbsPlugin {
                 (
                     mine_ore,
                     chop_tree,
+                    regrow_trees,
                     forage_pickup,
                     forage_respawn,
                     apple_harvest,
@@ -157,13 +158,30 @@ fn mine_ore(
 #[derive(Component)]
 pub struct ChopTree {
     hp: f64,
+    /// The trunk-blocker radius registered at scatter time, so a regrown tree can re-block.
+    trunk_r: f32,
 }
 
 impl ChopTree {
-    /// A fresh choppable tree at full HP — added to every scattered tree in `biome::scatter_region`.
-    pub fn new() -> Self {
-        Self { hp: TREE_HP }
+    /// A fresh choppable tree at full HP — added to every scattered tree in `biome::scatter_region`,
+    /// which passes the same trunk radius it registered as the blocker.
+    pub fn new(trunk_r: f32) -> Self {
+        Self { hp: TREE_HP, trunk_r }
     }
+
+    /// Take a work swing (a woodcutter's axe — `lumberjack.rs`). True once the tree is felled.
+    pub fn work_chop(&mut self, dmg: f64) -> bool {
+        self.hp -= dmg;
+        self.hp <= 0.0
+    }
+}
+
+/// A felled tree waiting to regrow: hidden in place (the trunk blocker lifted), restored to a
+/// full [`ChopTree`] by [`regrow_trees`] — so the woodcutters can't permanently deforest the
+/// safe zone, and the player's own clear-cuts heal over too.
+#[derive(Component)]
+pub struct Stump {
+    regrow_at: f32,
 }
 
 /// Swings to fell a tree (~2 at the hero's base 25–30 dmg).
@@ -172,16 +190,60 @@ const TREE_HP: f64 = 55.0;
 const TREE_WOOD: f64 = 1.0;
 /// Tree trunk radius added to the swing reach.
 const CHOP_TREE_RADIUS: f32 = 1.0;
+/// Seconds before a felled tree grows back in place.
+const TREE_REGROW: f32 = 150.0;
+
+/// Fell `e`: bank the wood (+ float), lift the trunk blocker, and leave a hidden [`Stump`] in
+/// place to regrow. Shared by the hero's [`chop_tree`] and the woodcutter NPC (`lumberjack.rs`).
+pub fn fell_tree(
+    commands: &mut Commands,
+    e: Entity,
+    at: Vec3,
+    now: f32,
+    bank: &mut tileworld_core::resource_store::ResourceState,
+    floats: &mut crate::combat_fx::FloatQueue,
+) {
+    bank.add_wood(TREE_WOOD);
+    floats.0.push(crate::combat_fx::FloatReq {
+        world: Vec3::new(at.x, at.y + 1.6, at.z),
+        text: format!("+{} wood", TREE_WOOD as i64),
+        color: Color::srgb(0.78, 0.62, 0.36),
+        scale: 1.1,
+    });
+    crate::blockers::remove_at(at.x, at.z); // clear the trunk blocker so no ghost nub
+    commands
+        .entity(e)
+        .try_insert((Stump { regrow_at: now + TREE_REGROW }, Visibility::Hidden));
+}
+
+/// Restore each due stump to a standing, choppable tree (visible again, trunk re-blocked).
+fn regrow_trees(
+    time: Res<Time>,
+    mut commands: Commands,
+    mut q: Query<(Entity, &mut ChopTree, &Stump, &Transform, &mut Visibility)>,
+) {
+    let now = time.elapsed_secs();
+    for (e, mut tree, stump, tf, mut vis) in &mut q {
+        if now < stump.regrow_at {
+            continue;
+        }
+        tree.hp = TREE_HP;
+        *vis = Visibility::Visible;
+        crate::blockers::add(tf.translation.x, tf.translation.z, tree.trunk_r);
+        commands.entity(e).try_remove::<Stump>();
+    }
+}
 
 /// Read each published swing; any live choppable tree in the cone takes the blow. On felling
 /// it banks 1 wood, pops a float, and despawns. Mirrors [`mine_ore`].
 fn chop_tree(
+    time: Res<Time>,
     mut swings: MessageReader<HeroSwing>,
     mut bank: ResMut<Bank>,
     mut commands: Commands,
     mut floats: ResMut<crate::combat_fx::FloatQueue>,
     mut cues: MessageWriter<AudioCue>,
-    mut q: Query<(Entity, &mut ChopTree, &Transform)>,
+    mut q: Query<(Entity, &mut ChopTree, &Transform), Without<Stump>>,
 ) {
     for sw in swings.read() {
         let mut struck = false; // one chop thunk per swing, even if several trees are in the cone
@@ -201,15 +263,7 @@ fn chop_tree(
             struck = true;
             tree.hp -= sw.base_dmg as f64;
             if tree.hp <= 0.0 {
-                bank.0.add_wood(TREE_WOOD);
-                floats.0.push(crate::combat_fx::FloatReq {
-                    world: Vec3::new(p.x, p.y + 1.6, p.z),
-                    text: format!("+{} wood", TREE_WOOD as i64),
-                    color: Color::srgb(0.78, 0.62, 0.36),
-                    scale: 1.1,
-                });
-                crate::blockers::remove_at(p.x, p.z); // clear the trunk blocker so no ghost nub
-                commands.entity(e).try_despawn();
+                fell_tree(&mut commands, e, p, time.elapsed_secs(), &mut bank.0, &mut floats);
             }
         }
         if struck {

--- a/src/villagers.rs
+++ b/src/villagers.rs
@@ -1,7 +1,9 @@
-//! **Villagers** — the castle town's ambient population, ported from the TS `Villager.tsx`
-//! mesh tree. Box-mesh humanoids that idle and stroll around the courtyard, with a few posted
-//! at the keep + spilling out through the gates. The scene is a viewer, so there's no day
-//! schedule, no guard combat and no upgrades — just lived-in townsfolk.
+//! **Villagers** — the castle town's population, ported from the TS `Villager.tsx` mesh tree.
+//! Box-mesh humanoids that idle and stroll around the courtyard, with a few posted at the keep +
+//! spilling out through the gates. The town pool ([`Townsfolk`]) is a full combat participant
+//! now: every member carries [`NpcHp`], guards hunt orks *and* predators near their post, passive
+//! workers fight back when struck ([`FightBack`]), and death is permanent (replacements are grown
+//! from the food surplus by day — see `town.rs`).
 //!
 //! Same ambient-biped pattern as `orks.rs`: a static **torso** plus articulated **parts**
 //! (2 legs, 2 arms, a head) that swing via the shared sin trick; navigation is the shared
@@ -50,20 +52,23 @@ enum Mode {
     Walk,
 }
 
+/// The shared villager pose/locomotion state. The gameplay-relevant fields are `pub(crate)` so
+/// the sibling NPC brains (`lumberjack.rs` chop/flee steering, the predator AI in `wildlife.rs`)
+/// can drive/read the same pose the in-module brains do.
 #[derive(Component)]
 pub struct Villager {
     home: Vec2,
     target: Vec2,
-    pos: Vec2,
-    facing: f32,
-    speed: f32,
+    pub(crate) pos: Vec2,
+    pub(crate) facing: f32,
+    pub(crate) speed: f32,
     wander_r: f32,
-    gait: f32,
+    pub(crate) gait: f32,
     swing: f32,
-    bob: f32,
-    body_r: f32,
-    phase: f32,
-    moving: bool,
+    pub(crate) bob: f32,
+    pub(crate) body_r: f32,
+    pub(crate) phase: f32,
+    pub(crate) moving: bool,
     mode: Mode,
     timer: f32,
     rng: u32,
@@ -103,21 +108,33 @@ pub struct Pilgrim {
 }
 
 /// A castle town-guard: a villager that fights invaders during a wave (chase → strike, trading
-/// blows), goes **down** at 0 HP (lies still), and is revived + walks back to its post at dawn.
+/// blows) and, in peacetime, sallies out after any ork or predator that prowls near its post
+/// (short detect, short leash — see [`guard_combat`]), walking back to the post after the kill.
+/// Its hit points live in the shared [`NpcHp`]; at 0 HP it dies for good like anyone else.
 #[derive(Component)]
 pub struct Guard {
-    hp: f32,
-    max: f32,
     atk_cd: f32,
-    pub downed: bool,
     post: Vec2,
 }
 
-impl Guard {
-    /// Down guards aren't worth an invader's attention (read by the invader AI's targeting).
-    pub fn is_downed(&self) -> bool {
-        self.downed
-    }
+/// Hit points for any town-pool NPC ([`Townsfolk`] — guard or worker alike). Death is
+/// **permanent**: at 0 HP the body crumples (`dying.rs`) and the town's population drops by one.
+/// Replacements are grown from the food surplus by day (`town::population_system`) — nobody is
+/// revived at dawn any more.
+#[derive(Component)]
+pub struct NpcHp {
+    pub hp: f32,
+    pub max: f32,
+}
+
+/// A **passive** townsperson (a worker — no [`Guard`] role) that has been struck in anger: it
+/// stands its ground and trades blows with its attacker until one of them is dead, then goes back
+/// to work. Inserted by [`npc_damage_apply`], driven by [`npc_fight_back`]. Guards never carry
+/// this — their own combat brain handles retaliation.
+#[derive(Component)]
+pub struct FightBack {
+    target: Entity,
+    atk_cd: f32,
 }
 
 /// Marks the **town's working-and-fighting population** (the labour/militia pool), as opposed to
@@ -136,23 +153,37 @@ pub struct Townsfolk;
 /// module-private). `try_insert` per the despawn-race convention.
 fn arm_as_guard(commands: &mut Commands, e: Entity, post: Vec2) {
     commands.entity(e).try_insert((
-        Guard { hp: GUARD_MAX_HP, max: GUARD_MAX_HP, atk_cd: 0.0, downed: false, post },
+        Guard { atk_cd: 0.0, post },
         crate::navgrid::NavPath::default(),
     ));
 }
 
-// Guard combat tuning. Guards now take damage ONLY from invaders that actually strike them
-// (via [`GuardDamage`]) — no more self-inflicted melt — so they're beefier + hit harder and a
-// pair can win a 1v1 but a wave still overwhelms them.
-const GUARD_MAX_HP: f32 = 65.0;
+// NPC combat tuning. Townsfolk take damage ONLY through the [`NpcDamage`] channel (ork blades
+// from `siege.rs`, predator bites from `wildlife.rs`) — no self-inflicted melt — so guards are
+// beefy enough that a pair wins a 1v1 but a wave still overwhelms them.
+const NPC_MAX_HP: f32 = 65.0;
 const GUARD_DAMAGE: f32 = 9.0;
 /// How far a guard will march to hunt an invader at night. Large enough to cover the whole
 /// defended area, so the reserve actively goes out to meet the wave instead of standing idle until
 /// an ork wanders within arm's reach (the old 12-unit passive radius left guards doing nothing).
 const GUARD_HUNT_RADIUS: f32 = 60.0;
+/// Peacetime: a hostile (ork or predator) this near a guard's POST is engaged on sight…
+const GUARD_DETECT: f32 = 15.0;
+/// …and chased only while it stays this near the post — past the leash the guard lets it go and
+/// ambles home, so wildlife can't kite the militia across the island.
+const GUARD_LEASH: f32 = 25.0;
+/// Peacetime mend rate (HP/s). Replaces the old instant dawn full-heal: a guard that brawls a
+/// wolf pack back-to-back stays wounded for a while, and a dead one stays dead.
+const GUARD_REGEN: f32 = 3.0;
 const GUARD_MELEE: f32 = 1.6;
 const GUARD_SPEED: f32 = 2.4;
 const GUARD_ATTACK_CD: f32 = 1.0;
+/// A passive townsperson's self-defence swing: weak (a hoe, an axe haft) but real.
+const NPC_DEFEND_DMG: f32 = 6.0;
+const NPC_DEFEND_CD: f32 = 1.2;
+const NPC_MELEE: f32 = 1.5;
+/// A defender gives up the brawl when its attacker breaks off this far away.
+const NPC_GIVE_UP: f32 = 12.0;
 /// A guard's strike only emits a clash SFX when this near the hero — a small earshot so distant
 /// skirmishes across the field stay silent and only the fight beside you is heard.
 const GUARD_SFX_RADIUS: f32 = 14.0;
@@ -160,11 +191,19 @@ const GUARD_SFX_RADIUS: f32 = 14.0;
 /// home by A* through the gates; nearer than this a revived town-guard just steers in directly.
 const GUARD_PATH_RANGE: f32 = 4.0;
 
-/// Damage invaders have dealt town-guards this frame (`(guard entity, amount)`), pushed by the
-/// invader AI in `siege.rs` and drained into guard HP by [`guard_combat`]. The mirror of the
-/// hero's [`crate::player::PendingHeroDamage`] — combat stays store-mediated, no collision events.
+/// One blow landed on a townsperson this frame. `attacker` lets the victim retaliate
+/// ([`FightBack`] for passive folk) — `None` only for source-less damage.
+pub struct NpcHit {
+    pub victim: Entity,
+    pub amount: f32,
+    pub attacker: Option<Entity>,
+}
+
+/// Damage dealt to town NPCs this frame, pushed by the invader AI in `siege.rs` and the predator
+/// AI in `wildlife.rs`, drained into [`NpcHp`] by [`npc_damage_apply`]. The mirror of the hero's
+/// [`crate::player::PendingHeroDamage`] — combat stays store-mediated, no collision events.
 #[derive(Resource, Default)]
-pub struct GuardDamage(pub Vec<(Entity, f32)>);
+pub struct NpcDamage(pub Vec<NpcHit>);
 
 /// Invader melee is blunted this much against an armoured guard (vs the hero) — guards soak.
 pub const GUARD_ARMOR_MULT: f32 = 0.6;
@@ -187,7 +226,7 @@ const CAMP_HOME_R: f32 = 6.0;
 impl Plugin for VillagersPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<RescuedCamps>()
-            .init_resource::<GuardDamage>()
+            .init_resource::<NpcDamage>()
             .init_resource::<TownSpots>()
             .add_systems(Update, villager_limbs) // limb anim keeps running while frozen
             // Ungated so they fire on the day↔night edge even if the world is frozen (panel open):
@@ -201,6 +240,8 @@ impl Plugin for VillagersPlugin {
                     worker_steer,
                     pilgrim_brain,
                     pilgrim_hint,
+                    npc_damage_apply,
+                    npc_fight_back,
                     guard_combat,
                     rearm_townsfolk,
                     reskin_townsfolk,
@@ -250,7 +291,12 @@ fn muster_townsfolk(
     *last = Some(wave);
     if wave {
         for e in &workers {
-            commands.entity(e).try_remove::<crate::town::Worker>();
+            // Down tools entirely: a woodcutter drops its tree job too, or it would keep the
+            // chop steering alongside the guard brain it's about to get.
+            commands
+                .entity(e)
+                .try_remove::<crate::town::Worker>()
+                .try_remove::<crate::lumberjack::ChopJob>();
         }
     }
 }
@@ -261,10 +307,18 @@ fn muster_townsfolk(
 /// fights by night; employment is the only thing that pulls one off guard duty.
 fn rearm_townsfolk(
     mut commands: Commands,
-    idle: Query<(Entity, &Villager), (With<Townsfolk>, Without<Guard>, Without<crate::town::Worker>)>,
+    idle: Query<
+        (Entity, &Villager),
+        (With<Townsfolk>, Without<Guard>, Without<crate::town::Worker>, Without<crate::dying::Dying>),
+    >,
 ) {
     for (e, v) in &idle {
-        arm_as_guard(&mut commands, e, v.pos);
+        // A woodcutter mustered deep in the woods at dusk gets posted back HOME (its courtyard
+        // spot), not where it stands — otherwise the militia ends up scattered through the forest.
+        let post = if v.pos.length() > 26.0 { v.home } else { v.pos };
+        // Shed any stale tree job (e.g. the plot collapsed mid-chop) before taking up arms.
+        commands.entity(e).try_remove::<crate::lumberjack::ChopJob>();
+        arm_as_guard(&mut commands, e, post);
     }
 }
 
@@ -374,10 +428,21 @@ fn recruit(
 
 /// Ambient townsfolk wander — guards (their AI is [`guard_combat`]) and pilgrims (their AI is
 /// [`pilgrim_brain`]) are excluded.
+#[allow(clippy::type_complexity)]
 fn villager_brain(
     time: Res<Time>,
     spots: Res<TownSpots>,
-    mut q: Query<(&mut Villager, &mut Transform, Has<Kid>), (Without<Guard>, Without<Pilgrim>, Without<crate::town::Worker>)>,
+    mut q: Query<
+        (&mut Villager, &mut Transform, Has<Kid>),
+        (
+            Without<Guard>,
+            Without<Pilgrim>,
+            Without<crate::town::Worker>,
+            Without<FightBack>,
+            Without<crate::lumberjack::Fleeing>,
+            Without<crate::dying::Dying>,
+        ),
+    >,
 ) {
     let dt = time.delta_secs().min(0.05);
     let tw = time.elapsed_secs_wrapped();
@@ -430,10 +495,19 @@ fn villager_brain(
 /// Steer assigned workers to their building, then hold post (sets `at_post`).
 /// Lives here because it pokes the private `Villager` fields. Workers inherit
 /// `townsfolk_curfew` (no `Guard`), so they flee at night automatically.
+#[allow(clippy::type_complexity)]
 fn worker_steer(
     time: Res<Time>,
     spots: Res<crate::town::PlotSpots>,
-    mut q: Query<(&mut crate::town::Worker, &mut Villager, &mut Transform)>,
+    mut q: Query<
+        (&mut crate::town::Worker, &mut Villager, &mut Transform),
+        (
+            Without<crate::lumberjack::ChopJob>,
+            Without<crate::lumberjack::Fleeing>,
+            Without<FightBack>,
+            Without<crate::dying::Dying>,
+        ),
+    >,
 ) {
     let dt = time.delta_secs().min(0.05);
     let tw = time.elapsed_secs_wrapped();
@@ -474,7 +548,12 @@ fn pilgrim_brain(
     time: Res<Time>,
     mut q: Query<
         (&mut Pilgrim, &mut Villager, &mut Transform),
-        (Without<Guard>, Without<crate::landmarks::Landmark>, Without<crate::town::Worker>),
+        (
+            Without<Guard>,
+            Without<crate::landmarks::Landmark>,
+            Without<crate::town::Worker>,
+            Without<crate::dying::Dying>,
+        ),
     >,
     marks: Query<&Transform, With<crate::landmarks::Landmark>>,
 ) {
@@ -592,24 +671,161 @@ fn compass(from: Vec2, to: Vec2) -> &'static str {
     ["north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest"][i as usize]
 }
 
-/// Town-guard AI: during a wave, chase the nearest invader inside the defend radius and trade
-/// blows in melee (the guard's strikes wound the invader's `Health`, the invader's wound the
-/// guard); a downed guard lies still. In peacetime guards heal up + amble back to their post.
+/// Drain the frame's NPC hits (ork blades via `siege.rs`, predator bites via `wildlife.rs`)
+/// into townsfolk HP. Death is **permanent**: the body crumples (`dying.rs`) and the town's
+/// population drops by one — the food surplus regrows a replacement by day
+/// (`town::population_system`); nobody rises at dawn. A surviving *passive* townsperson (no
+/// [`Guard`] role) rounds on its attacker ([`FightBack`]): villagers always defend themselves.
+#[allow(clippy::type_complexity)]
+fn npc_damage_apply(
+    time: Res<Time>,
+    mut incoming: ResMut<NpcDamage>,
+    mut town: ResMut<crate::town::TownRes>,
+    mut floats: ResMut<crate::combat_fx::FloatQueue>,
+    mut commands: Commands,
+    mut q: Query<(&mut NpcHp, &Transform, Has<Guard>), Without<crate::dying::Dying>>,
+) {
+    let now = time.elapsed_secs();
+    for hit in incoming.0.drain(..) {
+        let Ok((mut hp, tf, is_guard)) = q.get_mut(hit.victim) else { continue };
+        if hp.hp <= 0.0 {
+            continue; // already mortally struck this frame
+        }
+        hp.hp -= hit.amount;
+        if hp.hp <= 0.0 {
+            crate::dying::begin_dying(&mut commands, hit.victim, now);
+            // The headcount is the source of truth — dropping it keeps `sync_population_bodies`
+            // from spawning an instant free replacement; growth has to re-earn the body.
+            town.0.population = town.0.population.saturating_sub(1);
+            floats.0.push(crate::combat_fx::FloatReq {
+                world: tf.translation + Vec3::Y * 2.2,
+                text: "A townsperson has fallen!".into(),
+                color: Color::srgb(1.0, 0.45, 0.35),
+                scale: 1.2,
+            });
+        } else if !is_guard {
+            if let Some(att) = hit.attacker {
+                // "Always defends": a struck worker stops fleeing/working and turns on its foe.
+                commands
+                    .entity(hit.victim)
+                    .try_remove::<crate::lumberjack::Fleeing>()
+                    .try_insert(FightBack { target: att, atk_cd: 0.0 });
+            }
+        }
+    }
+}
+
+/// Passive self-defence: a [`FightBack`] townsperson squares up to its attacker and trades weak
+/// blows until the attacker is dead, it dies, or the attacker breaks off — then back to work.
+#[allow(clippy::type_complexity)]
+fn npc_fight_back(
+    time: Res<Time>,
+    hero: Query<&crate::player::Hero>,
+    mut commands: Commands,
+    mut cues: MessageWriter<crate::audio::AudioCue>,
+    mut kills: MessageWriter<crate::verbs::AnimalKilled>,
+    mut npcs: Query<
+        (Entity, &mut FightBack, &mut Villager, &mut Transform),
+        (Without<Guard>, Without<crate::dying::Dying>),
+    >,
+    mut hostiles: Query<
+        (&Transform, &mut crate::player::Health, Option<&crate::wildlife::Animal>),
+        (
+            Or<(With<crate::orks::Ork>, With<crate::wildlife::Animal>)>,
+            Without<Villager>,
+            Without<crate::dying::Dying>,
+        ),
+    >,
+) {
+    let dt = time.delta_secs().min(0.05);
+    let tw = time.elapsed_secs_wrapped();
+    let now = time.elapsed_secs();
+    let hero_pos = hero.single().ok().map(|h| h.pos);
+    for (self_e, mut fb, mut v, mut tf) in &mut npcs {
+        let Ok((ttf, mut thp, animal)) = hostiles.get_mut(fb.target) else {
+            commands.entity(self_e).try_remove::<FightBack>(); // foe gone (dead/despawned)
+            continue;
+        };
+        let tp = Vec2::new(ttf.translation.x, ttf.translation.z);
+        let d = v.pos.distance(tp);
+        if d > NPC_GIVE_UP {
+            commands.entity(self_e).try_remove::<FightBack>(); // it broke off — let it go
+            continue;
+        }
+        fb.atk_cd -= dt;
+        if d < NPC_MELEE {
+            v.moving = false;
+            let to = tp - v.pos;
+            if to.length_squared() > 1e-4 {
+                let want = to.x.atan2(to.y);
+                v.facing += steer::wrap_pi(want - v.facing).clamp(-VIL_MAX_TURN * 2.0 * dt, VIL_MAX_TURN * 2.0 * dt);
+            }
+            if fb.atk_cd <= 0.0 {
+                fb.atk_cd = NPC_DEFEND_CD;
+                thp.hp -= NPC_DEFEND_DMG;
+                if thp.hp <= 0.0 {
+                    crate::dying::begin_dying(&mut commands, fb.target, now);
+                    if let Some(a) = animal {
+                        // Feed the loot/respawn pipeline like any kill.
+                        kills.write(crate::verbs::AnimalKilled { at: ttf.translation, species: a.species });
+                    }
+                } else if animal.is_some() {
+                    // The beast snaps back at whoever is poking it.
+                    commands.entity(fb.target).try_insert(crate::wildlife::Struck { by: Some(self_e) });
+                }
+                if hero_pos.is_some_and(|hp| v.pos.distance(hp) < GUARD_SFX_RADIUS) {
+                    let at = Vec3::new(v.pos.x, tf.translation.y + 1.0, v.pos.y);
+                    cues.write(crate::audio::AudioCue::GuardStrike(at));
+                }
+            }
+        } else {
+            // Close the gap (a touch faster than the work amble — adrenaline).
+            let cur_y = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
+            match steer::advance(v.pos, v.facing, tp, v.speed * 1.25 * dt, v.body_r, cur_y, VIL_MAX_TURN * 2.0 * dt) {
+                Some(s) => {
+                    v.facing = s.facing;
+                    v.pos = s.pos;
+                    v.moving = s.moving;
+                }
+                None => v.moving = false,
+            }
+        }
+        let gy = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
+        let bob = if v.moving { (tw * v.gait + v.phase).sin().abs() * v.bob } else { 0.0 };
+        tf.translation = Vec3::new(v.pos.x, gy + bob, v.pos.y);
+        tf.rotation = Quat::from_rotation_y(v.facing);
+    }
+}
+
+/// Town-guard AI. During a wave: chase the nearest invader inside the big hunt radius and trade
+/// blows in melee. In peacetime: mend slowly, and sally out after any hostile — an ork **or a
+/// predator** (wolf, bear, golem…) — that prowls within [`GUARD_DETECT`] of the post, chasing it
+/// only while it stays inside [`GUARD_LEASH`]; after the kill (or the leash) walk back to post.
 #[allow(clippy::type_complexity)]
 fn guard_combat(
     time: Res<Time>,
     siege: Res<crate::siege::Siege>,
-    mut incoming: ResMut<GuardDamage>,
     mut commands: Commands,
     mut cues: MessageWriter<crate::audio::AudioCue>,
+    mut kills: MessageWriter<crate::verbs::AnimalKilled>,
     hero: Query<&crate::player::Hero>,
     mut guards: Query<
-        (Entity, &mut Guard, &mut Villager, &mut Transform, &mut crate::navgrid::NavPath),
-        Without<crate::orks::WaveInvader>,
+        (Entity, &mut Guard, &mut NpcHp, &mut Villager, &mut Transform, &mut crate::navgrid::NavPath),
+        Without<crate::dying::Dying>,
     >,
-    mut invaders: Query<
-        (Entity, &Transform, &mut crate::player::Health),
-        (With<crate::orks::WaveInvader>, Without<Guard>, Without<crate::dying::Dying>),
+    mut hostiles: Query<
+        (
+            Entity,
+            &Transform,
+            &mut crate::player::Health,
+            Has<crate::orks::WaveInvader>,
+            Option<&crate::wildlife::Animal>,
+        ),
+        (
+            Or<(With<crate::orks::Ork>, With<crate::wildlife::Animal>)>,
+            Without<Guard>,
+            Without<crate::dying::Dying>,
+        ),
     >,
 ) {
     let dt = time.delta_secs().min(0.05);
@@ -618,34 +834,106 @@ fn guard_combat(
     let in_wave = siege.phase == crate::siege::GamePhase::Wave;
     // Hero (≈ listener) position, for the small-earshot gate on guard clash SFX.
     let hero_pos = hero.single().ok().map(|h| h.pos);
-    let inv: Vec<(Entity, Vec2)> =
-        invaders.iter().map(|(e, tf, _)| (e, Vec2::new(tf.translation.x, tf.translation.z))).collect();
-    let mut dealt: Vec<(Entity, f32)> = Vec::new();
+    // Everything a guard may engage: every ork, plus the predator species only — the militia
+    // doesn't slaughter the deer herds.
+    let inv: Vec<(Entity, Vec2, bool)> = hostiles
+        .iter()
+        .filter_map(|(e, tf, _, invader, animal)| {
+            let hostile = match animal {
+                Some(a) => crate::wildlife::is_hostile_species(a.species),
+                None => true, // any ork
+            };
+            hostile.then_some((e, Vec2::new(tf.translation.x, tf.translation.z), invader))
+        })
+        .collect();
+    let mut dealt: Vec<(Entity, Entity, f32)> = Vec::new(); // (target, guard, dmg)
 
-    // Sum the invader strikes landed on each guard this frame, then drain the channel.
-    let mut hurt: std::collections::HashMap<Entity, f32> = std::collections::HashMap::new();
-    for (e, dmg) in incoming.0.drain(..) {
-        *hurt.entry(e).or_insert(0.0) += dmg;
-    }
-
-    for (self_e, mut g, mut v, mut tf, mut path) in &mut guards {
-        // Take any strikes invaders landed on this guard this frame.
-        if let Some(d) = hurt.get(&self_e) {
-            g.hp -= *d;
-            if g.hp <= 0.0 {
-                g.downed = true;
+    for (self_e, mut g, mut hp, mut v, mut tf, mut path) in &mut guards {
+        g.atk_cd -= dt;
+        if !in_wave {
+            // Peacetime mend — slow, so a mauling leaves a mark (no more instant dawn heal).
+            hp.hp = (hp.hp + GUARD_REGEN * dt).min(hp.max);
+        }
+        // Pick a target. At night: the nearest invader anywhere in the defended area. By day:
+        // the nearest hostile near the POST (engage inside the detect ring, finish a fight it's
+        // already toe-to-toe with anywhere inside the leash).
+        let mut best: Option<(Entity, Vec2, f32)> = None;
+        for (e, p, invader) in &inv {
+            let d = v.pos.distance(*p);
+            if in_wave {
+                if !*invader || d >= GUARD_HUNT_RADIUS {
+                    continue;
+                }
+            } else {
+                let dp = p.distance(g.post);
+                let engaged = d < GUARD_MELEE * 2.0;
+                if dp > if engaged { GUARD_LEASH } else { GUARD_DETECT } {
+                    continue;
+                }
+            }
+            if best.is_none_or(|(_, _, bd)| d < bd) {
+                best = Some((*e, *p, d));
             }
         }
-        if !in_wave {
-            // Dawn: heal, rise, and head back to the post.
-            g.hp = g.max;
-            g.downed = false;
+
+        if let Some((te, tp, d)) = best {
+            if d < GUARD_MELEE {
+                v.moving = false;
+                let to = tp - v.pos;
+                if to.length_squared() > 1e-4 {
+                    let want = to.x.atan2(to.y);
+                    v.facing += steer::wrap_pi(want - v.facing).clamp(-VIL_MAX_TURN * 2.0 * dt, VIL_MAX_TURN * 2.0 * dt);
+                }
+                if g.atk_cd <= 0.0 {
+                    g.atk_cd = GUARD_ATTACK_CD;
+                    dealt.push((te, self_e, GUARD_DAMAGE));
+                    // Clash SFX, but only when the fight is close to the hero (small earshot).
+                    if hero_pos.is_some_and(|hp| v.pos.distance(hp) < GUARD_SFX_RADIUS) {
+                        let at = Vec3::new(v.pos.x, tf.translation.y + 1.0, v.pos.y);
+                        cues.write(crate::audio::AudioCue::GuardStrike(at));
+                    }
+                }
+            } else {
+                // Far from the foe → A* toward it (thread walls/gates instead of wedging);
+                // close → cheap direct steer. Same pattern as the return-to-post walk.
+                let step_target = if d > GUARD_PATH_RANGE {
+                    if path.cursor >= path.waypoints.len()
+                        || now >= path.next_replan
+                        || path.goal_cached.distance(tp) > 2.0
+                    {
+                        path.waypoints = crate::navgrid::path_to(v.pos, tp);
+                        path.cursor = 0;
+                        path.goal_cached = tp;
+                        path.next_replan = now + 0.5 + (self_e.to_bits() % 16) as f32 * 0.04;
+                    }
+                    while path.cursor < path.waypoints.len()
+                        && v.pos.distance(path.waypoints[path.cursor]) < 1.2
+                    {
+                        path.cursor += 1;
+                    }
+                    path.waypoints.get(path.cursor).copied().unwrap_or(tp)
+                } else {
+                    path.waypoints.clear();
+                    path.cursor = 0;
+                    tp
+                };
+                let cur_y = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
+                if let Some(s) = steer::advance(v.pos, v.facing, step_target, GUARD_SPEED * dt, v.body_r, cur_y, VIL_MAX_TURN * 2.0 * dt) {
+                    v.facing = s.facing;
+                    v.pos = s.pos;
+                    v.moving = s.moving;
+                } else {
+                    v.moving = false;
+                }
+            }
+        } else {
+            // No foe — amble back to the post.
             let to_post = g.post - v.pos;
             if to_post.length() > 0.4 {
-                // Far from home (a freed captive marching in from a razed camp) → follow an A*
-                // route to the courtyard post so it threads the river crossing and the castle
-                // GATE instead of wedging on the wall. Near home (a revived town-guard) → cheap
-                // direct steer, no pathing churn. Mirrors the invader keep-march in `siege.rs`.
+                // Far from home (a freed captive marching in from a razed camp, or a guard back
+                // from a chase) → follow an A* route to the courtyard post so it threads the
+                // river crossing and the castle GATE instead of wedging on the wall. Near home →
+                // cheap direct steer, no pathing churn. Mirrors the invader keep-march in `siege.rs`.
                 let step_target = if to_post.length() > GUARD_PATH_RANGE {
                     if path.cursor >= path.waypoints.len()
                         || now >= path.next_replan
@@ -679,93 +967,29 @@ fn guard_combat(
             } else {
                 v.moving = false;
             }
-        } else if g.downed {
-            v.moving = false;
-        } else {
-            g.atk_cd -= dt;
-            // Hunt the NEAREST invader (within the big hunt radius) — march out to meet it.
-            let mut best: Option<(Entity, Vec2, f32)> = None;
-            for (e, p) in &inv {
-                let d = v.pos.distance(*p);
-                if d < GUARD_HUNT_RADIUS && best.is_none_or(|(_, _, bd)| d < bd) {
-                    best = Some((*e, *p, d));
-                }
-            }
-            if let Some((te, tp, d)) = best {
-                if d < GUARD_MELEE {
-                    v.moving = false;
-                    let to = tp - v.pos;
-                    if to.length_squared() > 1e-4 {
-                        let want = to.x.atan2(to.y);
-                        v.facing += steer::wrap_pi(want - v.facing).clamp(-VIL_MAX_TURN * 2.0 * dt, VIL_MAX_TURN * 2.0 * dt);
-                    }
-                    if g.atk_cd <= 0.0 {
-                        g.atk_cd = GUARD_ATTACK_CD;
-                        dealt.push((te, GUARD_DAMAGE));
-                        // Clash SFX, but only when the fight is close to the hero (small earshot).
-                        if hero_pos.is_some_and(|hp| v.pos.distance(hp) < GUARD_SFX_RADIUS) {
-                            let at = Vec3::new(v.pos.x, tf.translation.y + 1.0, v.pos.y);
-                            cues.write(crate::audio::AudioCue::GuardStrike(at));
-                        }
-                    }
-                } else {
-                    // Far from the ork → A* toward it (thread walls/gates instead of wedging);
-                    // close → cheap direct steer. Same pattern as the dawn return-to-post.
-                    let step_target = if d > GUARD_PATH_RANGE {
-                        if path.cursor >= path.waypoints.len()
-                            || now >= path.next_replan
-                            || path.goal_cached.distance(tp) > 2.0
-                        {
-                            path.waypoints = crate::navgrid::path_to(v.pos, tp);
-                            path.cursor = 0;
-                            path.goal_cached = tp;
-                            path.next_replan = now + 0.5 + (self_e.to_bits() % 16) as f32 * 0.04;
-                        }
-                        while path.cursor < path.waypoints.len()
-                            && v.pos.distance(path.waypoints[path.cursor]) < 1.2
-                        {
-                            path.cursor += 1;
-                        }
-                        path.waypoints.get(path.cursor).copied().unwrap_or(tp)
-                    } else {
-                        path.waypoints.clear();
-                        path.cursor = 0;
-                        tp
-                    };
-                    let cur_y = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
-                    if let Some(s) = steer::advance(v.pos, v.facing, step_target, GUARD_SPEED * dt, v.body_r, cur_y, VIL_MAX_TURN * 2.0 * dt) {
-                        v.facing = s.facing;
-                        v.pos = s.pos;
-                        v.moving = s.moving;
-                    } else {
-                        v.moving = false;
-                    }
-                }
-            } else {
-                v.moving = false;
-            }
         }
 
         // Ground-follow (guards own their full transform since they're out of villager_brain).
         let gy = worldmap::ground_at_world(v.pos.x, v.pos.y).unwrap_or(tf.translation.y);
         let bob = if v.moving { (tw * v.gait + v.phase).sin().abs() * v.bob } else { 0.0 };
-        // A downed guard sinks to the ground and keels over.
-        if g.downed {
-            tf.translation = Vec3::new(v.pos.x, gy + 0.1, v.pos.y);
-            tf.rotation = Quat::from_rotation_y(v.facing) * Quat::from_rotation_x(std::f32::consts::FRAC_PI_2);
-        } else {
-            tf.translation = Vec3::new(v.pos.x, gy + bob, v.pos.y);
-            tf.rotation = Quat::from_rotation_y(v.facing);
-        }
+        tf.translation = Vec3::new(v.pos.x, gy + bob, v.pos.y);
+        tf.rotation = Quat::from_rotation_y(v.facing);
     }
 
-    // Apply guard strikes to invader Health; reap the slain.
-    for (e, dmg) in dealt {
-        if let Ok((_, _, mut hp)) = invaders.get_mut(e) {
+    // Apply guard strikes to hostile Health; reap the slain, enrage struck beasts.
+    for (e, guard_e, dmg) in dealt {
+        if let Ok((_, ttf, mut hp, _, animal)) = hostiles.get_mut(e) {
             if hp.hp > 0.0 {
                 hp.hp -= dmg;
                 if hp.hp <= 0.0 {
                     crate::dying::begin_dying(&mut commands, e, time.elapsed_secs());
+                    if let Some(a) = animal {
+                        // Feed the loot/respawn pipeline like any kill.
+                        kills.write(crate::verbs::AnimalKilled { at: ttf.translation, species: a.species });
+                    }
+                } else if animal.is_some() {
+                    // Struck-enrage, aimed at the guard that landed the blow.
+                    commands.entity(e).try_insert(crate::wildlife::Struck { by: Some(guard_e) });
                 }
             }
         }
@@ -1249,7 +1473,8 @@ fn spawn(
     // when they take a job. The NavPath caches an A* route home for a freed captive (see `guard_combat`).
     if let Kind::Guard { skin, tunic } = kind {
         commands.entity(root).insert((
-            Guard { hp: GUARD_MAX_HP, max: GUARD_MAX_HP, atk_cd: 0.0, downed: false, post: home },
+            Guard { atk_cd: 0.0, post: home },
+            NpcHp { hp: NPC_MAX_HP, max: NPC_MAX_HP },
             crate::navgrid::NavPath::default(),
             Townsfolk,
             Folk { skin, tunic },

--- a/src/wildlife.rs
+++ b/src/wildlife.rs
@@ -85,20 +85,27 @@ pub struct Animal {
     /// Timestamp of the last blow the animal TOOK; drives a springy recoil-wobble (reuses
     /// `orks::recoil_tilt`). Stamped by `player::combat`. `0` = none.
     pub(crate) hit_recoil: f32,
-    /// When hunting, the prey entity being chased (None = hunting the hero / not hunting).
+    /// When hunting, the prey entity being chased (caught on contact — eaten).
     hunt_prey: Option<Entity>,
-    /// Elapsed-seconds until which a struck predator stays latched onto the hero (0 = calm).
+    /// When hunting, the townsperson being charged (bitten on contact, like the hero).
+    hunt_npc: Option<Entity>,
+    /// Elapsed-seconds until which a struck predator stays latched onto its attacker (0 = calm).
     aggro_until: f32,
+    /// Who the latch is aimed at: `None` = the hero, `Some` = the townsperson that struck it.
+    aggro_target: Option<Entity>,
     /// Decaying knockback shove (world XZ, units/s) from a recent hero blow — applied + slid
     /// against terrain each frame, the same stagger orks get (`orks::apply_knockback`).
     pub(crate) kb: Vec2,
     pub(crate) rng: u32,
 }
 
-/// Inserted by combat on a surviving animal it struck — a predator latches onto the hero
+/// Inserted by combat on a surviving animal it struck — a predator latches onto its attacker
 /// (struck-enrage). `animal_brain` reads it once, then removes it.
 #[derive(Component)]
-pub struct Struck;
+pub struct Struck {
+    /// Who landed the blow: `None` = the hero; `Some` = a townsperson (guard or defending worker).
+    pub by: Option<Entity>,
+}
 
 /// Seconds a struck predator stays enraged + locked onto the hero.
 const STRUCK_LATCH: f32 = 6.0;
@@ -114,13 +121,19 @@ struct AnimPart {
 
 // ── Systems ──────────────────────────────────────────────────────────────────────
 
+#[allow(clippy::type_complexity)]
 fn animal_brain(
     time: Res<Time>,
     cam: Query<&GlobalTransform, With<Camera3d>>,
     hero: Res<crate::player::HeroState>,
     mut pending: ResMut<crate::player::PendingHeroDamage>,
+    mut npc_dmg: ResMut<crate::villagers::NpcDamage>,
     mut cues: MessageWriter<crate::audio::AudioCue>,
     mut commands: Commands,
+    townsfolk: Query<
+        (Entity, &crate::villagers::Villager, &Visibility),
+        (With<crate::villagers::Townsfolk>, Without<crate::dying::Dying>),
+    >,
     mut q: Query<(Entity, &mut Animal, &mut Transform, Option<&Struck>), Without<crate::dying::Dying>>,
 ) {
     let dt = time.delta_secs().min(0.05);
@@ -130,6 +143,12 @@ fn animal_brain(
         let t = g.translation();
         Vec2::new(t.x, t.z)
     });
+    // The town pool is fair game for predators, exactly like the hero (hidden bodies excluded).
+    let npcs: Vec<(Entity, Vec2)> = townsfolk
+        .iter()
+        .filter(|(_, _, vis)| **vis != Visibility::Hidden)
+        .map(|(e, v, _)| (e, v.pos))
+        .collect();
 
     // Snapshot every animal's (entity, position, predator?, prey?) so the food-chain can target:
     // predators hunt the nearest prey, prey flee the nearest predator. Read-only pre-pass.
@@ -145,23 +164,35 @@ fn animal_brain(
         a.atk_cd -= dt;
 
         let pred = predator_stats(a.species);
-        // Struck-enrage: a wounded predator (incl. the boar) latches onto the hero for a beat.
-        if struck.is_some() {
+        // Struck-enrage: a wounded predator (incl. the boar) latches onto its attacker — the
+        // hero, or the townsperson whose blade/axe just landed — for a beat.
+        if let Some(s) = struck {
             commands.entity(self_e).remove::<Struck>();
             if pred.is_some() {
                 a.aggro_until = now + STRUCK_LATCH;
+                a.aggro_target = s.by;
             }
         }
         if let Some((aggro_r, _)) = pred {
-            // ── Predator: hunt the nearest prey in range; failing that, the hero — but only
-            // while near home (~26u) so a pack doesn't trail a target across the whole island.
-            // A recently-struck predator stays locked on the hero (ignores leash). ──
+            // ── Predator: hunt the nearest prey in range; failing that, the hero or a
+            // townsperson (the town pool is treated exactly like the hero) — but only while
+            // near home (~26u) so a pack doesn't trail a target across the whole island.
+            // A recently-struck predator stays locked on its attacker (ignores leash). ──
             let near_home = a.pos.distance(a.home) < 26.0;
-            let mut tgt: Option<(Vec2, Option<Entity>)> = None;
-            let mut best = aggro_r;
-            if hero.alive && now < a.aggro_until {
-                tgt = Some((hero.pos, None));
-            } else if near_home {
+            // (position, prey-to-eat, townsperson-to-bite); both None = the hero.
+            let mut tgt: Option<(Vec2, Option<Entity>, Option<Entity>)> = None;
+            if now < a.aggro_until {
+                match a.aggro_target {
+                    None if hero.alive => tgt = Some((hero.pos, None, None)),
+                    Some(ne) => match npcs.iter().find(|(e, _)| *e == ne) {
+                        Some((_, np)) => tgt = Some((*np, None, Some(ne))),
+                        None => a.aggro_until = 0.0, // attacker died/left — shake it off
+                    },
+                    _ => {}
+                }
+            }
+            if tgt.is_none() && near_home {
+                let mut best = aggro_r;
                 for (pe, pp, _ispred, isprey) in &snap {
                     if !*isprey || *pe == self_e {
                         continue;
@@ -169,21 +200,39 @@ fn animal_brain(
                     let d = a.pos.distance(*pp);
                     if d < best {
                         best = d;
-                        tgt = Some((*pp, Some(*pe)));
+                        tgt = Some((*pp, Some(*pe), None));
                     }
                 }
-                if tgt.is_none() && hero.alive && a.pos.distance(hero.pos) < aggro_r {
-                    tgt = Some((hero.pos, None));
+                if tgt.is_none() {
+                    // No prey about: the hero and the townsfolk are fair game alike — charge
+                    // whichever is nearest in aggro range.
+                    let mut best = aggro_r;
+                    if hero.alive {
+                        let d = a.pos.distance(hero.pos);
+                        if d < best {
+                            best = d;
+                            tgt = Some((hero.pos, None, None));
+                        }
+                    }
+                    for (ne, np) in &npcs {
+                        let d = a.pos.distance(*np);
+                        if d < best {
+                            best = d;
+                            tgt = Some((*np, None, Some(*ne)));
+                        }
+                    }
                 }
             }
-            if let Some((tp, prey)) = tgt {
+            if let Some((tp, prey, npc)) = tgt {
                 a.mode = Mode::Hunt;
                 a.target = tp;
                 a.hunt_prey = prey;
+                a.hunt_npc = npc;
             } else if a.mode == Mode::Hunt {
                 a.mode = Mode::Graze;
                 a.timer = rng_range(&mut a.rng, 1.0, 2.5);
                 a.hunt_prey = None;
+                a.hunt_npc = None;
             }
         } else if a.flee_r > 0.0 {
             // ── Prey: bolt from the nearest predator, else the hero, else the camera. ──
@@ -269,11 +318,22 @@ fn animal_brain(
                         a.mode = Mode::Graze;
                         a.timer = rng_range(&mut a.rng, 2.0, 4.0);
                         a.hunt_prey = None;
+                        a.hunt_npc = None;
                     } else if a.atk_cd <= 0.0 {
                         a.atk_cd = 1.0;
                         a.atk_anim = now; // play the lunge-bite / tail-sting / arm-slam
                         if let Some((_, bite)) = pred {
-                            pending.0 += bite;
+                            // The bite lands on whoever is being charged: a townsperson takes it
+                            // through the NPC damage channel, the hero through his own.
+                            if let Some(ne) = a.hunt_npc {
+                                npc_dmg.0.push(crate::villagers::NpcHit {
+                                    victim: ne,
+                                    amount: bite,
+                                    attacker: Some(self_e),
+                                });
+                            } else {
+                                pending.0 += bite;
+                            }
                             // Snarl as it bites — the creature-side SFX so an attack isn't silent.
                             let big = matches!(
                                 a.species,
@@ -553,6 +613,12 @@ fn predator_stats(s: Species) -> Option<(f32, f32)> {
     }
 }
 
+/// The species the town militia treats as hostile (read by `villagers::guard_combat` and the
+/// woodcutter's threat sense in `lumberjack.rs`) — exactly the set that hunts people.
+pub(crate) fn is_hostile_species(s: Species) -> bool {
+    predator_stats(s).is_some()
+}
+
 /// Grazers the predators hunt (the food-chain prey set). Dog/Cat are neutral critters — neither
 /// predator nor prey — so they only startle from the camera.
 fn is_prey(s: Species) -> bool {
@@ -802,7 +868,9 @@ fn spawn_one(
         atk_anim: 0.0,
         hit_recoil: 0.0,
         hunt_prey: None,
+        hunt_npc: None,
         aggro_until: 0.0,
+        aggro_target: None,
         kb: Vec2::ZERO,
         rng,
     };


### PR DESCRIPTION
## Summary

Overhaul NPC combat to make the town pool a full combat participant. Guards now hunt both orks *and* predators in peacetime, passive workers defend themselves when struck, and death is permanent — replacements grow from food surplus by day rather than reviving at dawn. Woodcutters gain a new subsystem (`lumberjack.rs`) that walks them to actual scattered trees to chop, with threat sense to flee hostile encounters.

## Key Changes

**Core NPC combat redesign:**
- Split guard HP out of `Guard` into a shared `NpcHp` component (all townsfolk carry it; death is permanent)
- Introduce `FightBack` component: passive workers struck in anger stand their ground and trade blows until the attacker dies or breaks off, then resume work
- Rename `GuardDamage` → `NpcDamage` and restructure as `Vec<NpcHit>` to track attacker identity (enables retaliation)
- Add `npc_damage_apply` system to drain hits into HP, trigger death (via `dying.rs`), and insert `FightBack` on survivors
- Add `npc_fight_back` system: passive townspeople close gaps and swing weak blows (6 DMG, 1.2s CD) until the target dies or flees >12u away

**Guard AI expansion:**
- Guards now hunt in peacetime: detect hostiles (orks *or* predators) within 15u of their post, chase only while inside 25u leash
- Slow peacetime mend (3 HP/s) replaces instant dawn full-heal — a mauled guard stays wounded
- Removed `downed` state; death is now the only way off the roster
- Updated targeting to filter predators by `is_hostile_species()` (militia doesn't slaughter deer)

**Woodcutter NPC subsystem (`lumberjack.rs`):**
- New `ChopJob` component: assigns idle Lumber-plot workers to nearest safe tree (inside 45u of castle, >22u from camps, not blacklisted)
- New `Fleeing` component: threat sense (any hostile <12u) triggers flight home; blacklists the spot for 120s to prevent re-farming
- Trees are only worked at the tree (counts `at_post` so plots stay staffed); woodcutters use A* pathfinding when far, direct steer when close
- Stall detection: if wedged >4s, abandon the tree and blacklist briefly
- Integrates with shared `Villager` pose/locomotion; `FightBack` takes over if caught mid-chop

**Tree regrowth:**
- `ChopTree` now stores trunk radius; felling creates a hidden `Stump` that regrows after 150s
- Shared `fell_tree()` function (used by hero swings and woodcutter chops) banks wood, lifts trunk blocker, and schedules regrowth
- Prevents permanent deforestation of the safe zone

**Predator AI update:**
- Predators now hunt townspeople (the town pool is treated exactly like the hero)
- `Struck` component now carries `by: Option<Entity>` to track whether the blow came from hero or NPC
- Struck predators latch onto their attacker (hero or townsperson) for 6s, ignoring leash during the rage

**Integration & cleanup:**
- `rearm_townsfolk` now posts mustered guards at their home (courtyard spot) if deep in woods, preventing scattered militia
- Woodcutters shed `ChopJob` when mustered or when `FightBack` triggers (drop tools entirely)
- Query filters updated across `villager_brain`, `worker_steer`, `pilgrim_brain` to exclude `Fleeing`, `FightBack`, `Dying` as appropriate
- `siege.rs` invader AI updated to push `NpcDamage` with attacker identity; guard targeting simplified (no longer reads HP directly)
- `town.rs` population growth pauses during night waves (no free peasants mid-siege)

## Notable Details

- Woodcutter threat sense and blacklist prevent the "ork farms the same villager forever" loop

https://claude.ai/code/session_01SdZk7AwMXLhe6ijaHLVHYq