### PR TITLE
Upgrade biome props with baked facet shading and enhanced detail

### DIFF
--- a/src/biome_desert.rs
+++ b/src/biome_desert.rs
@@ -170,31 +170,34 @@ fn build_saguaro_mesh(variant: u32) -> Mesh {
 
     let mut parts: Vec<Mesh> = Vec::new();
 
-    // Trunk body + a shaded back rib + a lit front rib (so it reads ribbed/lit).
-    parts.push(cyl_up(trunk_r, trunk_h, trunk_h * 0.5, 6, CACTUS_MID));
-    parts.push(tinted(
-        Cylinder::new(trunk_r * 0.6, trunk_h * 0.94)
-            .mesh()
-            .resolution(6)
-            .build()
-            .translated_by(Vec3::new(-trunk_r * 0.42, trunk_h * 0.5, 0.0)),
-        lin(CACTUS_DARK),
-    ));
-    parts.push(tinted(
-        Cylinder::new(trunk_r * 0.5, trunk_h * 0.9)
-            .mesh()
-            .resolution(6)
-            .build()
-            .translated_by(Vec3::new(trunk_r * 0.46, trunk_h * 0.52, 0.05)),
-        lin(CACTUS_LIGHT),
-    ));
+    // Trunk: a slightly tapering two-segment column (fatter foot) with TRUE rib ridges —
+    // six thin vertical green ridges standing proud of the surface, alternating shadowed
+    // and sunlit, so the column reads pleated from every side (the old build faked it
+    // with two offset cylinders that only read from one angle).
+    parts.push(cyl_up(trunk_r * 1.05, trunk_h * 0.45, trunk_h * 0.225, 7, CACTUS_MID));
+    parts.push(cyl_up(trunk_r * 0.92, trunk_h * 0.60, trunk_h * 0.72, 7, CACTUS_MID));
+    for i in 0..6 {
+        let a = (i as f32 / 6.0) * TAU + 0.26;
+        let c = if i % 2 == 0 { CACTUS_LIGHT } else { CACTUS_DARK };
+        parts.push(tinted(
+            Cuboid::new(0.030, trunk_h * 0.92, 0.030)
+                .mesh()
+                .build()
+                .translated_by(Vec3::new(trunk_r * 0.92, trunk_h * 0.47, 0.0))
+                .rotated_by(Quat::from_rotation_y(a)),
+            lin(c),
+        ));
+    }
     // Rounded green cap so the trunk top isn't a flat disc.
-    parts.push(ball_at(trunk_r * 0.95, y(trunk_h), 0.85, CACTUS_MID));
+    parts.push(ball_at(trunk_r * 0.92, y(trunk_h), 0.85, CACTUS_MID));
 
-    // ── Arms: an upturned arm = a horizontal elbow stub + an upright forearm + tip.
+    // ── Arms: an upturned arm = a round elbow joint + an outward stub + an upright
+    // forearm with its own short rib ridges + a rounded lit tip.
     let add_arm = |parts: &mut Vec<Mesh>, side: f32, attach_y: f32, arm_h: f32, arm_r: f32| {
-        let elbow_len = 0.30;
+        let elbow_len = 0.28;
         let elbow_x = side * (trunk_r + elbow_len * 0.5);
+        // Ball joint where the elbow meets the trunk (hides the seam).
+        parts.push(ball_at(arm_r * 1.1, Vec3::new(side * trunk_r * 0.9, attach_y, 0.0), 0.95, CACTUS_MID));
         // Elbow reaching outward (built upright, laid toward ±X by a 90° Z rotation).
         parts.push(tinted(
             Cylinder::new(arm_r, elbow_len)
@@ -203,22 +206,25 @@ fn build_saguaro_mesh(variant: u32) -> Mesh {
                 .build()
                 .rotated_by(Quat::from_rotation_z(FRAC_PI_2))
                 .translated_by(Vec3::new(elbow_x, attach_y, 0.0)),
-            lin(CACTUS_MID),
-        ));
-        let fore_x = side * (trunk_r + elbow_len);
-        // Upright forearm rising from the elbow's outer end.
-        parts.push(cyl_up_at(arm_r, arm_h, Vec3::new(fore_x, attach_y + arm_h * 0.5, 0.0), CACTUS_MID));
-        // Shaded back rib on the forearm.
-        parts.push(tinted(
-            Cylinder::new(arm_r * 0.55, arm_h * 0.9)
-                .mesh()
-                .resolution(6)
-                .build()
-                .translated_by(Vec3::new(fore_x - side * arm_r * 0.4, attach_y + arm_h * 0.5, 0.0)),
             lin(CACTUS_DARK),
         ));
-        // Rounded lit tip cap.
+        let fore_x = side * (trunk_r + elbow_len);
+        // Round outer elbow + upright forearm rising from it.
+        parts.push(ball_at(arm_r * 1.05, Vec3::new(fore_x, attach_y, 0.0), 0.95, CACTUS_MID));
+        parts.push(cyl_up_at(arm_r, arm_h, Vec3::new(fore_x, attach_y + arm_h * 0.5, 0.0), CACTUS_MID));
+        // Two short rib ridges on the forearm (in + out faces).
+        for s in [-1.0_f32, 1.0] {
+            parts.push(tinted(
+                Cuboid::new(0.022, arm_h * 0.85, 0.022)
+                    .mesh()
+                    .build()
+                    .translated_by(Vec3::new(fore_x + s * arm_r * 0.9, attach_y + arm_h * 0.5, 0.02)),
+                lin(if s > 0.0 { CACTUS_LIGHT } else { CACTUS_DARK }),
+            ));
+        }
+        // Rounded lit tip cap + a bloom crowning the arm.
         parts.push(ball_at(arm_r * 0.95, Vec3::new(fore_x, attach_y + arm_h, 0.0), 0.85, CACTUS_LIGHT));
+        parts.push(ball_at(arm_r * 0.42, Vec3::new(fore_x, attach_y + arm_h + 0.05, 0.0), 0.6, FLOWER_PINK));
     };
 
     match v {
@@ -235,14 +241,14 @@ fn build_saguaro_mesh(variant: u32) -> Mesh {
     parts.push(ball_at(trunk_r * 0.26, y(trunk_h + 0.12), 0.6, FLOWER_YELLOW));
 
     // ── Pale spine flecks spiralling up the trunk (tiny boxes) for texture.
-    for i in 0..5 {
-        let t = (i as f32 + 0.5) / 5.0;
+    for i in 0..7 {
+        let t = (i as f32 + 0.5) / 7.0;
         let a = i as f32 * 2.399_963_2; // golden angle spread
         parts.push(tinted(
-            Cuboid::new(0.02, 0.02, 0.02)
+            Cuboid::new(0.018, 0.018, 0.018)
                 .mesh()
                 .build()
-                .translated_by(Vec3::new(a.cos() * trunk_r * 0.96, trunk_h * (0.2 + t * 0.6), a.sin() * trunk_r * 0.96)),
+                .translated_by(Vec3::new(a.cos() * trunk_r * 0.98, trunk_h * (0.15 + t * 0.7), a.sin() * trunk_r * 0.98)),
             lin(CACTUS_SPINE),
         ));
     }
@@ -265,6 +271,21 @@ fn build_barrel_mesh(variant: u32) -> Mesh {
         ball_at(r * 0.98, y(h), 0.5, CACTUS_LIGHT),  // domed lit top
         ball_at(r * 0.9, y(h * 0.28), 0.5, CACTUS_DARK), // dark shaded skirt
     ];
+
+    // Eight TRUE vertical rib ridges standing proud of the barrel, alternating lit and
+    // shadowed, so the pleats read from every angle.
+    for i in 0..8 {
+        let a = (i as f32 / 8.0) * TAU + 0.2;
+        let c = if i % 2 == 0 { CACTUS_LIGHT } else { CACTUS_DARK };
+        parts.push(tinted(
+            Cuboid::new(0.026, h * 0.88, 0.026)
+                .mesh()
+                .build()
+                .translated_by(Vec3::new(r * 0.95, h * 0.48, 0.0))
+                .rotated_by(Quat::from_rotation_y(a)),
+            lin(c),
+        ));
+    }
 
     // Pale spine flecks around the upper ribs.
     for i in 0..8 {
@@ -452,8 +473,11 @@ fn build_dry_grass_mesh() -> Mesh {
     let parts = specs
         .iter()
         .map(|&(yaw, tilt, h, c)| {
+            // 4-sided blades: the crisp facet IS the look, and dry grass is scattered
+            // by the thousand (the default 32-segment cone was ~8× the vertices).
             let mut m = Cone { radius: 0.018, height: h }
                 .mesh()
+                .resolution(4)
                 .build()
                 .translated_by(y(h / 2.0))
                 .rotated_by(Quat::from_rotation_z(tilt))
@@ -501,7 +525,11 @@ fn build_desert_litter_mesh(variant: u32) -> Mesh {
             let head_y = 0.10;
             let mut parts = vec![
                 tinted(
-                    Cone { radius: 0.008, height: head_y }.mesh().build().translated_by(y(head_y * 0.5)),
+                    Cone { radius: 0.008, height: head_y }
+                        .mesh()
+                        .resolution(5)
+                        .build()
+                        .translated_by(y(head_y * 0.5)),
                     lin(DESERT_STEM),
                 ),
                 ball_at(0.018, y(head_y), 0.7, FLOWER_RED),
@@ -803,23 +831,33 @@ fn build_palm_mesh() -> Mesh {
     }
     let top = Vec3::new(top_x, trunk_h, 0.0);
 
-    // ── Crown: drooping fronds radiating out + down from the trunk top.
-    let n_fronds = 8;
-    for i in 0..n_fronds {
-        let a = (i as f32 / n_fronds as f32) * TAU;
-        let droop = if i % 2 == 0 { 0.55 } else { 0.75 };
-        let c = if i % 2 == 0 { FROND_LIGHT } else { FROND_DARK };
-        let frond_len = 1.1;
-        // Flattened leaf box: build along +Y from origin, droop past horizontal (tilt
-        // about X), yaw around the crown, then move to the trunk top.
-        let frond = Cuboid::new(0.16, frond_len, 0.03)
+    // ── Crown: two tiers of drooping fronds radiating out + down from the trunk top.
+    // Each frond is a squashed 4-sided cone — broad at the crown, tapering to a hanging
+    // tip — so the leaf reads pointed and ribbed, not a stiff rectangle.
+    let frond = |len: f32, a: f32, droop: f32, c: u32| -> Mesh {
+        let m = Cone { radius: 0.10, height: len }
             .mesh()
+            .resolution(4)
             .build()
-            .translated_by(y(frond_len * 0.5))
+            .scaled_by(Vec3::new(1.8, 1.0, 0.35))
+            .translated_by(y(len * 0.5))
             .rotated_by(Quat::from_rotation_x(FRAC_PI_2 + droop))
             .rotated_by(Quat::from_rotation_y(a))
             .translated_by(top);
-        parts.push(tinted(frond, lin(c)));
+        tinted(m, lin(c))
+    };
+    // Lower tier: eight long fronds drooping well past horizontal.
+    for i in 0..8 {
+        let a = (i as f32 / 8.0) * TAU;
+        let droop = if i % 2 == 0 { 0.60 } else { 0.80 };
+        let c = if i % 2 == 0 { FROND_LIGHT } else { FROND_DARK };
+        parts.push(frond(1.15, a, droop, c));
+    }
+    // Upper tier: five shorter fronds lifted nearer the vertical, offset between the
+    // lower tier's gaps, crowning the head.
+    for i in 0..5 {
+        let a = (i as f32 / 5.0) * TAU + 0.4;
+        parts.push(frond(0.75, a, 0.25, FROND_LIGHT));
     }
     // Crown core lump hiding the frond roots.
     parts.push(ball_at(0.14, top, 0.8, FROND_DARK));
@@ -846,6 +884,7 @@ fn build_reed_clump_mesh() -> Mesh {
         let tilt = 0.06 + (i % 4) as f32 * 0.05;
         let stalk = Cone { radius: 0.022, height: h }
             .mesh()
+            .resolution(5)
             .build()
             .translated_by(y(h / 2.0))
             .rotated_by(Quat::from_rotation_z(tilt))

--- a/src/biome_rocky.rs
+++ b/src/biome_rocky.rs
@@ -1,18 +1,27 @@
-//! Rocky highlands biome (key 3) — arid grey-brown stone country. The scatter is
-//! dominated by angular faceted BOULDERS (several sizes, layered/stacked chunks),
-//! punctuated by tall banded HOODOO spires (the "tree" class, spacing-checked so they
-//! never crowd), low dry SHRUB / dead-grass clumps (the first non-tree class → the
-//! tree-too-close fallback) and flat scatters of scree PEBBLES. Ground cover dresses
-//! the dirt with little pebbles + dry tufts. The horizon is a wide arc of tall craggy
-//! grey peaks (no treeline); dust drifts on the wind. River is off.
+//! Rocky highlands biome (key 3) — dramatic craggy stone country. The scatter is
+//! dominated by angular CRAG piles (big fractured slabs leaning into each other over dark
+//! crevice wedges, sun-bleached top facets, ochre/sage lichen crusts, shed cobbles at the
+//! foot — plus a stacked-flat-stone CAIRN variant), punctuated by a mixed "tree" class:
+//! banded HOODOO spires with wind-carved ledges, gnarled wind-bent mountain PINES streaming
+//! sparse tough foliage leeward, and a bleached splinter-topped SNAG (all spacing-checked so
+//! they never crowd). Low dry SHRUB clumps (the first non-tree class → the tree-too-close
+//! fallback) and directional SCREE spills fill between, with sparse crystal clusters as the
+//! one colour accent. Ground cover dresses the dirt with pebbles, dry tufts, lichen litter
+//! and tiny alpine wildflower specks. The horizon is a wide arc of tall craggy grey peaks
+//! (no treeline); dust drifts on the wind. River is off.
 //!
 //! Self-contained: every mesh is built here from primitives, tinted into ATTRIBUTE_COLOR
-//! and flat-shaded for the crisp low-poly facets the rest of the scene uses. Atmosphere
-//! is neutral hazy daylight. The landmark is a dramatic two-pillar ROCK ARCH plus a
-//! flat-topped MESA and a balanced-rock hoodoo, all on the land side (z < 0).
+//! and flat-shaded for the crisp low-poly facets the rest of the scene uses. Light is
+//! BAKED into the vertex colours: every prop stacks dark shadowed feet/undersides, a mid
+//! body and pale sun-bleached top facets so the hard facets read lit before the real sun
+//! even hits them. Atmosphere is neutral hazy daylight. The landmark is a dramatic
+//! two-pillar ROCK ARCH plus a flat-topped MESA (with a lone pine on its cap), a
+//! balanced-rock hoodoo and a waymarker cairn, all on the land side (z < 0).
 //!
 //! Palette (muted arid stone, lifted from the TS rock-highland feel — grey-browns with
-//! warm sand undertones and pale sun-bleached caps; banded ochre/rust for the hoodoos).
+//! warm sand undertones and pale sun-bleached caps; banded ochre/rust for the hoodoos;
+//! dusty conifer greens for the pines; pin-prick alpine flower colours kept tiny so the
+//! biome stays grey overall).
 
 // The `landmarks()` ROCK ARCH set-piece + its `arch_pillar` helper below are authored biome
 // content the world map doesn't place yet (it uses `ruins` landmarks instead). Kept per design;
@@ -25,9 +34,9 @@ use crate::biome::{Backdrop, Biome, BiomeConfig, BiomeEntity, GroundDetail, Part
 use crate::palette::{lin, lin_scaled};
 
 // ── Rocky palette ─────────────────────────────────────────────────────────────────
-// Stone body tones: a cool-warm grey-brown stack so a boulder reads lit (dark foot →
+// Stone body tones: a cool-warm grey-brown stack so a crag reads lit (dark foot →
 // mid body → pale sun-bleached cap). Hoodoos add warmer banded ochre/rust strata.
-const STONE_DARK: u32 = 0x6b6358; // shadowed lower stone
+const STONE_DARK: u32 = 0x6b6358; // shadowed lower stone / crevice
 const STONE_BODY: u32 = 0x8a7f70; // mid grey-brown body
 const STONE_PALE: u32 = 0xb3a692; // sun-bleached top facet
 const STONE_COOL: u32 = 0x7d7a72; // cooler neutral accent lump
@@ -40,6 +49,15 @@ const SHRUB_DRY: u32 = 0x7c7a3e; // olive-brown dry shrub body
 const SHRUB_DRY_DARK: u32 = 0x5f5d2c; // shadowed shrub skirt
 const SHRUB_DEAD: u32 = 0x9a8c52; // bleached dead-grass tips
 
+// Mountain pine / snag — tough dusty conifer greens on weathered grey-brown wood.
+const PINE_DARK: u32 = 0x46563a; // shadowed needle underside
+const PINE_BODY: u32 = 0x5c7046; // mid dusty needle clump
+const PINE_LIT: u32 = 0x7a8c54; // sunlit needle cap
+const BARK_BODY: u32 = 0x6e6052; // weathered grey-brown bark
+const BARK_DARK: u32 = 0x52463a; // bark shadow / root flare
+const SNAG_BLEACH: u32 = 0xb5a88f; // sun-bleached dead wood splinter
+const SNAG_GREY: u32 = 0x8d8273; // weathered snag trunk mid-tone
+
 // Crystal / geode cluster — saturated gem colours jutting from a small grey rock, the one
 // splash of colour in the grey biome. Two themes (amethyst / teal) keyed off the variant.
 const CRYSTAL_AMETHYST: u32 = 0x9b59d0; // amethyst body
@@ -48,14 +66,22 @@ const CRYSTAL_TEAL: u32 = 0x33c2ae; // teal body
 const CRYSTAL_TEAL_DK: u32 = 0x2493a0; // shaded teal facet
 const CRYSTAL_TIP: u32 = 0xe6dcf6; // pale near-white lit crystal tip
 
-// Lichen — the only living colour creeping over the stone (rusty orange + pale green).
+// Lichen — the only living colour creeping over the stone (rusty orange + two greens).
 const LICHEN_ORANGE: u32 = 0xc88a3a; // rusty orange lichen crust
-const LICHEN_GREEN: u32 = 0x8a9a4a; // pale lichen green
+const LICHEN_GREEN: u32 = 0x8a9a4a; // lichen green
+const LICHEN_SAGE: u32 = 0x9aa56b; // paler sage lichen
 
 const PEBBLE_GREY: u32 = 0x9a9085; // scree pebble
 const PEBBLE_WARM: u32 = 0x8a7a64; // warmer scree pebble
 const DRYTUFT_BASE: u32 = 0x86813f; // dry ground tuft base
 const DRYTUFT_TIP: u32 = 0xa89a55; // bleached tuft tip
+
+// Alpine wildflowers — tiny bright specks between the stones (heads are single squashed
+// facets ~0.02u, so they read as pinpricks of colour, not flowerbeds).
+const FLOWER_VIOLET: u32 = 0x9b7fd6;
+const FLOWER_WHITE: u32 = 0xeae6da;
+const FLOWER_GOLD: u32 = 0xd9b84e;
+const STEM_GREEN: u32 = 0x6f7a44;
 
 // ── Mesh helpers (mirror trees.rs / props.rs / decor.rs verbatim) ──────────────────
 
@@ -121,161 +147,444 @@ fn block_at(rx: f32, ry: f32, rz: f32, off: Vec3, tilt: f32, c: [f32; 4]) -> Mes
     )
 }
 
+/// `block_at` with an extra yaw (about Y, applied after the Z-tilt) so big fracture slabs
+/// can lean in ANY direction — the workhorse of the crag piles.
+fn slab_at(rx: f32, ry: f32, rz: f32, off: Vec3, yaw: f32, tilt: f32, c: [f32; 4]) -> Mesh {
+    tinted(
+        Sphere::new(1.0)
+            .mesh()
+            .ico(0)
+            .unwrap()
+            .scaled_by(Vec3::new(rx, ry, rz))
+            .rotated_by(Quat::from_rotation_y(yaw) * Quat::from_rotation_z(tilt))
+            .translated_by(off),
+        c,
+    )
+}
+
+/// Centre height that grounds a Z-tilted slab's lowest point exactly at y=0 — the support
+/// function of the scaled ico "ellipsoid" in -Y: `sqrt((rx·sin t)² + (ry·cos t)²)`. (The
+/// extra yaw in `slab_at` is about Y so it never changes the vertical extent.)
+fn slab_ground(rx: f32, ry: f32, tilt: f32) -> f32 {
+    ((rx * tilt.sin()).powi(2) + (ry * tilt.cos()).powi(2)).sqrt()
+}
+
+/// A flat lichen splotch — a strongly squashed facet lump pressed onto a stone surface.
+fn lichen_at(r: f32, off: Vec3, c: u32) -> Mesh {
+    facet_at(r, off, 0.24, lin(c))
+}
+
+/// A flat cairn stone — a thin cuboid slab yawed about Y, centre at `off`.
+fn flat_stone(w: f32, h: f32, d: f32, off: Vec3, yaw: f32, c: [f32; 4]) -> Mesh {
+    tinted(
+        Cuboid::new(w, h, d)
+            .mesh()
+            .build()
+            .rotated_by(Quat::from_rotation_y(yaw))
+            .translated_by(off),
+        c,
+    )
+}
+
 /// An upright cylinder whose centre sits at `cy` (so a part of height `h` rooted at y=0
 /// uses `cy = h/2`). `res` ≥ 3 (the Cylinder builder asserts resolution > 2).
 fn cyl_up(r: f32, h: f32, cy: f32, res: u32, c: [f32; 4]) -> Mesh {
     tinted(Cylinder::new(r, h).mesh().resolution(res).build().translated_by(y(cy)), c)
 }
 
-// ── Boulders (dominant scatter class) ───────────────────────────────────────────
-// Angular faceted rock chunks, layered/stacked. Three variants vary the silhouette:
-// a squat wide slab pile, a tall split crag, and a low scatter of broken cobbles. All
-// base flush at y=0. Authored ~0.4–0.7u; the scatter scales them 0.7–2.2 per instance,
-// so they range from knee-high rubble to chest-high boulders.
+/// One thin leaning blade — a skinny **res-4** cone (8 tris, vs 64 at default resolution)
+/// rooted at `foot`, tilted about Z then yawed about Y. Returns `(mesh, tip_position)` so
+/// a flower head / seed head can be perched exactly on the tip. Shared by the dry-shrub
+/// spikes, dry tufts, wildflowers and scree accents.
+fn blade(r: f32, h: f32, yaw: f32, tilt: f32, foot: Vec3, c: [f32; 4]) -> (Mesh, Vec3) {
+    let rot = Quat::from_rotation_y(yaw) * Quat::from_rotation_z(tilt);
+    let m = tinted(
+        Cone { radius: r, height: h }
+            .mesh()
+            .resolution(4)
+            .build()
+            .translated_by(y(h * 0.5))
+            .rotated_by(rot)
+            .translated_by(foot),
+        c,
+    );
+    (m, foot + rot * y(h))
+}
+
+// ── Crags / boulders (dominant scatter class) ─────────────────────────────────────
+// Angular fractured rock, with the lighting BAKED in: dark crevice wedges and shadowed
+// feet, mid grey-brown bodies, pale sun-bleached facets on every raised edge, plus
+// ochre/sage lichen crusts. Four variants: a leaning slab crag, a tall split crag, a
+// cobble spill (with grass + a flower speck between the stones) and a stacked-stone
+// CAIRN. All base flush at y=0 (leaning slabs are grounded via `slab_ground`). Authored
+// ~0.4–0.7u; the scatter scales 0.7–2.2, knee-high rubble → chest-high crags.
 
 pub fn build_boulder_mesh(variant: u32) -> Mesh {
-    let m = match variant % 3 {
-        // 0 — squat wide slab: a broad tilted block + a stacked upper slab + side chunks.
+    let m = match variant % 4 {
+        // 0 — leaning slab crag: two big fractured slabs leaning into each other over a
+        // dark crevice wedge; pale facets on the raised edges; cobbles shed at the foot.
         0 => {
             let r = 0.42;
+            let (mx, my, mt) = (r * 1.3, r * 0.75, 0.30); // main slab dims + lean
+            let (cx, cy, ct) = (r * 0.95, r * 0.62, -0.38); // counter-slab leaning back
             merged(vec![
-                // Broad base slab, stretched flat and lightly tilted.
-                block_at(r * 1.25, r * 0.62, r * 1.05, y(r * 0.5), 0.10, lin_scaled(STONE_BODY, 0.9)),
-                // Stacked upper slab offset to one side (the "layering").
-                block_at(r * 0.9, r * 0.5, r * 0.78, Vec3::new(r * 0.28, r * 1.05, -r * 0.12), -0.14, lin(STONE_COOL)),
-                // Bright pale cap catching the sun.
-                facet_at(r * 0.5, Vec3::new(r * 0.34, r * 1.55, -r * 0.1), 0.7, lin(STONE_PALE)),
-                // Side chunks leaning on the base.
-                facet_at(r * 0.55, Vec3::new(-r * 0.95, r * 0.45, r * 0.22), 0.8, lin_scaled(STONE_DARK, 1.05)),
-                facet_at(r * 0.46, Vec3::new(r * 0.85, r * 0.4, -r * 0.55), 0.8, lin(STONE_COOL)),
+                slab_at(mx, my, r * 0.95, Vec3::new(-r * 0.15, slab_ground(mx, my, mt), 0.0), 0.2, mt, lin_scaled(STONE_BODY, 0.92)),
+                slab_at(cx, cy, r * 0.8, Vec3::new(r * 0.6, slab_ground(cx, cy, ct), -r * 0.1), -0.5, ct, lin(STONE_COOL)),
+                // Dark wedge jammed in the crevice where the slabs meet (baked shadow).
+                facet_at(r * 0.4, Vec3::new(r * 0.18, r * 0.55, r * 0.12), 0.9, lin_scaled(STONE_DARK, 0.85)),
+                // Sun-bleached facets riding the raised slab edges.
+                facet_at(r * 0.4, Vec3::new(r * 0.55, r * 1.45, 0.05), 0.45, lin(STONE_PALE)),
+                facet_at(r * 0.28, Vec3::new(r * 0.25, r * 1.2, -r * 0.35), 0.45, lin_scaled(STONE_PALE, 0.95)),
+                // Lichen crusts — orange on the sunny top, sage low on the flank.
+                lichen_at(r * 0.26, Vec3::new(-r * 0.3, r * 1.5, r * 0.2), LICHEN_ORANGE),
+                lichen_at(r * 0.2, Vec3::new(-r * 0.95, r * 0.55, r * 0.3), LICHEN_SAGE),
+                // Shed cobbles at the foot.
+                facet_at(r * 0.3, Vec3::new(-r * 1.3, r * 0.21, -r * 0.45), 0.7, lin_scaled(STONE_DARK, 1.05)),
+                facet_at(r * 0.24, Vec3::new(r * 1.3, r * 0.17, r * 0.55), 0.7, lin(PEBBLE_WARM)),
             ])
         }
-        // 1 — tall split crag: stacked blocks climbing up + a wedged chip + pale peak.
+        // 1 — tall split crag: stacked blocks climbing up, a flank slab propped against
+        // the base, a dark cleft chip, lit ledges and a pale sun-bleached peak.
         1 => {
             let r = 0.4;
+            let (fx, fy, ft) = (r * 0.85, r * 0.4, 0.5); // propped flank slab
             merged(vec![
-                // Lower block.
-                block_at(r * 0.95, r * 0.8, r * 0.9, y(r * 0.7), 0.06, lin_scaled(STONE_DARK, 1.08)),
-                // Middle block offset (the split).
-                block_at(r * 0.78, r * 0.7, r * 0.72, Vec3::new(r * 0.3, r * 1.7, -r * 0.1), -0.12, lin(STONE_BODY)),
-                // Upper block.
-                block_at(r * 0.55, r * 0.6, r * 0.52, Vec3::new(r * 0.12, r * 2.55, r * 0.06), 0.1, lin(STONE_COOL)),
-                // A small chip wedged in the cleft.
-                facet_at(r * 0.34, Vec3::new(-r * 0.5, r * 1.3, r * 0.28), 0.85, lin_scaled(STONE_DARK, 1.0)),
-                // Pale sun-bleached peak.
-                facet_at(r * 0.4, Vec3::new(r * 0.14, r * 3.15, r * 0.02), 0.78, lin(STONE_PALE)),
+                // Lower block (grounded: vertical extent ≈ 0.85r at this tilt).
+                block_at(r * 1.05, r * 0.85, r * 0.95, y(r * 0.86), 0.06, lin_scaled(STONE_DARK, 1.08)),
+                // Middle block offset (the split), then the upper block.
+                block_at(r * 0.8, r * 0.72, r * 0.75, Vec3::new(r * 0.3, r * 1.75, -r * 0.1), -0.12, lin(STONE_BODY)),
+                block_at(r * 0.58, r * 0.62, r * 0.55, Vec3::new(r * 0.1, r * 2.6, r * 0.05), 0.10, lin(STONE_COOL)),
+                // Fracture slab propped against the lower block.
+                slab_at(fx, fy, r * 0.6, Vec3::new(-r * 0.8, slab_ground(fx, fy, ft), r * 0.2), 0.7, ft, lin_scaled(STONE_BODY, 0.9)),
+                // Dark chip wedged in the cleft (baked crevice shadow).
+                facet_at(r * 0.32, Vec3::new(-r * 0.45, r * 1.35, r * 0.3), 0.85, lin_scaled(STONE_DARK, 0.85)),
+                // Lit ledge facet on the mid block + pale sun-bleached peak.
+                facet_at(r * 0.26, Vec3::new(r * 0.6, r * 2.25, -r * 0.15), 0.5, lin_scaled(STONE_PALE, 0.94)),
+                facet_at(r * 0.42, Vec3::new(r * 0.12, r * 3.2, 0.0), 0.75, lin(STONE_PALE)),
+                // Lichen — orange on the mid shoulder, sage low.
+                lichen_at(r * 0.18, Vec3::new(-r * 0.1, r * 2.2, r * 0.45), LICHEN_ORANGE),
+                lichen_at(r * 0.16, Vec3::new(r * 0.85, r * 0.9, r * 0.35), LICHEN_GREEN),
+                // A cobble shed at the foot.
+                facet_at(r * 0.26, Vec3::new(r * 1.1, r * 0.19, r * 0.5), 0.7, lin(PEBBLE_WARM)),
             ])
         }
-        // 2 — low scatter of broken cobbles spread flat (rubble field).
-        _ => {
+        // 2 — cobble spill: a low central slab with broken cobbles drifted around it,
+        // dry grass + one gold alpine speck poking up between the stones.
+        2 => {
             let r = 0.34;
-            merged(vec![
-                block_at(r * 1.0, r * 0.5, r * 0.85, y(r * 0.46), 0.08, lin_scaled(STONE_BODY, 0.94)),
-                facet_at(r * 0.78, Vec3::new(r * 1.05, r * 0.45, r * 0.28), 0.7, lin(STONE_COOL)),
-                facet_at(r * 0.66, Vec3::new(-r * 0.98, r * 0.4, -r * 0.42), 0.7, lin_scaled(STONE_DARK, 1.05)),
-                facet_at(r * 0.5, Vec3::new(r * 0.12, r * 0.4, -r * 1.05), 0.72, lin(STONE_PALE)),
-                facet_at(r * 0.42, Vec3::new(-r * 0.22, r * 0.36, r * 1.0), 0.72, lin(STONE_BODY)),
-            ])
+            let (sx, sy, st) = (r * 1.1, r * 0.45, 0.10);
+            let mut parts = vec![
+                slab_at(sx, sy, r * 0.8, Vec3::new(0.0, slab_ground(sx, sy, st), 0.0), 0.3, st, lin_scaled(STONE_BODY, 0.94)),
+                // Lit fleck on the central slab's crown.
+                facet_at(r * 0.3, Vec3::new(r * 0.2, r * 0.78, 0.0), 0.4, lin(STONE_PALE)),
+                // The cobble drift, mixed tones, thinning outward.
+                facet_at(r * 0.78, Vec3::new(r * 1.1, r * 0.4, r * 0.3), 0.7, lin(STONE_COOL)),
+                facet_at(r * 0.66, Vec3::new(-r * 1.0, r * 0.34, -r * 0.45), 0.7, lin_scaled(STONE_DARK, 1.05)),
+                facet_at(r * 0.5, Vec3::new(r * 0.12, r * 0.27, -r * 1.05), 0.72, lin(STONE_PALE)),
+                facet_at(r * 0.44, Vec3::new(-r * 0.25, r * 0.24, r * 1.05), 0.72, lin(PEBBLE_WARM)),
+                facet_at(r * 0.36, Vec3::new(r * 1.6, r * 0.2, -r * 0.5), 0.7, lin_scaled(PEBBLE_GREY, 0.94)),
+                facet_at(r * 0.3, Vec3::new(-r * 1.55, r * 0.17, r * 0.35), 0.7, lin(PEBBLE_GREY)),
+                // Sage lichen on the big cool cobble.
+                lichen_at(r * 0.2, Vec3::new(r * 1.15, r * 0.85, r * 0.35), LICHEN_SAGE),
+            ];
+            // Dry grass + a gold flower speck in the gaps.
+            let (g1, _) = blade(0.013, 0.17, 0.8, 0.3, Vec3::new(-r * 0.6, 0.02, -r * 0.9), lin(DRYTUFT_BASE));
+            let (g2, _) = blade(0.012, 0.14, 3.9, 0.36, Vec3::new(-r * 0.5, 0.02, -r * 0.8), lin(DRYTUFT_TIP));
+            let (stem, tip) = blade(0.008, 0.10, 2.0, 0.25, Vec3::new(r * 0.7, 0.01, -r * 0.55), lin(STEM_GREEN));
+            parts.push(g1);
+            parts.push(g2);
+            parts.push(stem);
+            parts.push(facet_at(0.018, tip, 0.75, lin(FLOWER_GOLD)));
+            merged(parts)
+        }
+        // 3 — CAIRN: a hand-stacked tower of flat stones (thin yawed cuboids) tapering
+        // up to a pale top stone + a pebble topper; lichen on the weathered courses.
+        _ => {
+            // (w, d, h, yaw, x-jog, z-jog, colour) per course, bottom → top.
+            let stones = [
+                (0.46_f32, 0.40_f32, 0.100_f32, 0.15_f32, 0.000_f32, 0.000_f32, lin_scaled(STONE_BODY, 0.92)),
+                (0.40, 0.35, 0.095, -0.35, 0.020, -0.015, lin(STONE_COOL)),
+                (0.35, 0.30, 0.090, 0.55, -0.025, 0.020, lin(STONE_BODY)),
+                (0.28, 0.25, 0.085, -0.20, 0.015, 0.015, lin_scaled(STONE_DARK, 1.12)),
+                (0.22, 0.19, 0.080, 0.95, -0.010, -0.020, lin_scaled(STONE_BODY, 1.04)),
+                (0.16, 0.13, 0.075, 0.35, 0.020, 0.010, lin(STONE_PALE)),
+            ];
+            let mut parts = Vec::new();
+            let mut cy = 0.0;
+            for &(w, d, h, yaw, jx, jz, c) in &stones {
+                parts.push(flat_stone(w, h, d, Vec3::new(jx, cy + h * 0.5, jz), yaw, c));
+                cy += h;
+            }
+            // Pebble topper + lichen on the courses + two stones dropped at the foot.
+            parts.push(facet_at(0.05, Vec3::new(0.02, cy + 0.035, 0.01), 0.7, lin(PEBBLE_WARM)));
+            parts.push(lichen_at(0.055, Vec3::new(0.17, 0.20, 0.12), LICHEN_ORANGE));
+            parts.push(lichen_at(0.05, Vec3::new(-0.20, 0.07, 0.06), LICHEN_SAGE));
+            parts.push(facet_at(0.05, Vec3::new(0.30, 0.031, 0.14), 0.6, lin(PEBBLE_GREY)));
+            parts.push(facet_at(0.04, Vec3::new(-0.27, 0.025, -0.12), 0.6, lin(PEBBLE_WARM)));
+            merged(parts)
         }
     };
     flat_shaded(m)
 }
 
-// ── Hoodoo / rock spire (the "tree" class — spacing-checked) ─────────────────────
-// A tapered stack of stone drums in alternating ochre/rust/pale bands — a wind-carved
-// column. Some carry a wider "balanced" cap rock perched on the narrow neck. Base at
-// y=0. Authored ~1.4–1.8u tall; the scatter scales them up so they tower like landmarks.
+// ── Hoodoo / rock spire (part of the "tree" class — spacing-checked) ──────────────
+// A tapered stack of stone drums in alternating ochre/rust/pale bands, now wind-carved:
+// the drums drift sideways as they climb, hard pale bands resist erosion and jut out as
+// protruding LEDGE rims, a dark plinth shadows the foot, and fallen band-rubble + lichen
+// dress the base. Base at y=0. Authored ~1.5–1.9u; the scatter scales them up to tower.
 
 pub fn build_hoodoo_mesh(variant: u32) -> Mesh {
     let m = match variant % 2 {
-        // 0 — slender banded spire tapering to a point.
+        // 0 — slender banded spire: 7 drifting drums tapering to a pointed cap, with two
+        // ledge rims where the hard pale bands overhang.
         0 => {
-            // Stack of drums, each narrower than the last, alternating bands.
+            // (radius, height, band colour, sideways drift of the drum centre).
             let bands = [
-                (0.30_f32, 0.34_f32, HOODOO_RUST),
-                (0.27, 0.32, HOODOO_BASE),
-                (0.24, 0.30, HOODOO_PALE),
-                (0.20, 0.30, HOODOO_BASE),
-                (0.16, 0.28, HOODOO_RUST),
-                (0.12, 0.26, HOODOO_PALE),
+                (0.31_f32, 0.32_f32, HOODOO_RUST, 0.000_f32),
+                (0.28, 0.30, HOODOO_BASE, 0.015),
+                (0.25, 0.28, HOODOO_PALE, 0.030),
+                (0.21, 0.28, HOODOO_BASE, 0.050),
+                (0.17, 0.26, HOODOO_RUST, 0.065),
+                (0.13, 0.24, HOODOO_PALE, 0.085),
+                (0.10, 0.22, HOODOO_BASE, 0.100),
             ];
-            let mut parts = Vec::new();
+            // Dark shadowed plinth hugging the foot (baked contact shadow).
+            let mut parts = vec![cyl_up(0.36, 0.10, 0.05, 8, lin_scaled(HOODOO_RUST, 0.82))];
             let mut cy = 0.0;
-            for &(r, h, c) in &bands {
-                parts.push(cyl_up(r, h, cy + h * 0.5, 8, lin(c)));
+            for (i, &(r, h, c, drift)) in bands.iter().enumerate() {
+                parts.push(tinted(
+                    Cylinder::new(r, h)
+                        .mesh()
+                        .resolution(8)
+                        .build()
+                        .translated_by(Vec3::new(drift, cy + h * 0.5, drift * 0.4)),
+                    lin(c),
+                ));
                 cy += h;
+                if i == 2 || i == 4 {
+                    // Hard band resists the wind → a pale protruding ledge rim at the joint.
+                    parts.push(facet_at(r * 1.18, Vec3::new(drift, cy, drift * 0.4), 0.22, lin(STONE_PALE)));
+                }
             }
-            // A small pointed cap.
+            // Pointed cap, leaning with the drift.
             parts.push(tinted(
-                Cone { radius: 0.12, height: 0.22 }.mesh().resolution(8).build().translated_by(y(cy + 0.11)),
+                Cone { radius: 0.10, height: 0.22 }
+                    .mesh()
+                    .resolution(8)
+                    .build()
+                    .translated_by(Vec3::new(0.10, cy + 0.11, 0.04)),
                 lin(HOODOO_RUST),
             ));
+            // Lichen streaks on the shaded base + fallen band-rubble at the foot.
+            parts.push(lichen_at(0.12, Vec3::new(-0.26, 0.30, 0.08), LICHEN_ORANGE));
+            parts.push(lichen_at(0.09, Vec3::new(-0.22, 0.62, -0.12), LICHEN_SAGE));
+            parts.push(facet_at(0.10, Vec3::new(0.40, 0.07, 0.16), 0.7, lin(PEBBLE_WARM)));
+            parts.push(facet_at(0.08, Vec3::new(-0.36, 0.055, -0.20), 0.7, lin_scaled(HOODOO_RUST, 0.9)));
             merged(parts)
         }
-        // 1 — balanced rock: a narrow stacked neck with a wide cap rock perched on top.
+        // 1 — balanced rock: a drifting banded neck (its top band darkened — it lives in
+        // the cap's shadow) carrying a two-slab layered cap rock with a lit pale crown;
+        // a dark squashed facet just under the cap bakes the overhang shadow in.
         _ => {
             let bands = [
-                (0.26_f32, 0.40_f32, HOODOO_BASE),
-                (0.20, 0.36, HOODOO_RUST),
-                (0.15, 0.34, HOODOO_PALE),
-                (0.11, 0.30, HOODOO_BASE), // narrow neck
+                (0.27_f32, 0.38_f32, lin(HOODOO_BASE), 0.000_f32),
+                (0.21, 0.34, lin(HOODOO_RUST), 0.020),
+                (0.16, 0.32, lin(HOODOO_PALE), 0.040),
+                (0.115, 0.28, lin_scaled(HOODOO_BASE, 0.78), 0.050), // shadowed narrow neck
             ];
             let mut parts = Vec::new();
             let mut cy = 0.0;
-            for &(r, h, c) in &bands {
-                parts.push(cyl_up(r, h, cy + h * 0.5, 8, lin(c)));
+            for &(r, h, c, drift) in &bands {
+                parts.push(tinted(
+                    Cylinder::new(r, h)
+                        .mesh()
+                        .resolution(8)
+                        .build()
+                        .translated_by(Vec3::new(drift, cy + h * 0.5, drift * 0.3)),
+                    c,
+                ));
                 cy += h;
             }
-            // Wide balanced cap rock — a stretched faceted block overhanging the neck.
-            parts.push(block_at(0.36, 0.20, 0.32, y(cy + 0.18), 0.06, lin_scaled(STONE_BODY, 1.05)));
-            parts.push(facet_at(0.18, y(cy + 0.42), 0.7, lin(STONE_PALE)));
+            // Baked contact shadow where the cap overhangs the neck.
+            parts.push(facet_at(0.18, Vec3::new(0.05, cy + 0.03, 0.0), 0.3, lin_scaled(STONE_DARK, 0.88)));
+            // The layered cap: main slab + smaller offset top slab + pale lit crown.
+            parts.push(slab_at(0.40, 0.21, 0.34, Vec3::new(0.06, cy + 0.20, 0.0), 0.3, 0.07, lin_scaled(STONE_BODY, 1.05)));
+            parts.push(slab_at(0.26, 0.14, 0.22, Vec3::new(0.10, cy + 0.42, -0.04), -0.4, -0.06, lin(STONE_COOL)));
+            parts.push(facet_at(0.16, Vec3::new(0.10, cy + 0.55, -0.03), 0.55, lin(STONE_PALE)));
+            // Lichen clinging to the cap rim + rubble and sage at the foot.
+            parts.push(lichen_at(0.10, Vec3::new(0.40, cy + 0.24, 0.12), LICHEN_ORANGE));
+            parts.push(lichen_at(0.10, Vec3::new(-0.22, 0.26, 0.10), LICHEN_SAGE));
+            parts.push(facet_at(0.10, Vec3::new(0.36, 0.07, -0.14), 0.7, lin(PEBBLE_WARM)));
+            parts.push(facet_at(0.08, Vec3::new(-0.32, 0.055, 0.18), 0.7, lin_scaled(STONE_BODY, 0.95)));
             merged(parts)
         }
     };
     flat_shaded(m)
 }
 
+// ── Wind-bent mountain pine (part of the "tree" class) ────────────────────────────
+// A gnarled timberline conifer: three chained trunk segments leaning progressively
+// downwind, a dark root flare, snapped branch stubs on the windward side, and a sparse
+// flag of tough foliage streaming leeward — dark shadowed underside clumps, mid dusty
+// bodies, small sunlit caps on top. `variant` mirrors the wind direction (and the odd
+// variant carries one extra clump near the crown). Base at y=0, ~1.5u authored.
+
+pub fn build_windpine_mesh(variant: u32) -> Mesh {
+    // Wind blows toward +X for even variants, mirrored for odd.
+    let sweep: f32 = if variant % 2 == 0 { 1.0 } else { -1.0 };
+    let mut parts = vec![
+        // Dark root flare gripping the stone.
+        facet_at(0.10, y(0.06), 0.66, lin(BARK_DARK)),
+        facet_at(0.06, Vec3::new(0.09 * sweep, 0.045, 0.04), 0.66, lin_scaled(BARK_DARK, 0.9)),
+        facet_at(0.055, Vec3::new(-0.08 * sweep, 0.04, -0.05), 0.66, lin(BARK_BODY)),
+    ];
+
+    // Trunk: three chained segments, each leaning further downwind (twisted-bole look).
+    let segs = [(0.085_f32, 0.55_f32, 0.16_f32), (0.065, 0.45, 0.34), (0.05, 0.40, 0.55)];
+    let mut foot = y(0.02);
+    for (i, &(r, len, lean)) in segs.iter().enumerate() {
+        let rot = Quat::from_rotation_z(-lean * sweep);
+        let mid = foot + rot * y(len * 0.5);
+        let c = if i == 0 { lin_scaled(BARK_BODY, 0.92) } else { lin(BARK_BODY) };
+        parts.push(tinted(
+            Cylinder::new(r, len).mesh().resolution(6).build().rotated_by(rot).translated_by(mid),
+            c,
+        ));
+        foot += rot * y(len);
+    }
+    let t = foot; // crown anchor ≈ (0.45·sweep, 1.33, 0)
+    let at = |dx: f32, dy: f32, dz: f32| t + Vec3::new(dx * sweep, dy, dz);
+
+    // Snapped branch stubs on the windward side (the wind strips that flank bare).
+    let (s1, _) = blade(0.022, 0.16, 0.0, 1.30 * sweep, Vec3::new(0.10 * sweep, 0.62, 0.01), lin(BARK_DARK));
+    let (s2, _) = blade(0.018, 0.12, 0.0, 1.45 * sweep, Vec3::new(0.20 * sweep, 0.91, -0.02), lin(SNAG_GREY));
+    parts.push(s1);
+    parts.push(s2);
+
+    // Foliage flag streaming leeward: dark undersides → mid bodies → sunlit caps.
+    parts.push(facet_at(0.16, at(0.02, -0.02, 0.0), 0.6, lin(PINE_DARK)));
+    parts.push(facet_at(0.13, at(0.24, -0.05, 0.09), 0.6, lin(PINE_DARK)));
+    parts.push(facet_at(0.12, at(-0.13, -0.07, -0.08), 0.6, lin(PINE_DARK)));
+    parts.push(facet_at(0.15, at(0.10, 0.08, 0.04), 0.66, lin(PINE_BODY)));
+    parts.push(facet_at(0.12, at(0.32, 0.02, -0.06), 0.62, lin(PINE_BODY)));
+    parts.push(facet_at(0.11, at(-0.05, 0.10, 0.09), 0.64, lin(PINE_BODY)));
+    parts.push(facet_at(0.10, at(0.13, 0.19, 0.0), 0.5, lin(PINE_LIT)));
+    parts.push(facet_at(0.08, at(0.31, 0.13, -0.03), 0.5, lin(PINE_LIT)));
+    // A lower clump trailing off the mid-trunk, with its own lit cap.
+    parts.push(facet_at(0.11, Vec3::new(0.30 * sweep, 0.88, 0.06), 0.6, lin(PINE_DARK)));
+    parts.push(facet_at(0.075, Vec3::new(0.34 * sweep, 0.99, 0.05), 0.5, lin(PINE_LIT)));
+    if variant % 2 == 1 {
+        // The mirrored tree is a touch fuller at the crown.
+        parts.push(facet_at(0.09, at(0.44, 0.06, 0.02), 0.55, lin(PINE_BODY)));
+    }
+    flat_shaded(merged(parts))
+}
+
+// ── Weathered snag (part of the "tree" class) ─────────────────────────────────────
+// A long-dead tree: a tilted weathered-grey bole rising from a dark root flare to a
+// splintered crown (a tall bleached shard + a shorter dark one), one bare near-horizontal
+// branch, a snapped stub, and lichen creeping up the shaded side. Base at y=0, ~1.4u.
+
+pub fn build_snag_mesh() -> Mesh {
+    let rot = Quat::from_rotation_z(0.06);
+    let mut parts = vec![
+        // Dark root flare.
+        facet_at(0.11, y(0.06), 0.6, lin(BARK_DARK)),
+        facet_at(0.07, Vec3::new(0.10, 0.045, 0.05), 0.6, lin_scaled(BARK_DARK, 0.9)),
+        facet_at(0.06, Vec3::new(-0.09, 0.04, -0.06), 0.6, lin(SNAG_GREY)),
+        // Slightly tilted weathered bole.
+        tinted(
+            Cylinder::new(0.085, 0.95).mesh().resolution(7).build().rotated_by(rot).translated_by(rot * y(0.475) + y(0.012)),
+            lin(SNAG_GREY),
+        ),
+    ];
+    let top = rot * y(0.95) + y(0.012); // ≈ (-0.057, 0.96)
+    // Splintered crown: tall bleached shard + shorter dark shard beside it.
+    parts.push(tinted(
+        Cone { radius: 0.06, height: 0.48 }
+            .mesh()
+            .resolution(5)
+            .build()
+            .translated_by(y(0.24))
+            .rotated_by(Quat::from_rotation_z(0.14))
+            .translated_by(top),
+        lin(SNAG_BLEACH),
+    ));
+    parts.push(tinted(
+        Cone { radius: 0.045, height: 0.26 }
+            .mesh()
+            .resolution(5)
+            .build()
+            .translated_by(y(0.13))
+            .rotated_by(Quat::from_rotation_z(-0.34))
+            .translated_by(top + Vec3::new(0.03, -0.04, 0.02)),
+        lin_scaled(BARK_DARK, 1.05),
+    ));
+    // One bare near-horizontal branch + a snapped stub lower on the other side.
+    parts.push(tinted(
+        Cylinder::new(0.02, 0.42)
+            .mesh()
+            .resolution(5)
+            .build()
+            .translated_by(y(0.21))
+            .rotated_by(Quat::from_rotation_y(0.5) * Quat::from_rotation_z(1.22))
+            .translated_by(Vec3::new(-0.02, 0.68, 0.0)),
+        lin_scaled(SNAG_BLEACH, 0.92),
+    ));
+    let (stub, _) = blade(0.028, 0.14, 3.6, 1.35, Vec3::new(0.02, 0.48, 0.02), lin(BARK_DARK));
+    parts.push(stub);
+    // Lichen creeping up the shaded (-X) side.
+    parts.push(lichen_at(0.055, Vec3::new(-0.085, 0.34, 0.03), LICHEN_GREEN));
+    parts.push(lichen_at(0.045, Vec3::new(-0.075, 0.58, -0.02), LICHEN_ORANGE));
+    flat_shaded(merged(parts))
+}
+
 // ── Dry shrub / dead-grass clump (first non-tree class → tree fallback) ──────────
-// A low olive-brown scrub: a dark squashed skirt of foliage lumps with a few bleached
-// dead-grass spikes poking out. Base at y=0, ~0.35u tall. Two variants vary fullness.
+// A low olive-brown scrub with the light baked in as three tone layers: a dark grounded
+// skirt → olive mid body → a sunlit crown lump. Bleached dead-grass spikes (cheap res-4
+// cones) lean out of the clump; the odd variant perches bright seed heads on its two
+// tallest spikes. Base at y=0, ~0.38u tall.
 
 pub fn build_dry_shrub_mesh(variant: u32) -> Mesh {
     let mut parts = vec![
         // Dark grounded skirt.
-        facet_at(0.20, y(0.13), 0.7, lin(SHRUB_DRY_DARK)),
-        facet_at(0.16, Vec3::new(0.15, 0.11, 0.05), 0.7, lin(SHRUB_DRY_DARK)),
-        facet_at(0.14, Vec3::new(-0.13, 0.10, 0.09), 0.7, lin(SHRUB_DRY_DARK)),
-        // Olive body.
-        facet_at(0.17, y(0.22), 0.78, lin(SHRUB_DRY)),
-        facet_at(0.13, Vec3::new(0.10, 0.25, -0.10), 0.78, lin(SHRUB_DRY)),
+        facet_at(0.21, y(0.13), 0.62, lin(SHRUB_DRY_DARK)),
+        facet_at(0.16, Vec3::new(0.16, 0.10, 0.05), 0.62, lin(SHRUB_DRY_DARK)),
+        facet_at(0.14, Vec3::new(-0.14, 0.09, 0.09), 0.62, lin(SHRUB_DRY_DARK)),
+        // Olive mid body.
+        facet_at(0.17, y(0.23), 0.78, lin(SHRUB_DRY)),
+        facet_at(0.13, Vec3::new(0.11, 0.25, -0.10), 0.78, lin(SHRUB_DRY)),
+        facet_at(0.11, Vec3::new(-0.10, 0.24, -0.06), 0.74, lin_scaled(SHRUB_DRY, 0.92)),
+        // Sunlit crown.
+        facet_at(0.11, y(0.33), 0.8, lin_scaled(SHRUB_DRY, 1.16)),
     ];
     if variant % 2 == 0 {
-        parts.push(facet_at(0.11, y(0.31), 0.82, lin_scaled(SHRUB_DRY, 1.1)));
+        parts.push(facet_at(0.08, Vec3::new(0.07, 0.36, -0.04), 0.8, lin_scaled(SHRUB_DRY, 1.24)));
     }
-    // A few bleached dead-grass spikes (thin cones) leaning out of the clump.
-    let spikes = if variant % 2 == 0 { 5 } else { 4 };
+    // Bleached dead-grass spikes leaning out of the clump, alternating two tones.
+    let spikes = if variant % 2 == 0 { 6 } else { 5 };
     for i in 0..spikes {
         let a = (i as f32 / spikes as f32) * std::f32::consts::TAU + 0.4;
-        let h = 0.24 + (i % 3) as f32 * 0.05;
-        let tilt = 0.22 + (i % 2) as f32 * 0.10;
-        let foot = 0.10;
-        let spike = Cone { radius: 0.012, height: h }
-            .mesh()
-            .build()
-            .translated_by(y(h / 2.0))
-            .rotated_by(Quat::from_rotation_z(tilt))
-            .rotated_by(Quat::from_rotation_y(a))
-            .translated_by(Vec3::new(a.cos() * foot, 0.06, a.sin() * foot));
-        parts.push(tinted(spike, lin(SHRUB_DEAD)));
+        let h = 0.26 + (i % 3) as f32 * 0.05;
+        let tilt = 0.24 + (i % 2) as f32 * 0.12;
+        let foot = Vec3::new(a.cos() * 0.10, 0.05, a.sin() * 0.10);
+        let c = if i % 2 == 0 { lin(SHRUB_DEAD) } else { lin_scaled(SHRUB_DEAD, 0.86) };
+        let (m, tip) = blade(0.012, h, a, tilt, foot, c);
+        parts.push(m);
+        if variant % 2 == 1 && i < 2 {
+            // Bright seed heads catching the light on the tallest spikes.
+            parts.push(facet_at(0.016, tip, 0.8, lin_scaled(SHRUB_DEAD, 1.2)));
+        }
     }
     flat_shaded(merged(parts))
 }
 
 // ── Crystal / geode cluster (scatter — the one colour accent) ────────────────────
-// A small grey rock base with a fan of 6-sided crystal shards (hex prism + pointed cap)
-// jutting up at mixed tilts/sizes, in saturated amethyst or teal with a pale lit tip.
-// Vertex-colour only (no emissive) so it still batches on the shared material. Base at
-// y=0, ~0.6u tall. `variant` switches the gem theme.
+// A small grey rock base (now with a pale lit crown facet + a sage lichen fleck) with a
+// fan of 6-sided crystal shards (hex prism + pointed cap) jutting up at mixed tilts and
+// sizes — a tall centre shard, four leaners, and two small chips at the foot — in
+// saturated amethyst or teal with a pale lit tip. Vertex-colour only (no emissive) so it
+// still batches on the shared material. Base at y=0, ~0.6u tall. `variant` = gem theme.
 
 /// One crystal shard: a 6-sided prism capped with a 6-sided point, tilted + yawed off the
 /// base, in `body`/`tip` linear colours. Returned as one merged (2-part) mesh.
@@ -309,19 +618,23 @@ pub fn build_crystal_mesh(variant: u32) -> Mesh {
     let tip = lin(CRYSTAL_TIP);
 
     let mut parts = vec![
-        // Small grey host rock the crystals erupt from.
-        facet_at(0.22, y(0.10), 0.62, lin(STONE_DARK)),
-        facet_at(0.15, Vec3::new(0.13, 0.09, 0.05), 0.7, lin(STONE_BODY)),
-        facet_at(0.12, Vec3::new(-0.12, 0.07, -0.06), 0.7, lin_scaled(STONE_DARK, 1.05)),
+        // Grey host rock the crystals erupt from — dark base, lit crown, lichen fleck.
+        facet_at(0.22, y(0.14), 0.62, lin(STONE_DARK)),
+        facet_at(0.15, Vec3::new(0.13, 0.10, 0.05), 0.7, lin(STONE_BODY)),
+        facet_at(0.12, Vec3::new(-0.12, 0.085, -0.06), 0.7, lin_scaled(STONE_DARK, 1.05)),
+        facet_at(0.10, Vec3::new(0.02, 0.24, -0.02), 0.45, lin(STONE_PALE)),
+        lichen_at(0.05, Vec3::new(-0.15, 0.14, 0.04), LICHEN_SAGE),
     ];
 
-    // A tall central shard + four shorter ones leaning out around it.
-    parts.push(crystal_shard(0.06, 0.42, 0.0, 0.0, y(0.14), body, tip));
+    // A tall central shard + four leaners + two small chips low at the foot.
+    parts.push(crystal_shard(0.06, 0.42, 0.0, 0.0, y(0.16), body, tip));
     let shards = [
-        (0.05_f32, 0.30_f32, 0.40_f32, 0.6_f32, Vec3::new(0.12, 0.12, 0.04), body_dk),
-        (0.045, 0.26, -0.42, 2.1, Vec3::new(-0.13, 0.11, 0.05), body),
-        (0.04, 0.22, 0.34, 3.6, Vec3::new(0.05, 0.10, -0.13), body_dk),
-        (0.038, 0.20, -0.30, 5.0, Vec3::new(-0.06, 0.10, -0.10), body),
+        (0.05_f32, 0.30_f32, 0.40_f32, 0.6_f32, Vec3::new(0.12, 0.13, 0.04), body_dk),
+        (0.045, 0.26, -0.42, 2.1, Vec3::new(-0.13, 0.12, 0.05), body),
+        (0.04, 0.22, 0.34, 3.6, Vec3::new(0.05, 0.11, -0.13), body_dk),
+        (0.038, 0.20, -0.30, 5.0, Vec3::new(-0.06, 0.11, -0.10), body),
+        (0.030, 0.14, 0.55, 1.3, Vec3::new(0.18, 0.05, -0.07), body),
+        (0.028, 0.12, -0.50, 4.2, Vec3::new(-0.16, 0.045, -0.10), body_dk),
     ];
     for (r, h, tilt, yaw, base, c) in shards {
         parts.push(crystal_shard(r, h, tilt, yaw, base, c, tip));
@@ -330,43 +643,88 @@ pub fn build_crystal_mesh(variant: u32) -> Mesh {
     flat_shaded(merged(parts))
 }
 
-// ── Scree pebble cluster (scatter) ───────────────────────────────────────────────
-// A flat spread of several tiny faceted stones — broken rock litter. Base at y=0,
-// very low. Two variants vary the count / spread.
+// ── Scree spill (scatter) ────────────────────────────────────────────────────────
+// A directional drift of broken-rock litter: one anchor cobble (with a pale lit cap and
+// a sage lichen fleck) trailing a spill of mixed grey/warm/pale pebbles that thins along
+// X. Variant 0 grows dry grass + a gold alpine speck in the gaps; variant 1 swaps in a
+// pale chip, an orange lichen dot and a violet speck. Base at y=0, very low.
 
 pub fn build_scree_mesh(variant: u32) -> Mesh {
     let mut parts = vec![
-        block_at(0.14, 0.07, 0.11, y(0.06), 0.12, lin(PEBBLE_GREY)),
-        facet_at(0.09, Vec3::new(0.18, 0.05, 0.06), 0.6, lin(PEBBLE_WARM)),
-        facet_at(0.08, Vec3::new(-0.15, 0.045, 0.12), 0.6, lin_scaled(PEBBLE_GREY, 0.9)),
-        facet_at(0.07, Vec3::new(0.05, 0.04, -0.17), 0.6, lin(PEBBLE_WARM)),
+        // Anchor cobble, grounded (vertical extent ≈ 0.086 at this tilt).
+        block_at(0.15, 0.085, 0.12, y(0.088), 0.1, lin(PEBBLE_GREY)),
+        facet_at(0.07, Vec3::new(0.02, 0.15, 0.0), 0.4, lin(STONE_PALE)),
+        lichen_at(0.05, Vec3::new(0.12, 0.08, 0.05), LICHEN_SAGE),
+        // The drift, thinning toward +X.
+        facet_at(0.09, Vec3::new(0.22, 0.055, 0.09), 0.6, lin(PEBBLE_WARM)),
+        facet_at(0.075, Vec3::new(-0.19, 0.046, 0.11), 0.6, lin_scaled(PEBBLE_GREY, 0.9)),
+        facet_at(0.07, Vec3::new(0.34, 0.043, -0.04), 0.6, lin(STONE_COOL)),
+        facet_at(0.06, Vec3::new(-0.31, 0.037, -0.09), 0.6, lin_scaled(PEBBLE_WARM, 1.05)),
+        facet_at(0.055, Vec3::new(0.11, 0.034, -0.16), 0.6, lin(PEBBLE_GREY)),
+        facet_at(0.05, Vec3::new(-0.07, 0.031, 0.18), 0.6, lin(STONE_PALE)),
+        facet_at(0.045, Vec3::new(0.45, 0.028, 0.03), 0.6, lin_scaled(PEBBLE_GREY, 0.94)),
     ];
     if variant % 2 == 0 {
-        parts.push(facet_at(0.06, Vec3::new(-0.10, 0.035, -0.14), 0.6, lin(PEBBLE_GREY)));
-        parts.push(facet_at(0.055, Vec3::new(0.16, 0.03, -0.05), 0.6, lin_scaled(PEBBLE_WARM, 1.05)));
+        // Dry grass + a gold alpine speck poking between the stones.
+        let (g1, _) = blade(0.013, 0.18, 0.7, 0.30, Vec3::new(-0.13, 0.02, -0.05), lin(DRYTUFT_BASE));
+        let (g2, _) = blade(0.012, 0.15, 3.6, 0.35, Vec3::new(-0.11, 0.02, -0.03), lin(DRYTUFT_TIP));
+        let (stem, tipp) = blade(0.008, 0.09, 1.8, 0.25, Vec3::new(0.25, 0.01, 0.14), lin(STEM_GREEN));
+        parts.push(g1);
+        parts.push(g2);
+        parts.push(stem);
+        parts.push(facet_at(0.018, tipp, 0.75, lin(FLOWER_GOLD)));
+    } else {
+        // A pale chip + an orange lichen dot + a violet speck.
+        parts.push(facet_at(0.05, Vec3::new(0.20, 0.032, -0.13), 0.6, lin_scaled(STONE_PALE, 0.96)));
+        parts.push(lichen_at(0.035, Vec3::new(0.23, 0.085, 0.10), LICHEN_ORANGE));
+        let (stem, tipp) = blade(0.008, 0.10, 4.6, 0.30, Vec3::new(-0.24, 0.01, 0.12), lin(STEM_GREEN));
+        parts.push(stem);
+        parts.push(facet_at(0.018, tipp, 0.75, lin(FLOWER_VIOLET)));
     }
     flat_shaded(merged(parts))
 }
 
 // ── Rocky ground litter (cover) ──────────────────────────────────────────────────
-// The little colour accents on the stony floor. `variant`: 0 = a small stone crusted
-// with rusty-orange + pale-green lichen, 1 = a tiny crystal sprinkle (a grey nub with a
-// couple of small amethyst/teal shards). Very low (≤0.12u), base at y=0.
+// The little colour accents on the stony floor. `variant`: 0 = a stone crusted with
+// rusty-orange + green/sage lichen and a pale lit fleck, 1 = a tiny crystal sprinkle
+// (small amethyst/teal shards on a dark nub), 2 = an alpine wildflower tuft — three thin
+// stems with violet/white/gold speck heads between two mini pebbles. ≤0.12u, base y=0.
 fn build_rocky_litter_mesh(variant: u32) -> Mesh {
-    match variant % 2 {
-        // Lichen-crusted stone — a grey facet nub with flat lichen splotches on top.
+    match variant % 3 {
+        // Lichen-crusted stone — grey facet nub, lit crown fleck, three lichen splotches.
         0 => flat_shaded(merged(vec![
             facet_at(0.08, y(0.05), 0.6, lin(STONE_BODY)),
             facet_at(0.05, Vec3::new(0.06, 0.04, 0.02), 0.6, lin_scaled(STONE_DARK, 1.05)),
+            facet_at(0.035, Vec3::new(-0.02, 0.092, -0.01), 0.35, lin(STONE_PALE)),
             facet_at(0.045, Vec3::new(0.0, 0.085, 0.0), 0.22, lin(LICHEN_ORANGE)),
             facet_at(0.035, Vec3::new(0.05, 0.072, 0.03), 0.22, lin(LICHEN_GREEN)),
-            facet_at(0.028, Vec3::new(-0.04, 0.066, -0.03), 0.22, lin(LICHEN_ORANGE)),
+            facet_at(0.028, Vec3::new(-0.04, 0.066, -0.03), 0.22, lin(LICHEN_SAGE)),
         ])),
-        // Mini crystal sprinkle — small amethyst + teal shards on a dark stone nub.
-        _ => {
+        // Mini crystal sprinkle — amethyst + teal shards on a dark stone nub.
+        1 => {
             let mut parts = vec![facet_at(0.06, y(0.04), 0.6, lin(STONE_DARK))];
             parts.push(crystal_shard(0.025, 0.10, 0.0, 0.0, y(0.06), lin(CRYSTAL_AMETHYST), lin(CRYSTAL_TIP)));
             parts.push(crystal_shard(0.02, 0.08, 0.4, 2.0, Vec3::new(0.04, 0.05, 0.02), lin(CRYSTAL_TEAL), lin(CRYSTAL_TIP)));
+            parts.push(crystal_shard(0.016, 0.06, -0.45, 4.1, Vec3::new(-0.035, 0.045, -0.02), lin(CRYSTAL_AMETHYST_DK), lin(CRYSTAL_TIP)));
+            flat_shaded(merged(parts))
+        }
+        // Alpine wildflower tuft — bright pinprick heads on thin leaning stems.
+        _ => {
+            let mut parts = vec![
+                facet_at(0.035, y(0.022), 0.6, lin(PEBBLE_GREY)),
+                facet_at(0.028, Vec3::new(0.05, 0.018, 0.02), 0.6, lin(PEBBLE_WARM)),
+            ];
+            let flowers = [
+                (0.4_f32, 0.25_f32, 0.095_f32, FLOWER_VIOLET),
+                (2.5, 0.35, 0.080, FLOWER_WHITE),
+                (4.6, 0.30, 0.070, FLOWER_GOLD),
+            ];
+            for &(yaw, tilt, h, c) in &flowers {
+                let foot = Vec3::new(yaw.cos() * 0.02, 0.01, yaw.sin() * 0.02);
+                let (stem, tipp) = blade(0.007, h, yaw, tilt, foot, lin(STEM_GREEN));
+                parts.push(stem);
+                parts.push(facet_at(0.018, tipp, 0.75, lin(c)));
+            }
             flat_shaded(merged(parts))
         }
     }
@@ -374,37 +732,40 @@ fn build_rocky_litter_mesh(variant: u32) -> Mesh {
 
 // ── Ground cover meshes ──────────────────────────────────────────────────────────
 
-/// A single tiny ground pebble (a small flat faceted stone), base at y=0.
+/// A single tiny ground pebble pair with the light baked in — grey block + warm chip,
+/// a pale lit fleck on the crown and an orange lichen dot on the shaded side. Base y=0.
 fn build_cover_pebble_mesh() -> Mesh {
     flat_shaded(merged(vec![
-        block_at(0.08, 0.05, 0.07, y(0.045), 0.1, lin(PEBBLE_GREY)),
-        facet_at(0.045, Vec3::new(0.07, 0.03, 0.02), 0.6, lin(PEBBLE_WARM)),
+        block_at(0.085, 0.052, 0.07, y(0.054), 0.1, lin(PEBBLE_GREY)),
+        facet_at(0.05, Vec3::new(0.075, 0.032, 0.02), 0.6, lin(PEBBLE_WARM)),
+        facet_at(0.035, Vec3::new(0.01, 0.09, 0.0), 0.4, lin(STONE_PALE)),
+        facet_at(0.02, Vec3::new(-0.055, 0.045, 0.025), 0.25, lin(LICHEN_ORANGE)),
     ]))
 }
 
-/// A small dry-grass tuft — a fan of bleached cone blades, base at y=0, ~0.2u tall.
+/// A dry-grass tuft — six lean res-4 blades fanned around the root in alternating
+/// base/bleached tones, plus one taller wind-bent blade carrying a bright seed head.
+/// Base at y=0, ~0.24u tall, ~80 tris (the old default-res cones cost 64 tris EACH).
 fn build_cover_drytuft_mesh() -> Mesh {
     let specs = [
-        (0.0_f32, 0.00_f32, 0.20_f32, DRYTUFT_BASE),
-        (0.6, 0.20, 0.16, DRYTUFT_TIP),
-        (-0.5, -0.18, 0.15, DRYTUFT_TIP),
-        (1.9, 0.14, 0.13, DRYTUFT_BASE),
+        (0.0_f32, 0.18_f32, 0.21_f32, DRYTUFT_BASE),
+        (1.05, -0.24, 0.16, DRYTUFT_TIP),
+        (2.10, 0.28, 0.14, DRYTUFT_BASE),
+        (3.20, -0.20, 0.17, DRYTUFT_TIP),
+        (4.20, 0.26, 0.13, DRYTUFT_BASE),
+        (5.20, -0.30, 0.15, DRYTUFT_TIP),
     ];
-    let parts = specs
-        .iter()
-        .map(|&(yaw, tilt, h, c)| {
-            let mut m = Cone { radius: 0.016, height: h }
-                .mesh()
-                .build()
-                .translated_by(y(h / 2.0))
-                .rotated_by(Quat::from_rotation_z(tilt))
-                .rotated_by(Quat::from_rotation_y(yaw));
-            m.duplicate_vertices();
-            m.compute_flat_normals();
-            tinted(m, lin(c))
-        })
-        .collect();
-    merged(parts)
+    let mut parts = Vec::new();
+    for &(yaw, tilt, h, c) in &specs {
+        let (m, _) = blade(0.015, h, yaw, tilt, y(0.005), lin(c));
+        parts.push(m);
+    }
+    // The seed-head blade, bowing with the wind, its tip catching the light. (Foot a
+    // touch higher: at tilt 0.5 the base rim swings ~0.0065 below the root point.)
+    let (m, tipp) = blade(0.013, 0.24, 2.7, 0.5, y(0.008), lin(DRYTUFT_BASE));
+    parts.push(m);
+    parts.push(facet_at(0.016, tipp, 0.8, lin_scaled(DRYTUFT_TIP, 1.15)));
+    flat_shaded(merged(parts))
 }
 
 // ── Config ───────────────────────────────────────────────────────────────────────
@@ -439,7 +800,7 @@ pub fn config() -> BiomeConfig {
         sun_pos: Vec3::new(18.0, 38.0, 12.0),
 
         seed: 4002,
-        tree_min_dist: 3.2, // hoodoos are tall — keep them well spaced
+        tree_min_dist: 3.2, // hoodoos/pines are tall — keep them well spaced
         classes: vec![
             // Dry shrub — the FIRST non-tree class (the tree-too-close fallback). 2 variants.
             PropClass {
@@ -452,30 +813,36 @@ pub fn config() -> BiomeConfig {
                 tree: false,
                 block_radius: 0.0,
             },
-            // Boulders — the DOMINANT class. 3 variants, big scale range.
+            // Crags — the DOMINANT class. 4 variants (slab crag / split crag / cobble
+            // spill / rare cairn), big scale range.
             PropClass {
                 variants: vec![
                     (build_boulder_mesh(0), 1.0),
                     (build_boulder_mesh(1), 0.85),
-                    (build_boulder_mesh(2), 1.1),
+                    (build_boulder_mesh(2), 1.05),
+                    (build_boulder_mesh(3), 0.3), // cairns stay a rare waymarker treat
                 ],
                 chance: 0.085,
                 scale: (0.7, 2.2),
                 tree: false,
-                block_radius: 0.3, // dominant boulders — big ones block, scree-sized walk-through
+                block_radius: 0.3, // dominant crags — big ones block, scree-sized walk-through
             },
-            // Hoodoo spires — the "tree" class (spacing-checked, no sway harm). 2 variants.
+            // The "tree" class (spacing-checked, no sway harm): hoodoos + wind-bent
+            // mountain pines (mirrored pair) + a bleached snag. 5 variants.
             PropClass {
                 variants: vec![
                     (build_hoodoo_mesh(0), 1.0),
-                    (build_hoodoo_mesh(1), 0.8),
+                    (build_hoodoo_mesh(1), 0.75),
+                    (build_windpine_mesh(0), 0.9),
+                    (build_windpine_mesh(1), 0.9),
+                    (build_snag_mesh(), 0.45),
                 ],
-                chance: 0.022,
+                chance: 0.024,
                 scale: (0.9, 1.8),
                 tree: true,
                 block_radius: 0.0,
             },
-            // Scree pebble clusters. 2 variants.
+            // Scree spills. 2 variants (grass+gold speck / lichen+violet speck).
             PropClass {
                 variants: vec![
                     (build_scree_mesh(0), 1.0),
@@ -513,10 +880,10 @@ pub fn config() -> BiomeConfig {
                 tree: false,
                 block_radius: 0.0,
             },
-            // Rocky litter — lichen-crusted stones + tiny crystal sprinkles (colour).
+            // Rocky litter — lichen stones, crystal sprinkles + alpine wildflower tufts.
             PropClass {
-                variants: (0..2).map(|v| (build_rocky_litter_mesh(v), 1.0)).collect(),
-                chance: 0.10,
+                variants: (0..3).map(|v| (build_rocky_litter_mesh(v), 1.0)).collect(),
+                chance: 0.11,
                 scale: (0.7, 1.3),
                 tree: false,
                 block_radius: 0.0,
@@ -547,7 +914,8 @@ pub fn config() -> BiomeConfig {
 // ── Landmark: a dramatic ROCK ARCH + a flat-topped MESA + a balanced hoodoo ───────
 
 /// Build one stacked-drum banded column rooted at y=0, returned as a finished mesh.
-/// Used for the arch pillars (so the lintel can bridge two of them).
+/// Used for the arch pillars (so the lintel can bridge two of them). Hard pale bands
+/// now jut out as ledge rims partway up, and lichen crusts the foot.
 fn arch_pillar(height: f32, r0: f32) -> Mesh {
     // Drums getting slightly narrower toward the top, alternating bands.
     let drums = 6;
@@ -559,7 +927,14 @@ fn arch_pillar(height: f32, r0: f32) -> Mesh {
         let r = r0 * (1.0 - t * 0.28);
         let c = bands[i % bands.len()];
         parts.push(cyl_up(r, h * 1.04, h * (i as f32 + 0.5), 10, lin(c)));
+        if i == 2 || i == 4 {
+            // Wind-resistant band → a pale protruding ledge rim at the joint.
+            parts.push(facet_at(r * 1.14, y(h * (i as f32 + 1.0)), 0.2, lin(STONE_PALE)));
+        }
     }
+    // Lichen crusting the sheltered foot.
+    parts.push(lichen_at(0.16, Vec3::new(r0 * 0.8, 0.5, 0.2), LICHEN_ORANGE));
+    parts.push(lichen_at(0.13, Vec3::new(-r0 * 0.75, 0.9, -0.15), LICHEN_SAGE));
     merged(parts)
 }
 
@@ -592,7 +967,8 @@ pub fn landmarks(
         ));
     }
     // Lintel — a long thick faceted block spanning the tops, sagging slightly to read as
-    // a natural arch span (two stretched blocks meeting at a high centre).
+    // a natural arch span (two stretched blocks meeting at a high centre), with dark
+    // eroded chunks hanging under the span and rubble fallen onto the ground beneath it.
     let lintel = flat_shaded(merged(vec![
         // Left half rising to centre.
         block_at(span * 0.34, 0.55, pillar_r * 0.95, Vec3::new(-span * 0.28, pillar_h + 0.2, 0.0), -0.10, lin(HOODOO_RUST)),
@@ -602,6 +978,13 @@ pub fn landmarks(
         block_at(span * 0.16, 0.5, pillar_r * 0.92, Vec3::new(0.0, pillar_h + 0.5, 0.0), 0.0, lin(HOODOO_PALE)),
         // Warm underside band so the span reads layered.
         block_at(span * 0.5, 0.22, pillar_r * 0.8, Vec3::new(0.0, pillar_h - 0.05, 0.0), 0.0, lin(HOODOO_BASE)),
+        // Dark eroded chunks clinging under the span (baked shadow weight).
+        facet_at(0.5, Vec3::new(-0.7, pillar_h - 0.45, 0.1), 0.8, lin_scaled(STONE_DARK, 0.9)),
+        facet_at(0.4, Vec3::new(0.9, pillar_h - 0.4, -0.1), 0.8, lin_scaled(HOODOO_RUST, 0.85)),
+        // Rubble fallen from the span onto the ground under the arch.
+        slab_at(0.55, 0.28, 0.45, Vec3::new(-0.4, 0.30, 0.6), 0.7, 0.18, lin(STONE_COOL)),
+        facet_at(0.35, Vec3::new(0.7, 0.24, -0.5), 0.65, lin_scaled(STONE_BODY, 0.95)),
+        facet_at(0.22, Vec3::new(0.1, 0.14, 0.9), 0.6, lin(PEBBLE_WARM)),
     ]));
     commands.spawn((
         Mesh3d(meshes.add(lintel)),
@@ -611,7 +994,9 @@ pub fn landmarks(
     ));
 
     // ── MESA — a wide flat-topped butte: a broad banded drum stack with a pale caprock
-    // and a talus skirt of fallen boulders around its foot. To the right, on land. ──
+    // (its overhang shadow baked in as a dark band beneath), protruding ledge slabs at
+    // the rim, lichen crusts on the cap, and a talus skirt of fallen boulders around its
+    // foot. To the right, on land. ──
     let mesa_cx = 11.0;
     let mesa_cz = -14.0;
     let mesa = {
@@ -622,16 +1007,31 @@ pub fn landmarks(
             cyl_up(2.7, 1.4, 1.9, 14, lin(STONE_BODY)),
             cyl_up(2.45, 1.1, 3.15, 14, lin(HOODOO_BASE)),
             cyl_up(2.3, 0.9, 4.15, 14, lin_scaled(STONE_BODY, 1.04)),
+            // Dark band tucked under the caprock overhang (baked contact shadow).
+            cyl_up(2.42, 0.12, 4.56, 14, lin_scaled(STONE_DARK, 0.85)),
             // Hard pale caprock (a wider thin slab on top — the erosion-resistant cap).
             cyl_up(2.5, 0.45, 4.83, 16, lin(STONE_PALE)),
         ];
-        // Talus boulders strewn around the base.
+        // Protruding ledge slabs around the cap rim.
+        for i in 0..4 {
+            let a = i as f32 * 1.7 + 0.5;
+            parts.push(slab_at(0.55, 0.16, 0.4, Vec3::new(a.cos() * 2.4, 4.66, a.sin() * 2.4), a, 0.08, lin_scaled(STONE_PALE, 0.97)));
+        }
+        // Lichen crusts spreading over the sunny cap.
+        parts.push(lichen_at(0.22, Vec3::new(1.4, 5.06, 1.6), LICHEN_ORANGE));
+        parts.push(lichen_at(0.18, Vec3::new(-1.8, 5.05, 0.9), LICHEN_GREEN));
+        // Talus boulders strewn around the base, mixed tones.
         for i in 0..7 {
             let a = (i as f32 / 7.0) * std::f32::consts::TAU + 0.3;
             let rr = 3.1 + (i % 3) as f32 * 0.35;
             let off = Vec3::new(a.cos() * rr, 0.0, a.sin() * rr);
             let s = 0.6 + (i % 3) as f32 * 0.2;
-            parts.push(block_at(0.6 * s, 0.34 * s, 0.5 * s, off + y(0.3 * s), 0.12, lin(STONE_COOL)));
+            let c = match i % 3 {
+                0 => lin(STONE_COOL),
+                1 => lin_scaled(STONE_DARK, 1.05),
+                _ => lin(PEBBLE_WARM),
+            };
+            parts.push(block_at(0.6 * s, 0.34 * s, 0.5 * s, off + y(0.35 * s), 0.12, c));
         }
         flat_shaded(merged(parts))
     };
@@ -639,6 +1039,26 @@ pub fn landmarks(
         Mesh3d(meshes.add(mesa)),
         MeshMaterial3d(mat.clone()),
         Transform::from_xyz(mesa_cx, 0.0, mesa_cz).with_rotation(Quat::from_rotation_y(0.4)),
+        BiomeEntity,
+    ));
+    // A lone wind-bent pine on the mesa cap + another rooted in the talus below — the
+    // classic "tree on the butte" silhouette. (Cap top sits at y ≈ 5.06.)
+    let pine0 = meshes.add(build_windpine_mesh(0));
+    let pine1 = meshes.add(build_windpine_mesh(1));
+    commands.spawn((
+        Mesh3d(pine0),
+        MeshMaterial3d(mat.clone()),
+        Transform::from_xyz(mesa_cx + 0.6, 5.06, mesa_cz - 0.5)
+            .with_scale(Vec3::splat(1.25))
+            .with_rotation(Quat::from_rotation_y(2.0)),
+        BiomeEntity,
+    ));
+    commands.spawn((
+        Mesh3d(pine1),
+        MeshMaterial3d(mat.clone()),
+        Transform::from_xyz(mesa_cx - 3.9, 0.0, mesa_cz + 1.2)
+            .with_scale(Vec3::splat(1.5))
+            .with_rotation(Quat::from_rotation_y(0.9)),
         BiomeEntity,
     ));
 
@@ -654,7 +1074,18 @@ pub fn landmarks(
         BiomeEntity,
     ));
 
-    // A couple of big loose boulders flanking the arch foot to ground the scene.
+    // A big waymarker CAIRN on the route between the set-pieces.
+    let cairn = meshes.add(build_boulder_mesh(3));
+    commands.spawn((
+        Mesh3d(cairn),
+        MeshMaterial3d(mat.clone()),
+        Transform::from_xyz(4.0, 0.0, -10.5)
+            .with_scale(Vec3::splat(1.9))
+            .with_rotation(Quat::from_rotation_y(0.7)),
+        BiomeEntity,
+    ));
+
+    // A couple of big loose crags flanking the arch foot to ground the scene.
     let big_boulder = meshes.add(build_boulder_mesh(0));
     for (bx, bz, s, ry) in [(-13.5_f32, -10.5_f32, 1.8_f32, 0.6_f32), (-6.5, -10.0, 2.1, 2.3)] {
         commands.spawn((

--- a/src/biome_snow.rs
+++ b/src/biome_snow.rs
@@ -1,16 +1,24 @@
 //! Snow biome (key 2) — a crisp winter scene mirroring the Forest module's structure.
 //!
 //! All snow props are built **locally** in this file (self-contained — touches no other
-//! module): snow-laden conifer pines (brown stub trunk + stacked dark-green cone tiers,
-//! each boughed with a smaller WHITE snow cone), bare snowy birch (white trunk, a few
-//! bare twigs, a dab of snow), low snow-dusted shrubs / mounds (the first non-tree
-//! fallback class), and frost boulders (blue-grey rock with a white snow cap). Ground
-//! cover is tiny snow tufts + ice glints. Particle: drifting snow. Backdrop: tall
-//! white-capped peaks over a dark conifer treeline, land on one side, no ocean.
+//! module). Conifer pines stack off-axis green cone tiers (a zig-zag silhouette, three
+//! variants incl. a tall slim spire) and drape snow PER TIER — a short skirt cone plus
+//! squashed blobs piled on the rim, sunlit-white on top, ice-blue in shade. Bare birches
+//! get a kinked two-segment trunk and a two-storey twig fan. The mound class is three
+//! variants: a wind-sculpted drift, a frost-tipped frozen shrub, and a snow-capped stump
+//! + fallen log. Boulders are angular tilted rock chunks over dark exposed footings,
+//! draped with snow and hung with icicles under their overhangs. Plus the rare snowman
+//! centrepiece. Ground cover: snow tufts with dry winter grass poking through, angular
+//! ice glints, and litter (holly sprig / toppled pinecone / ice shards / frosted twig).
+//! Every prop gets `bake_facet_shading`: down-facing facets darken and cool toward blue
+//! (shadowed snow reads blue, not grey), up-facing facets brighten — baked light/shadow
+//! contrast that realtime fill alone can't produce (see trees.rs for the rationale).
+//! Particle: drifting snow. Backdrop: tall white-capped peaks over a dark conifer
+//! treeline, land on one side, no ocean.
 //!
 //! Landmark: a frozen pond — a low-roughness pale-blue ice disc sitting just above y=0
-//! (reflects the sky via IBL) ringed by a couple of snow-laden dead trees + a small
-//! rock cairn.
+//! (reflects the sky via IBL) with a frosted rim, ringed by snow-laden dead trees,
+//! shoreline ice-shard clumps, a drift tongue, and an angular snow-capped stone cairn.
 //!
 //! CONTRACT (mirrors trees.rs / props.rs / decor.rs): every prop is ONE merged,
 //! vertex-coloured `Mesh` with its base at y=0, tinted into `ATTRIBUTE_COLOR` (the
@@ -67,6 +75,11 @@ const HOLLY_LEAF: u32 = 0x2f6b3a; // dark holly-leaf green
 const HOLLY_BERRY: u32 = 0xcc2a2a; // bright red holly berry
 const PINECONE_BROWN: u32 = 0x6e5038; // brown pinecone scales
 
+// Stumps / logs / winter grass — the warm accents poking through the snowfield.
+const STUMP_WOOD: u32 = 0x584234; // weathered stump / log bark
+const STUMP_CUT: u32 = 0xa8896a; // pale sawn cut-face ring
+const GRASS_DRY: u32 = 0xb3a274; // dry straw-yellow winter grass
+
 // Frozen-pond ice (FrozenSpire family): pale crystal blue.
 const ICE_PALE: u32 = 0xbfe0f4; // pale ice surface tint
 const ICE_RIM: u32 = 0x9cc3e0; // darker frosted rim
@@ -109,6 +122,43 @@ fn flat_shaded(mut m: Mesh) -> Mesh {
     m
 }
 
+/// Bake painterly facet shading into the vertex colours (call AFTER `flat_shaded`, so the
+/// per-face normals exist and every facet shades uniformly): down-facing facets darken AND
+/// cool toward blue (shadowed snow reads blue, not grey), up-facing facets brighten toward
+/// sunlit white, plus a mild base→crown lift. Gentler factors than the trees.rs bake and
+/// clamped at 1.0 so the near-white snow tones never blow out / bloom.
+fn bake_facet_shading(mut m: Mesh) -> Mesh {
+    use bevy::mesh::VertexAttributeValues as V;
+    let Some(V::Float32x3(pos)) = m.attribute(Mesh::ATTRIBUTE_POSITION) else { return m };
+    let (mut y_min, mut y_max) = (f32::MAX, f32::MIN);
+    for p in pos {
+        y_min = y_min.min(p[1]);
+        y_max = y_max.max(p[1]);
+    }
+    let span = (y_max - y_min).max(1e-4);
+    let ys: Vec<f32> = pos.iter().map(|p| p[1]).collect();
+    let Some(V::Float32x3(ns)) = m.attribute(Mesh::ATTRIBUTE_NORMAL) else { return m };
+    let nys: Vec<f32> = ns.iter().map(|n| n[1]).collect();
+    if let Some(V::Float32x4(cols)) = m.attribute_mut(Mesh::ATTRIBUTE_COLOR) {
+        for (c, (ny, y)) in cols.iter_mut().zip(nys.iter().zip(&ys)) {
+            let up = ny * 0.5 + 0.5; // 0 facing down … 1 facing up
+            let h = (y - y_min) / span; // 0 base … 1 crown
+            let f = (0.76 + 0.36 * up) * (0.90 + 0.16 * h);
+            // The deeper the shadow, the bluer it gets (snow bounce light is sky-blue).
+            let cool = (1.0 - f).max(0.0) * 0.35;
+            c[0] = (c[0] * f).min(1.0);
+            c[1] = (c[1] * (f + cool * 0.3)).min(1.0);
+            c[2] = (c[2] * (f + cool)).min(1.0);
+        }
+    }
+    m
+}
+
+/// The standard finish for every snow prop: flat-shade, then bake the facet shading.
+fn shaded(m: Mesh) -> Mesh {
+    bake_facet_shading(flat_shaded(m))
+}
+
 fn y(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)
 }
@@ -118,15 +168,15 @@ fn cyl_up(r: f32, h: f32, cy: f32, res: u32, c: u32) -> Mesh {
     tinted(Cylinder::new(r, h).mesh().resolution(res).build().translated_by(y(cy)), lin(c))
 }
 
-/// A cone tier sitting with its base at `base_y` (cones are centre-anchored, so lift by
-/// `h/2 + base_y`). `res` = radial sides.
-fn cone_at(r: f32, h: f32, base_y: f32, res: u32, c: u32) -> Mesh {
+/// A cone with its base-circle centre at `at` (cones are centre-anchored, so lift by
+/// `h/2`). `res` = radial sides.
+fn cone_at(r: f32, h: f32, at: Vec3, res: u32, c: u32) -> Mesh {
     tinted(
         Cone { radius: r, height: h }
             .mesh()
             .resolution(res)
             .build()
-            .translated_by(y(h * 0.5 + base_y)),
+            .translated_by(at + y(h * 0.5)),
         lin(c),
     )
 }
@@ -144,158 +194,349 @@ fn ball_at(r: f32, off: Vec3, squash: f32, c: u32) -> Mesh {
     )
 }
 
+/// An angular rock chunk: an icosphere squashed non-uniformly THEN tilted, so its facets
+/// skew into a fractured-block read instead of a pebble. `detail` 0 (20 tris) or 1 (80).
+fn chunk_at(r: f32, off: Vec3, scale: Vec3, yaw: f32, pitch: f32, detail: u32, c: u32) -> Mesh {
+    tinted(
+        Sphere::new(r)
+            .mesh()
+            .ico(detail)
+            .expect("ico detail in range")
+            .scaled_by(scale)
+            .rotated_by(Quat::from_rotation_y(yaw) * Quat::from_rotation_x(pitch))
+            .translated_by(off),
+        lin(c),
+    )
+}
+
+/// An icicle — a slim pale-blue cone hanging point-DOWN, its root (base disc) at `root`,
+/// tip reaching `root.y - len`. Callers must hang them from ledges with `root.y > len`
+/// so nothing pokes below y=0.
+fn icicle(r: f32, len: f32, root: Vec3) -> Mesh {
+    tinted(
+        Cone { radius: r, height: len }
+            .mesh()
+            .resolution(4)
+            .build()
+            .rotated_by(Quat::from_rotation_x(std::f32::consts::PI)) // flip apex down
+            .translated_by(root - y(len * 0.5)),
+        lin(ICE_PALE),
+    )
+}
+
 // ── Snow-laden conifer pine ──────────────────────────────────────────────────────
 //
-// A brown stub trunk + 3 stacked dark→light green cone tiers (wide low, narrow high),
-// each capped with a smaller WHITE snow cone sitting on its boughs, plus a snow tip on
-// the crown. ~1.4u tall before TREE_SCALE. Two snow-load variants (heavier vs lighter).
-fn build_pine_mesh(snowy: bool) -> Mesh {
+// A brown trunk (with a root flare) + a stack of dark→light green cone tiers, every tier
+// nudged off-axis so the silhouette zig-zags instead of reading as a perfect kebab. Snow
+// is DRAPED per tier: a short wide skirt cone over the rim plus 3 squashed blobs piled on
+// the boughs — sunlit-white / body / ice-blue shaded lobes. Crown carries a green spike
+// + a white snow tip; a drift banks against the trunk. `bake_facet_shading` then darkens
+// the bough undersides. Variants: 0 = broad + heavy load, 1 = standard + light dusting,
+// 2 = tall slim 5-tier spire. ~1.7u tall before TREE_SCALE.
+fn build_pine_mesh(variant: u32) -> Mesh {
+    // (tier count, base tier radius, base tier height, heavy snow load?)
+    let (tiers_n, r0, h0, heavy) = match variant % 3 {
+        0 => (4, 0.58, 0.50, true),
+        1 => (4, 0.53, 0.48, false),
+        _ => (5, 0.43, 0.42, true),
+    };
+
     let mut parts = vec![
-        // Stub trunk poking out of the snow.
-        cyl_up(0.07, 0.30, 0.15, 6, PINE_TRUNK),
+        // Trunk poking out of the snow + a wider root flare at the base.
+        cyl_up(0.075, 0.36, 0.18, 6, PINE_TRUNK),
+        cyl_up(0.105, 0.10, 0.05, 6, PINE_TRUNK),
     ];
 
-    // Three green cone tiers + a white snow cone capping each bough ring. Tiers shrink
-    // and rise; the snow cone is shorter & wider so it reads as snow piled on the boughs.
-    // (base_y, tier_radius, tier_height, green-tone)
-    let tiers = [
-        (0.22, 0.55, 0.62, PINE_DARK),
-        (0.58, 0.44, 0.56, PINE_MID),
-        (0.94, 0.32, 0.48, PINE_LIGHT),
-    ];
-    for (base_y, r, h, green) in tiers {
-        // The dark-green bough tier.
-        parts.push(cone_at(r, h, base_y, 7, green));
-        // A WHITE snow cone resting on the boughs: a hair wider at the rim, much shorter,
-        // sitting at the same base so its skirt drapes over the green tier's shoulders.
-        let snow_c = if snowy { SNOW_CAP_HI } else { SNOW_CAP };
-        parts.push(cone_at(r * 1.04, h * 0.42, base_y + 0.015, 7, snow_c));
-        // A faint blue snow-shade lobe under the snow skirt for depth (one side).
-        parts.push(ball_at(r * 0.34, Vec3::new(r * 0.5, base_y + h * 0.12, 0.0), 0.45, SNOW_SHADE));
+    let tau = std::f32::consts::TAU;
+    let mut base_y = 0.22;
+    let mut top = base_y;
+    for k in 0..tiers_n {
+        let t = k as f32 / (tiers_n - 1) as f32;
+        let r = r0 * (1.0 - 0.55 * t);
+        let h = h0 * (1.0 - 0.16 * t);
+        // Off-axis nudge, strongest low, fading toward the crown → a zig-zag silhouette.
+        let wob = 0.055 * (1.0 - t * 0.7);
+        let at = Vec3::new(
+            (k as f32 * 2.3 + variant as f32 * 1.7).sin() * wob,
+            base_y,
+            (k as f32 * 1.6 + variant as f32).cos() * wob,
+        );
+        // Green bough tier: shadowed dark low boughs → lit upper tiers.
+        let green = if t < 0.34 {
+            PINE_DARK
+        } else if t < 0.75 {
+            PINE_MID
+        } else {
+            PINE_LIGHT
+        };
+        parts.push(cone_at(r, h, at, 7, green));
+        // Snow skirt draped over the tier's shoulders: a hair wider at the rim, much
+        // shorter, so its hem drapes over the green tier's boughs.
+        let skirt_h = if heavy { h * 0.40 } else { h * 0.30 };
+        parts.push(cone_at(r * 1.05, skirt_h, at + y(0.015), 7, if heavy { SNOW_CAP } else { SNOW_SHADE }));
+        // Three snow blobs piled around the rim — sunlit / body / ice-blue shaded lobes
+        // walking around the tree per tier so no two tiers load the same side.
+        let blob_r = r * if heavy { 0.34 } else { 0.26 };
+        for (j, tone) in [SNOW_CAP_HI, SNOW_CAP, SNOW_SHADE].into_iter().enumerate() {
+            let a = j as f32 / 3.0 * tau + k as f32 * 0.9 + variant as f32 * 0.5;
+            let p = at + Vec3::new(a.cos() * r * 0.62, h * 0.26, a.sin() * r * 0.62);
+            parts.push(ball_at(blob_r, p, 0.5, tone));
+        }
+        base_y += h * 0.58;
+        top = at.y + h;
     }
 
-    // Snow-capped crown tip (a small white cone on the very top).
-    parts.push(cone_at(0.16, 0.30, 1.30, 7, SNOW_CAP_HI));
-    // A couple of clinging snow dabs on lower boughs for irregularity.
-    parts.push(ball_at(0.12, Vec3::new(-0.30, 0.40, 0.10), 0.5, SNOW_CAP));
-    parts.push(ball_at(0.10, Vec3::new(0.24, 0.74, -0.12), 0.5, SNOW_CAP));
+    // Crown: a green spike + a white snow tip wrapping it + a clinging dab just below.
+    parts.push(cone_at(0.13, 0.26, y(top - 0.10), 7, PINE_LIGHT));
+    parts.push(cone_at(0.10, 0.20, y(top + 0.06), 6, SNOW_CAP_HI));
+    parts.push(ball_at(0.085, Vec3::new(0.06, top - 0.04, -0.04), 0.55, SNOW_CAP));
+    // Drift banked against the trunk base (bright lee side / blue windward side).
+    parts.push(ball_at(0.16, Vec3::new(0.10, 0.05, 0.06), 0.4, SNOW_CAP));
+    parts.push(ball_at(0.13, Vec3::new(-0.13, 0.04, -0.05), 0.4, SNOW_SHADE));
 
-    flat_shaded(merged(parts))
+    shaded(merged(parts))
 }
 
 // ── Bare snowy birch ───────────────────────────────────────────────────────────
 //
-// A pale white trunk + 2 dark bark marks + a few bare grey-brown twigs fanning from the
-// top + a dab of snow caught in the crook. No foliage (winter-bare). ~1.3u tall.
+// A kinked two-segment pale trunk (lower upright + upper segment leaning a touch) + four
+// peeling-bark scar boxes + a two-storey fan of bare twigs from the crook — long mains
+// with forking twiglets — snow dabs caught in the crooks, a frost ledge clinging to the
+// trunk's lee side, and a drift collar at the base. No foliage (winter-bare). ~1.3u tall.
 fn build_birch_mesh() -> Mesh {
+    let kink = 0.10; // upper-trunk lean (radians)
     let mut parts = vec![
-        // Pale trunk (slightly tapered look via a slim cylinder).
-        cyl_up(0.055, 1.05, 0.525, 6, BIRCH_TRUNK),
-        // Two dark bark-mark boxes (peeling-bark stripes).
+        // Lower trunk + the slightly leaning upper segment → a gentle kink, not a pole.
+        cyl_up(0.060, 0.62, 0.31, 6, BIRCH_TRUNK),
         tinted(
-            Cuboid::new(0.006, 0.05, 0.10)
+            Cylinder::new(0.048, 0.55)
                 .mesh()
+                .resolution(6)
                 .build()
-                .translated_by(Vec3::new(0.055, 0.70, 0.0)),
-            lin(BIRCH_MARK),
-        ),
-        tinted(
-            Cuboid::new(0.006, 0.04, 0.08)
-                .mesh()
-                .build()
-                .translated_by(Vec3::new(-0.055, 0.42, 0.03)),
-            lin(BIRCH_MARK),
+                .translated_by(y(0.275))
+                .rotated_by(Quat::from_rotation_z(kink))
+                .translated_by(y(0.58)),
+            lin(BIRCH_TRUNK),
         ),
     ];
 
-    // A fan of bare twigs from the upper trunk: slim cones leaning out, alternating two
-    // lengths. Build upright, lean (Z), yaw around the trunk, then lift to the branch crook.
-    let twigs = [
-        (0.0_f32, 0.5_f32, 0.40_f32),
-        (1.3, 0.7, 0.34),
-        (2.6, 0.45, 0.36),
-        (3.9, 0.8, 0.30),
-        (5.2, 0.55, 0.33),
+    // Peeling-bark scar boxes wrapped at varying heights and alternating sides.
+    let marks = [
+        (0.060_f32, 0.70_f32, 0.0_f32, 0.05_f32, 0.10_f32),
+        (-0.060, 0.42, 0.03, 0.04, 0.08),
+        (0.052, 0.94, -0.02, 0.04, 0.07),
+        (-0.048, 0.20, -0.03, 0.035, 0.09),
     ];
-    for (yaw, tilt, len) in twigs {
+    for (mx, my, mz, mh, md) in marks {
+        parts.push(tinted(
+            Cuboid::new(0.008, mh, md).mesh().build().translated_by(Vec3::new(mx, my, mz)),
+            lin(BIRCH_MARK),
+        ));
+    }
+
+    // Two-storey twig fan from the crook (top of the leaning segment): six slim mains
+    // alternating length/pitch; every third forks a twiglet at its elbow; every other
+    // catches a snow dab where it meets the trunk.
+    let crook = Vec3::new(-0.05, 1.06, 0.0);
+    let twigs = [
+        (0.0_f32, 0.55_f32, 0.42_f32),
+        (1.1, 0.75, 0.34),
+        (2.2, 0.45, 0.38),
+        (3.3, 0.85, 0.30),
+        (4.4, 0.60, 0.35),
+        (5.4, 0.40, 0.28),
+    ];
+    for (i, (yaw, tilt, len)) in twigs.into_iter().enumerate() {
+        let rot = Quat::from_rotation_y(yaw) * Quat::from_rotation_z(tilt);
         let twig = Cone { radius: 0.016, height: len }
             .mesh()
-            .resolution(5)
+            .resolution(4)
             .build()
             .translated_by(y(len * 0.5))
-            .rotated_by(Quat::from_rotation_z(tilt))
-            .rotated_by(Quat::from_rotation_y(yaw))
-            .translated_by(y(0.92));
+            .rotated_by(rot)
+            .translated_by(crook);
         parts.push(tinted(twig, lin(BIRCH_TWIG)));
+        if i % 3 == 0 {
+            // A forking twiglet splayed off this main's elbow.
+            let elbow = crook + rot * y(len * 0.6);
+            let frot = rot * Quat::from_rotation_z(0.55);
+            let f = Cone { radius: 0.010, height: len * 0.45 }
+                .mesh()
+                .resolution(4)
+                .build()
+                .translated_by(y(len * 0.225))
+                .rotated_by(frot)
+                .translated_by(elbow);
+            parts.push(tinted(f, lin(BIRCH_TWIG)));
+        }
+        if i % 2 == 0 {
+            // Snow dab caught where the twig leaves the trunk.
+            parts.push(ball_at(0.05, crook + rot * y(len * 0.22), 0.55, SNOW_CAP_HI));
+        }
     }
 
-    // Dabs of snow: one on the crook, one near the trunk base.
-    parts.push(ball_at(0.10, y(0.98), 0.45, SNOW_CAP_HI));
-    parts.push(ball_at(0.13, Vec3::new(0.05, 0.06, 0.0), 0.4, SNOW_CAP));
+    // Snow in the main crook, a frost ledge on the trunk's lee side, drift collar at the
+    // base (bright + blue-shaded lobes).
+    parts.push(ball_at(0.09, crook + y(0.02), 0.5, SNOW_CAP_HI));
+    parts.push(ball_at(0.045, Vec3::new(0.058, 0.55, 0.01), 0.4, SNOW_CAP));
+    parts.push(ball_at(0.14, Vec3::new(0.06, 0.05, 0.02), 0.42, SNOW_CAP));
+    parts.push(ball_at(0.10, Vec3::new(-0.10, 0.04, -0.05), 0.42, SNOW_SHADE));
 
-    flat_shaded(merged(parts))
+    shaded(merged(parts))
 }
 
-// ── Snow-dusted shrub / mound (the first non-tree fallback class) ────────────────
+// ── Snow shrub / drift / stump (the first non-tree fallback class) ───────────────
 //
-// A low cluster of white-blue snow blobs — a buried shrub or a wind-packed drift. Base
-// flush at y=0; ~0.4u tall. Three tiers (blue-shade skirt → snow body → bright crown) so
-// it reads 3D, never a flat sphere. Two variants vary the lump count.
+// Three low winter set-dressing variants, all base-flush and ≤ ~0.45u tall:
+//   0 — wind-sculpted drift: a tapering line of snow lumps kicking into a tail, bright
+//       wind-packed crest on top, blue-shadowed windward skirt (reads directional);
+//   1 — frozen shrub: a dark evergreen tuft buried to its shoulders, frost-tipped bare
+//       twigs poking through, snow banked around it;
+//   2 — snow-covered stump + fallen log: sawn cut-face ring, snow capping both.
 fn build_mound_mesh(variant: u32) -> Mesh {
-    let mut parts = vec![
-        // Bluish snow-shade skirt (grounded spread).
-        ball_at(0.30, y(0.13), 0.62, SNOW_SHADE),
-        ball_at(0.22, Vec3::new(0.22, 0.11, 0.06), 0.62, SNOW_SHADE),
-        ball_at(0.20, Vec3::new(-0.20, 0.10, 0.10), 0.62, SNOW_SHADE),
-        // Snow body.
-        ball_at(0.24, y(0.22), 0.66, SNOW_CAP),
-        ball_at(0.17, Vec3::new(0.15, 0.24, -0.13), 0.66, SNOW_CAP),
-        // Bright sunlit crown.
-        ball_at(0.18, y(0.32), 0.7, SNOW_CAP_HI),
-        ball_at(0.12, Vec3::new(-0.10, 0.35, 0.07), 0.7, SNOW_CAP_HI),
-    ];
-    if variant % 2 == 1 {
-        // A second hump beside the first → a longer drift.
-        parts.push(ball_at(0.20, Vec3::new(0.36, 0.14, -0.10), 0.62, SNOW_CAP));
-        parts.push(ball_at(0.14, Vec3::new(0.40, 0.24, -0.12), 0.7, SNOW_CAP_HI));
+    match variant % 3 {
+        // Wind-sculpted drift.
+        0 => shaded(merged(vec![
+            // Head → tail lumps along +X, the tail kicking into -Z.
+            ball_at(0.28, Vec3::new(-0.12, 0.15, 0.0), 0.62, SNOW_CAP),
+            ball_at(0.22, Vec3::new(0.14, 0.12, -0.05), 0.60, SNOW_CAP),
+            ball_at(0.15, Vec3::new(0.36, 0.09, -0.10), 0.58, SNOW_CAP),
+            ball_at(0.09, Vec3::new(0.52, 0.05, -0.14), 0.55, SNOW_CAP),
+            // Bright wind-packed crest.
+            ball_at(0.18, Vec3::new(-0.10, 0.25, 0.0), 0.6, SNOW_CAP_HI),
+            ball_at(0.12, Vec3::new(0.14, 0.19, -0.05), 0.6, SNOW_CAP_HI),
+            // Blue-shadowed windward skirt.
+            ball_at(0.22, Vec3::new(-0.26, 0.09, 0.06), 0.5, SNOW_SHADE),
+            ball_at(0.14, Vec3::new(0.05, 0.07, 0.12), 0.5, SNOW_SHADE),
+        ])),
+        // Frozen shrub with frost tips.
+        1 => {
+            let mut parts = vec![
+                // Snow banked around the buried shrub.
+                ball_at(0.26, y(0.10), 0.52, SNOW_CAP),
+                ball_at(0.18, Vec3::new(0.20, 0.08, 0.10), 0.5, SNOW_SHADE),
+                ball_at(0.16, Vec3::new(-0.18, 0.08, -0.08), 0.5, SNOW_CAP_HI),
+                // Dark evergreen tuft poking through.
+                ball_at(0.19, y(0.22), 0.75, PINE_DARK),
+                ball_at(0.13, Vec3::new(0.10, 0.30, -0.06), 0.75, PINE_MID),
+            ];
+            // Bare twigs leaning out of the tuft, each tipped with a frost crystal.
+            let tau = std::f32::consts::TAU;
+            for i in 0..4 {
+                let a = i as f32 / 4.0 * tau + 0.6;
+                let rot = Quat::from_rotation_y(a) * Quat::from_rotation_z(0.55);
+                let len = 0.20 + (i % 2) as f32 * 0.06;
+                let root = Vec3::new(a.cos() * 0.06, 0.24, a.sin() * 0.06);
+                let twig = Cone { radius: 0.012, height: len }
+                    .mesh()
+                    .resolution(4)
+                    .build()
+                    .translated_by(y(len * 0.5))
+                    .rotated_by(rot)
+                    .translated_by(root);
+                parts.push(tinted(twig, lin(BIRCH_TWIG)));
+                parts.push(ball_at(0.030, root + rot * y(len), 0.8, SNOW_CAP_HI));
+            }
+            // Frost dabs sitting on the evergreen crown.
+            parts.push(ball_at(0.09, y(0.35), 0.5, SNOW_CAP_HI));
+            parts.push(ball_at(0.06, Vec3::new(0.11, 0.36, -0.06), 0.5, SNOW_CAP));
+            shaded(merged(parts))
+        }
+        // Snow-covered stump + fallen log.
+        _ => {
+            let mut parts = vec![
+                // Stump: bark drum + root flare + pale sawn cut-face ring + a snow cap.
+                cyl_up(0.125, 0.24, 0.12, 7, STUMP_WOOD),
+                cyl_up(0.155, 0.06, 0.03, 7, STUMP_WOOD),
+                cyl_up(0.110, 0.035, 0.255, 7, STUMP_CUT),
+                ball_at(0.105, y(0.295), 0.45, SNOW_CAP_HI),
+                // Snow banked against the stump's foot.
+                ball_at(0.13, Vec3::new(0.14, 0.05, 0.08), 0.45, SNOW_CAP),
+            ];
+            // Fallen log alongside (lying cylinder, yawed) with a snow ridge on top.
+            let lyaw = 0.5_f32;
+            let log = Cylinder::new(0.075, 0.52)
+                .mesh()
+                .resolution(7)
+                .build()
+                .rotated_by(Quat::from_rotation_z(FRAC_PI_2)) // lie the axis along X
+                .rotated_by(Quat::from_rotation_y(lyaw))
+                .translated_by(Vec3::new(0.05, 0.075, -0.30));
+            parts.push(tinted(log, lin(STUMP_WOOD)));
+            // Three snow lumps along the log's upper flank (bright in the middle).
+            let along = Vec3::new(lyaw.cos(), 0.0, -lyaw.sin());
+            for i in 0..3 {
+                let t = i as f32 - 1.0;
+                parts.push(ball_at(
+                    0.07 - (t * t) * 0.015,
+                    Vec3::new(0.05, 0.145, -0.30) + along * (t * 0.16),
+                    0.5,
+                    if i == 1 { SNOW_CAP_HI } else { SNOW_CAP },
+                ));
+            }
+            shaded(merged(parts))
+        }
     }
-    flat_shaded(merged(parts))
 }
 
 // ── Frost boulder ────────────────────────────────────────────────────────────────
 //
-// A faceted blue-grey rock (dark base + lit facet) topped with a WHITE snow cap, plus a
-// side cobble. Base flush at y=0. Two variants vary the proportions.
+// Angular fractured stone, not pebbles: non-uniformly squashed + tilted icosphere chunks
+// stacked over a DARK exposed footing (the shadowed stone under the snowline), draped
+// with squashed snow blobs (bright crown / body / ice-blue shade lobes) and hung with
+// icicles under the overhang lips. Base flush at y=0. Three silhouettes:
+//   0 — broad tilted slab with a +X overhang (two icicles) and a side cobble;
+//   1 — tall split tor: two counter-tilted blocks, one long icicle under the upper lip;
+//   2 — low huddle of three cobbles bridged by a snow blanket.
 fn build_boulder_mesh(variant: u32) -> Mesh {
-    match variant % 2 {
+    match variant % 3 {
         0 => {
-            let r = 0.34;
-            flat_shaded(merged(vec![
-                // Body — wide squashed lump, darker base tone.
-                ball_at(r, y(r * 0.74), 0.78, ROCK_DARK),
-                // Lit facet catching the light.
-                ball_at(r * 0.6, Vec3::new(r * 0.12, r * 1.0, -r * 0.1), 0.72, ROCK_BODY),
-                // Side cobble.
-                ball_at(r * 0.5, Vec3::new(-r * 0.85, r * 0.4, r * 0.2), 0.82, ROCK_LIGHT),
-                // White snow cap draped over the crown.
-                ball_at(r * 0.78, y(r * 1.26), 0.5, SNOW_CAP_HI),
-                ball_at(r * 0.42, Vec3::new(r * 0.4, r * 1.05, r * 0.2), 0.5, SNOW_CAP),
-            ]))
+            let mut parts = vec![
+                // Dark buried under-stone (the exposed shadowed footing).
+                chunk_at(0.30, y(0.12), Vec3::new(1.35, 0.55, 1.1), 0.2, 0.0, 0, ROCK_DARK),
+                // Main tilted slab — the tilt opens an overhang lip on the +X side.
+                chunk_at(0.34, y(0.30), Vec3::new(1.25, 0.72, 1.0), 0.45, 0.18, 1, ROCK_BODY),
+                // Lit crown facet + a side cobble huddled against the slab.
+                chunk_at(0.20, Vec3::new(-0.06, 0.46, -0.05), Vec3::new(1.2, 0.6, 1.0), 0.9, -0.1, 0, ROCK_LIGHT),
+                chunk_at(0.15, Vec3::new(-0.34, 0.12, 0.18), Vec3::new(1.1, 0.85, 1.0), 1.4, 0.2, 0, ROCK_BODY),
+                // Snow draped over the crown — bright top + body + ice-blue shade lobes.
+                ball_at(0.22, y(0.52), 0.45, SNOW_CAP_HI),
+                ball_at(0.15, Vec3::new(0.16, 0.46, 0.12), 0.45, SNOW_CAP),
+                ball_at(0.13, Vec3::new(-0.18, 0.44, -0.14), 0.45, SNOW_SHADE),
+                ball_at(0.08, Vec3::new(-0.36, 0.22, 0.18), 0.5, SNOW_CAP),
+            ];
+            // Icicles hanging off the overhang lip (+X side); tips stay well above y=0.
+            parts.push(icicle(0.022, 0.13, Vec3::new(0.40, 0.26, 0.04)));
+            parts.push(icicle(0.016, 0.09, Vec3::new(0.36, 0.24, -0.10)));
+            shaded(merged(parts))
         }
-        _ => {
-            let r = 0.30;
-            flat_shaded(merged(vec![
-                // Lower block.
-                ball_at(r, y(r * 0.82), 0.9, ROCK_DARK),
-                // Upper split block.
-                ball_at(r * 0.72, Vec3::new(r * 0.3, r * 1.55, -r * 0.1), 0.9, ROCK_BODY),
-                // Lit chip.
-                ball_at(r * 0.4, Vec3::new(-r * 0.55, r * 0.7, r * 0.3), 0.85, ROCK_LIGHT),
-                // Snow cap on the peak + a side dab.
-                ball_at(r * 0.64, Vec3::new(r * 0.25, r * 2.0, -r * 0.08), 0.46, SNOW_CAP_HI),
-                ball_at(r * 0.36, Vec3::new(-r * 0.5, r * 0.95, r * 0.3), 0.46, SNOW_CAP),
-            ]))
+        1 => {
+            let mut parts = vec![
+                // Lower block (dark) + counter-tilted upper block → the split-tor profile.
+                chunk_at(0.28, y(0.24), Vec3::new(1.15, 0.95, 1.05), 0.1, 0.1, 1, ROCK_DARK),
+                chunk_at(0.21, Vec3::new(0.08, 0.58, -0.04), Vec3::new(1.2, 0.85, 0.95), 0.8, -0.22, 1, ROCK_BODY),
+                // Lit chip wedged in the split.
+                chunk_at(0.12, Vec3::new(-0.16, 0.50, 0.10), Vec3::new(1.0, 0.7, 1.1), 1.9, 0.15, 0, ROCK_LIGHT),
+                // Snow: bright peak cap + a dab on each shoulder + a shade lobe low.
+                ball_at(0.14, Vec3::new(0.08, 0.74, -0.04), 0.45, SNOW_CAP_HI),
+                ball_at(0.10, Vec3::new(-0.14, 0.56, 0.10), 0.45, SNOW_CAP),
+                ball_at(0.09, Vec3::new(0.20, 0.40, 0.14), 0.45, SNOW_SHADE),
+            ];
+            // One long icicle under the upper block's lip.
+            parts.push(icicle(0.020, 0.16, Vec3::new(0.26, 0.46, -0.06)));
+            shaded(merged(parts))
         }
+        _ => shaded(merged(vec![
+            // Three huddled cobbles, a snow blanket bridging their tops.
+            chunk_at(0.26, Vec3::new(-0.08, 0.16, 0.02), Vec3::new(1.2, 0.7, 1.0), 0.3, 0.1, 1, ROCK_BODY),
+            chunk_at(0.17, Vec3::new(0.24, 0.12, -0.12), Vec3::new(1.1, 0.75, 1.0), 1.1, -0.1, 0, ROCK_DARK),
+            chunk_at(0.13, Vec3::new(0.12, 0.10, 0.22), Vec3::new(1.0, 0.8, 1.1), 2.0, 0.12, 0, ROCK_LIGHT),
+            // Snow blanket draped across the tops + a shade lobe in the crevice.
+            ball_at(0.19, Vec3::new(-0.06, 0.30, 0.02), 0.42, SNOW_CAP_HI),
+            ball_at(0.13, Vec3::new(0.20, 0.22, -0.10), 0.42, SNOW_CAP),
+            ball_at(0.10, Vec3::new(0.10, 0.18, 0.18), 0.45, SNOW_CAP),
+            ball_at(0.09, Vec3::new(0.04, 0.16, -0.18), 0.5, SNOW_SHADE),
+        ])),
     }
 }
 
@@ -303,9 +544,10 @@ fn build_boulder_mesh(variant: u32) -> Mesh {
 //
 // The charming centrepiece: three stacked bright-snow balls (big → mid → head), a coal
 // face (two eyes + an arc-of-coal smile), an orange carrot nose, two bare twig arms
-// fanning up-and-out, a red scarf wound at the neck with a hanging tail, and a dark
-// bucket hat. Base flush at y=0, ~1.15u tall (incl. hat) before the scatter scales it.
-// Built facing +Z; the scatter gives it a random yaw. Single merged vertex-coloured mesh.
+// fanning up-and-out, a red scarf wound at the neck with a hanging tail, a dark bucket
+// hat with a red knitted band, and a drift skirt banked against his base (hides the
+// ball/ground seam). Base flush at y=0, ~1.15u tall (incl. hat) before the scatter
+// scales it. Built facing +Z; the scatter gives it a random yaw. Single merged mesh.
 fn build_snowman_mesh() -> Mesh {
     let mut parts: Vec<Mesh> = Vec::new();
 
@@ -317,6 +559,10 @@ fn build_snowman_mesh() -> Mesh {
     parts.push(ball_at(0.225, y(mid_cy), 0.96, SNOWMAN_BODY));
     let head_cy = 0.84;
     parts.push(ball_at(0.165, y(head_cy), 0.97, SNOWMAN_BODY));
+
+    // ── Drift skirt banked against the base (bright lee lobe / blue windward lobe).
+    parts.push(ball_at(0.20, Vec3::new(0.16, 0.05, 0.14), 0.45, SNOW_CAP));
+    parts.push(ball_at(0.17, Vec3::new(-0.20, 0.04, -0.08), 0.45, SNOW_SHADE));
 
     // ── Face (on the +Z front of the head): two coal eyes + a carrot nose + a coal smile.
     let face_z = 0.135;
@@ -382,112 +628,238 @@ fn build_snowman_mesh() -> Mesh {
         lin(SCARF),
     ));
 
-    // ── Dark bucket hat on the crown: a wide thin brim + a tapered crown drum.
+    // ── Dark bucket hat on the crown: a wide thin brim + a tapered crown drum + a red
+    // knitted band wrapping the crown's base (matches the scarf).
     let head_top = head_cy + 0.165 * 0.97;
     parts.push(cyl_up(0.205, 0.035, head_top - 0.01, 12, HAT)); // brim
     parts.push(cyl_up(0.135, 0.20, head_top + 0.10, 10, HAT)); // crown
+    parts.push(cyl_up(0.142, 0.045, head_top + 0.035, 10, SCARF)); // band
 
-    flat_shaded(merged(parts))
+    shaded(merged(parts))
 }
 
 // ── Ground cover: snow tuft + ice glint ─────────────────────────────────────────
 
-/// A tiny snow tuft — a low cluster of three white-blue specks (wind-packed snow nub).
+/// A tiny snow tuft — wind-packed snow specks with three dry straw-yellow winter grass
+/// blades poking through (the sparse grass surviving under the snow), the tallest blade
+/// carrying a frost crystal at its tip.
 fn build_snow_tuft_mesh() -> Mesh {
-    flat_shaded(merged(vec![
+    let mut parts = vec![
         ball_at(0.05, y(0.03), 0.5, SNOW_CAP),
         ball_at(0.04, Vec3::new(0.05, 0.03, 0.02), 0.5, SNOW_CAP_HI),
         ball_at(0.035, Vec3::new(-0.04, 0.025, -0.03), 0.5, SNOW_SHADE),
-    ]))
+    ];
+    let blades = [(0.4_f32, 0.30_f32, 0.11_f32), (2.5, -0.40, 0.14), (4.6, 0.25, 0.09)];
+    for (i, (yaw, tilt, len)) in blades.into_iter().enumerate() {
+        let rot = Quat::from_rotation_y(yaw) * Quat::from_rotation_z(tilt);
+        let at = Vec3::new(yaw.cos() * 0.03, 0.0, yaw.sin() * 0.03);
+        let b = Cone { radius: 0.010, height: len }
+            .mesh()
+            .resolution(4)
+            .build()
+            .translated_by(y(len * 0.5))
+            .rotated_by(rot)
+            .translated_by(at);
+        parts.push(tinted(b, lin(GRASS_DRY)));
+        if i == 1 {
+            // Frost crystal clinging to the tallest blade's tip.
+            parts.push(ball_at(0.016, at + rot * y(len), 0.9, SNOW_CAP_HI));
+        }
+    }
+    shaded(merged(parts))
 }
 
-/// An ice glint — a tiny flat pale-blue ice shard catching the light (a low faceted disc
-/// nub). Sits essentially flat at y≈0.
+/// An ice glint — a low angular ice slab (tilted squashed chunk) with two tiny shard
+/// spikes leaning off it and a bright sparkle nub. Sits essentially flat at y≈0.
 fn build_ice_glint_mesh() -> Mesh {
-    flat_shaded(merged(vec![
-        ball_at(0.06, y(0.012), 0.18, ICE_PALE),
-        ball_at(0.035, Vec3::new(0.04, 0.02, 0.0), 0.3, SNOW_CAP_HI),
-    ]))
+    let mut parts = vec![
+        chunk_at(0.06, y(0.015), Vec3::new(1.3, 0.3, 1.0), 0.7, 0.0, 0, ICE_PALE),
+        ball_at(0.022, Vec3::new(0.045, 0.025, 0.01), 0.6, SNOW_CAP_HI),
+    ];
+    for (a, h) in [(0.9_f32, 0.07_f32), (3.8, 0.05)] {
+        let shard = Cone { radius: 0.014, height: h }
+            .mesh()
+            .resolution(4)
+            .build()
+            .translated_by(y(h * 0.5))
+            .rotated_by(Quat::from_rotation_y(a) * Quat::from_rotation_z(0.25))
+            .translated_by(Vec3::new(a.cos() * 0.035, 0.0, a.sin() * 0.035));
+        parts.push(tinted(shard, lin(ICE_RIM)));
+    }
+    shaded(merged(parts))
 }
 
-/// Winter ground litter (cover). `variant`: 0 = a holly sprig (dark leaves + red berries +
-/// a snow dab), 1 = a snow-capped pinecone, 2 = a tiny pale-blue ice-shard cluster. Very
-/// low (≤0.13u), base at y=0 — the colourful little touches that dress the snowfield.
+/// Winter ground litter (cover). `variant`: 0 = a holly sprig (angular dark leaves + red
+/// berries + a snow dab), 1 = a toppled snow-dusted pinecone with a ring of scales, 2 = a
+/// pale-blue ice-shard cluster (one shard catching the light), 3 = a frosted fallen twig.
+/// Very low (≤0.15u), base at y=0 — the colourful little touches dressing the snowfield.
 fn build_winter_litter_mesh(variant: u32) -> Mesh {
     let tau = std::f32::consts::TAU;
-    match variant % 3 {
-        // Holly sprig — four dark flattened leaves around a few red berries + a snow dab.
+    match variant % 4 {
+        // Holly sprig — five angular tip-tilted leaves fanned around four berries.
         0 => {
             let mut parts: Vec<Mesh> = Vec::new();
-            for i in 0..4 {
-                let a = (i as f32 / 4.0) * tau;
-                parts.push(ball_at(0.05, Vec3::new(a.cos() * 0.06, 0.03, a.sin() * 0.06), 0.28, HOLLY_LEAF));
+            for i in 0..5 {
+                let a = i as f32 / 5.0 * tau;
+                parts.push(chunk_at(
+                    0.045,
+                    Vec3::new(a.cos() * 0.06, 0.032, a.sin() * 0.06),
+                    Vec3::new(1.5, 0.30, 0.8), // long flat leaf blade
+                    -a,
+                    0.25, // tips tilt up out of the snow
+                    0,
+                    HOLLY_LEAF,
+                ));
             }
-            parts.push(ball_at(0.022, y(0.05), 0.9, HOLLY_BERRY));
-            parts.push(ball_at(0.020, Vec3::new(0.03, 0.05, 0.0), 0.9, HOLLY_BERRY));
-            parts.push(ball_at(0.020, Vec3::new(-0.02, 0.05, 0.025), 0.9, HOLLY_BERRY));
-            parts.push(ball_at(0.04, Vec3::new(0.05, 0.02, -0.04), 0.4, SNOW_CAP_HI));
-            flat_shaded(merged(parts))
+            for (bx, bz) in [(0.0_f32, 0.0_f32), (0.032, -0.01), (-0.02, 0.026), (0.005, -0.034)] {
+                parts.push(ball_at(0.020, Vec3::new(bx, 0.055, bz), 0.9, HOLLY_BERRY));
+            }
+            parts.push(ball_at(0.04, Vec3::new(0.055, 0.02, -0.045), 0.4, SNOW_CAP_HI));
+            shaded(merged(parts))
         }
-        // Snow-capped pinecone — a stack of brown balls with a bright snow tip.
-        1 => flat_shaded(merged(vec![
-            ball_at(0.045, y(0.04), 1.15, PINECONE_BROWN),
-            ball_at(0.036, y(0.085), 1.15, PINECONE_BROWN),
-            ball_at(0.026, y(0.115), 1.1, SNOW_CAP_HI),
-        ])),
-        // Ice-shard cluster — a few small pale-blue pointed cones poking up.
-        _ => {
+        // Toppled pinecone — a fat lying cone (tip +X) ringed by scale-balls at the butt,
+        // snow piled along its upper flank.
+        1 => {
+            let mut parts = vec![tinted(
+                Cone { radius: 0.045, height: 0.13 }
+                    .mesh()
+                    .resolution(6)
+                    .build()
+                    .rotated_by(Quat::from_rotation_z(-FRAC_PI_2)) // tip the apex to +X
+                    .translated_by(y(0.045)),
+                lin(PINECONE_BROWN),
+            )];
+            for i in 0..5 {
+                let a = i as f32 / 5.0 * tau + 0.3;
+                parts.push(ball_at(
+                    0.020,
+                    Vec3::new(-0.035, 0.045 + a.sin() * 0.034, a.cos() * 0.034),
+                    0.9,
+                    PINECONE_BROWN,
+                ));
+            }
+            parts.push(ball_at(0.030, Vec3::new(0.0, 0.085, 0.0), 0.5, SNOW_CAP_HI));
+            parts.push(ball_at(0.024, Vec3::new(-0.055, 0.06, 0.01), 0.6, SNOW_CAP));
+            shaded(merged(parts))
+        }
+        // Ice-shard cluster — four leaning pointed cones, one bright (catching the sun).
+        2 => {
             let mut parts: Vec<Mesh> = Vec::new();
-            for i in 0..3 {
-                let a = (i as f32 / 3.0) * tau + 0.4;
-                let h = 0.10 + (i % 2) as f32 * 0.05;
-                let shard = Cone { radius: 0.022, height: h }
+            for i in 0..4 {
+                let a = i as f32 / 4.0 * tau + 0.4;
+                let h = 0.09 + (i % 2) as f32 * 0.06;
+                let shard = Cone { radius: 0.020, height: h }
+                    .mesh()
+                    .resolution(4)
+                    .build()
+                    .translated_by(y(h * 0.5))
+                    .rotated_by(Quat::from_rotation_y(a) * Quat::from_rotation_z(0.22))
+                    .translated_by(Vec3::new(a.cos() * 0.04, 0.0, a.sin() * 0.04));
+                parts.push(tinted(shard, lin(if i == 0 { SNOW_CAP_HI } else { ICE_PALE })));
+            }
+            parts.push(ball_at(0.035, y(0.02), 0.4, SNOW_CAP_HI));
+            shaded(merged(parts))
+        }
+        // Frosted fallen twig — a thin lying branch with one stub fork, snow dusted along
+        // its top.
+        _ => {
+            let lyaw = 0.7_f32;
+            let dir = Vec3::new(lyaw.cos(), 0.0, -lyaw.sin());
+            let mut parts = vec![tinted(
+                Cylinder::new(0.013, 0.26)
                     .mesh()
                     .resolution(5)
                     .build()
-                    .translated_by(y(h * 0.5))
-                    .rotated_by(Quat::from_rotation_z(0.2 * (i as f32 - 1.0)))
-                    .translated_by(Vec3::new(a.cos() * 0.04, 0.0, a.sin() * 0.04));
-                parts.push(tinted(shard, lin(ICE_PALE)));
+                    .rotated_by(Quat::from_rotation_z(FRAC_PI_2)) // lie the axis flat
+                    .rotated_by(Quat::from_rotation_y(lyaw))
+                    .translated_by(y(0.013)),
+                lin(BIRCH_TWIG),
+            )];
+            let fork = Cone { radius: 0.010, height: 0.09 }
+                .mesh()
+                .resolution(4)
+                .build()
+                .translated_by(y(0.045))
+                .rotated_by(Quat::from_rotation_y(lyaw + 0.5) * Quat::from_rotation_z(1.05))
+                .translated_by(dir * 0.05 + y(0.012));
+            parts.push(tinted(fork, lin(BIRCH_TWIG)));
+            for t in [-0.08_f32, 0.0, 0.09] {
+                parts.push(ball_at(0.016, dir * t + y(0.028), 0.6, SNOW_CAP_HI));
             }
-            parts.push(ball_at(0.03, y(0.02), 0.4, SNOW_CAP_HI));
-            flat_shaded(merged(parts))
+            shaded(merged(parts))
         }
     }
 }
 
 // ── A snow-laden bare dead tree for the pond ring ────────────────────────────────
 //
-// A grey-brown bare trunk + a few up-angled broken branches, each carrying a snow dab.
-// Base at y=0. ~1.3u tall.
+// A kinked grey two-segment trunk snapped off in a splintered tip spike, a dark hollow
+// scar low on the bole, five up-angled broken branches each loaded with two snow dabs,
+// one icicle hanging from the lowest branch's elbow, and a drift banked around the
+// roots. Base at y=0. ~1.35u tall.
 fn build_dead_snow_tree_mesh() -> Mesh {
-    let mut parts = vec![cyl_up(0.07, 1.10, 0.55, 6, BIRCH_TWIG)];
-
-    // Four angled bare branches with a snow dab near each tip.
-    let branches = [
-        (0.0_f32, -0.8_f32, 0.46_f32, Vec3::new(0.18, 0.80, 0.06)),
-        (1.6, 0.7, 0.40, Vec3::new(-0.16, 0.92, -0.04)),
-        (3.0, 0.5, 0.34, Vec3::new(0.06, 1.05, 0.12)),
-        (4.5, -0.55, 0.30, Vec3::new(-0.10, 1.10, -0.10)),
+    let mut parts = vec![
+        cyl_up(0.075, 0.66, 0.33, 6, BIRCH_TWIG),
+        // Leaning upper segment + the splintered snapped-off tip.
+        tinted(
+            Cylinder::new(0.058, 0.46)
+                .mesh()
+                .resolution(6)
+                .build()
+                .translated_by(y(0.23))
+                .rotated_by(Quat::from_rotation_z(-0.14))
+                .translated_by(y(0.62)),
+            lin(BIRCH_TWIG),
+        ),
+        tinted(
+            Cone { radius: 0.055, height: 0.22 }
+                .mesh()
+                .resolution(5)
+                .build()
+                .translated_by(y(0.11))
+                .rotated_by(Quat::from_rotation_z(-0.14))
+                .translated_by(Vec3::new(0.064, 1.07, 0.0)),
+            lin(BIRCH_TWIG),
+        ),
+        // Dark hollow scar low on the bole.
+        tinted(
+            Cuboid::new(0.012, 0.10, 0.06).mesh().build().translated_by(Vec3::new(0.072, 0.30, 0.01)),
+            lin(BIRCH_MARK),
+        ),
     ];
-    for (yaw, tilt, len, tip) in branches {
-        let m = Cone { radius: 0.022, height: len }
+
+    // Five angled broken branches, each loaded with two snow dabs along its upper side.
+    let branches = [
+        (0.0_f32, -0.85_f32, 0.50_f32, Vec3::new(0.07, 0.74, 0.02)),
+        (1.5, 0.70, 0.42, Vec3::new(-0.05, 0.88, -0.02)),
+        (2.9, 0.52, 0.36, Vec3::new(0.05, 0.98, 0.03)),
+        (4.3, -0.60, 0.32, Vec3::new(0.02, 1.06, -0.03)),
+        (5.5, 0.78, 0.26, Vec3::new(0.06, 0.55, 0.0)),
+    ];
+    for (i, (byaw, tilt, len, root)) in branches.into_iter().enumerate() {
+        let rot = Quat::from_rotation_y(byaw) * Quat::from_rotation_z(tilt);
+        let m = Cone { radius: 0.024, height: len }
             .mesh()
             .resolution(5)
             .build()
             .translated_by(y(len * 0.5))
-            .rotated_by(Quat::from_rotation_z(tilt))
-            .rotated_by(Quat::from_rotation_y(yaw))
-            .translated_by(tip);
+            .rotated_by(rot)
+            .translated_by(root);
         parts.push(tinted(m, lin(BIRCH_TWIG)));
-        // Snow dab clinging to the branch.
-        parts.push(ball_at(0.07, tip + y(len * 0.18), 0.5, SNOW_CAP_HI));
+        parts.push(ball_at(0.06, root + rot * y(len * 0.45), 0.5, SNOW_CAP_HI));
+        parts.push(ball_at(0.045, root + rot * y(len * 0.8), 0.5, SNOW_CAP));
+        if i == 4 {
+            // An icicle hanging from the lowest branch's elbow (tip stays well above y=0).
+            parts.push(icicle(0.016, 0.12, root + rot * y(len * 0.5) - y(0.02)));
+        }
     }
-    // Snow piled at the base.
-    parts.push(ball_at(0.16, y(0.06), 0.4, SNOW_CAP));
-    parts.push(ball_at(0.11, Vec3::new(0.18, 0.05, 0.05), 0.4, SNOW_CAP_HI));
 
-    flat_shaded(merged(parts))
+    // Drift banked around the roots + snow caught on the snapped tip.
+    parts.push(ball_at(0.18, Vec3::new(0.06, 0.06, 0.02), 0.42, SNOW_CAP));
+    parts.push(ball_at(0.12, Vec3::new(-0.16, 0.05, -0.06), 0.42, SNOW_SHADE));
+    parts.push(ball_at(0.07, Vec3::new(0.066, 1.27, 0.0), 0.5, SNOW_CAP_HI));
+
+    shaded(merged(parts))
 }
 
 // ── config() ─────────────────────────────────────────────────────────────────────
@@ -526,11 +898,12 @@ pub fn config() -> BiomeConfig {
         seed: 4127,
         tree_min_dist: 2.9,
         classes: vec![
-            // Trees: 78% snow-laden conifer (two snow loads) / 22% bare snowy birch.
+            // Trees: 78% snow-laden conifer (heavy / light / tall-spire) / 22% bare birch.
             PropClass {
                 variants: vec![
-                    (build_pine_mesh(false), 0.46),
-                    (build_pine_mesh(true), 0.32),
+                    (build_pine_mesh(0), 0.30), // broad, heavy snow load
+                    (build_pine_mesh(1), 0.26), // standard, light dusting
+                    (build_pine_mesh(2), 0.22), // tall slim 5-tier spire
                     (build_birch_mesh(), 0.22),
                 ],
                 chance: 0.072,
@@ -538,17 +911,18 @@ pub fn config() -> BiomeConfig {
                 tree: true,
                 block_radius: 0.0,
             },
-            // Snow shrub / mound — FIRST non-tree class (the tree-too-close fallback).
+            // Snow drift / frozen shrub / stump+log — FIRST non-tree class (the
+            // tree-too-close fallback).
             PropClass {
-                variants: vec![(build_mound_mesh(0), 1.0), (build_mound_mesh(1), 1.0)],
+                variants: (0..3).map(|v| (build_mound_mesh(v), 1.0)).collect(),
                 chance: 0.055,
                 scale: (0.8, 1.45),
                 tree: false,
                 block_radius: 0.0,
             },
-            // Frost boulders.
+            // Frost boulders (slab / split tor / low huddle).
             PropClass {
-                variants: vec![(build_boulder_mesh(0), 1.0), (build_boulder_mesh(1), 1.0)],
+                variants: (0..3).map(|v| (build_boulder_mesh(v), 1.0)).collect(),
                 chance: 0.028,
                 scale: (0.6, 1.5),
                 tree: false,
@@ -565,7 +939,7 @@ pub fn config() -> BiomeConfig {
             },
         ],
         cover: vec![
-            // Snow tufts everywhere; sparser ice glints.
+            // Snow tufts (with winter grass) everywhere; sparser ice glints.
             PropClass {
                 variants: vec![(build_snow_tuft_mesh(), 1.0)],
                 chance: 0.34,
@@ -580,9 +954,9 @@ pub fn config() -> BiomeConfig {
                 tree: false,
                 block_radius: 0.0,
             },
-            // Winter litter — holly berries, snow-capped pinecones, ice shards.
+            // Winter litter — holly, toppled pinecone, ice shards, frosted twig.
             PropClass {
-                variants: (0..3).map(|v| (build_winter_litter_mesh(v), 1.0)).collect(),
+                variants: (0..4).map(|v| (build_winter_litter_mesh(v), 1.0)).collect(),
                 chance: 0.09,
                 scale: (0.7, 1.3),
                 tree: false,
@@ -615,8 +989,9 @@ pub fn config() -> BiomeConfig {
 // ── landmarks() — the frozen pond ────────────────────────────────────────────────
 
 /// A frozen pond: a pale-blue low-roughness ice disc sitting just above y=0 (reflects the
-/// sky via IBL), ringed by a darker frosted rim, a couple of snow-laden dead trees, and a
-/// small rock cairn. All entities tagged `BiomeEntity` so a biome switch wipes them.
+/// sky via IBL), ringed by a darker frosted rim, snow-laden dead trees, shoreline
+/// ice-shard clumps + a drift tongue, and an angular snow-capped stone cairn. All
+/// entities tagged `BiomeEntity` so a biome switch wipes them.
 pub fn landmarks(
     commands: &mut Commands,
     meshes: &mut Assets<Mesh>,
@@ -657,7 +1032,8 @@ pub fn landmarks(
     ));
 
     // Frosted rim ring — a slightly larger, darker disc a hair LOWER than the ice so it
-    // peeks out as a frozen shoreline lip (uses the shared vertex-colour material).
+    // peeks out as a frozen shoreline lip (uses the shared vertex-colour material; plain
+    // flat_shaded — the bake is meaningless on a flat ground disc).
     let rim = tinted(
         Circle::new(pond_r * 1.12)
             .mesh()
@@ -693,18 +1069,49 @@ pub fn landmarks(
         ));
     }
 
-    // ── A small rock cairn beside the pond (stacked frost-rock balls, snow-capped) ──
+    // ── Shoreline dressing: ice-shard clumps cracked up through the rim ice + a
+    // wind-sculpted drift tongue spilling onto the shore (reuses the scatter builders).
+    let shard_clump = meshes.add(build_winter_litter_mesh(2));
+    for (i, &a) in [1.2_f32, 3.3, 5.0].iter().enumerate() {
+        let rr = pond_r * (0.88 + 0.06 * i as f32);
+        commands.spawn((
+            Mesh3d(shard_clump.clone()),
+            MeshMaterial3d(mat.clone()),
+            Transform {
+                translation: pond + Vec3::new(a.cos() * rr, 0.05, a.sin() * rr),
+                rotation: Quat::from_rotation_y(a * 2.1),
+                scale: Vec3::splat(1.6 - 0.2 * i as f32),
+            },
+            BiomeEntity,
+        ));
+    }
+    commands.spawn((
+        Mesh3d(meshes.add(build_mound_mesh(0))),
+        MeshMaterial3d(mat.clone()),
+        Transform {
+            translation: pond + Vec3::new(-pond_r * 0.7, 0.0, pond_r * 0.95),
+            rotation: Quat::from_rotation_y(2.3),
+            scale: Vec3::splat(1.5),
+        },
+        BiomeEntity,
+    ));
+
+    // ── A small rock cairn beside the pond — four stacked ANGULAR frost stones (tilted
+    // chunks, dark footing → lit upper), a bright snow cap on the top stone, dabs on the
+    // shoulders, and an icicle under the second stone's lip.
     let cairn = {
-        let parts = vec![
-            ball_at(0.34, y(0.26), 0.78, ROCK_DARK),
-            ball_at(0.28, y(0.62), 0.82, CAIRN_STONE),
-            ball_at(0.22, y(0.92), 0.86, ROCK_LIGHT),
-            ball_at(0.16, y(1.14), 0.9, CAIRN_STONE),
-            // Snow cap on the top stone + a dab on the shoulder.
-            ball_at(0.15, y(1.28), 0.5, SNOW_CAP_HI),
-            ball_at(0.12, Vec3::new(0.18, 0.70, 0.06), 0.5, SNOW_CAP),
+        let mut parts = vec![
+            chunk_at(0.34, y(0.24), Vec3::new(1.2, 0.8, 1.05), 0.2, 0.08, 1, ROCK_DARK),
+            chunk_at(0.27, Vec3::new(0.03, 0.60, -0.02), Vec3::new(1.15, 0.75, 1.0), 1.1, -0.12, 1, CAIRN_STONE),
+            chunk_at(0.21, Vec3::new(-0.02, 0.88, 0.03), Vec3::new(1.1, 0.7, 1.0), 2.0, 0.10, 0, ROCK_LIGHT),
+            chunk_at(0.15, Vec3::new(0.02, 1.10, 0.0), Vec3::new(1.05, 0.8, 1.0), 2.8, -0.08, 0, CAIRN_STONE),
+            // Bright snow cap on the top stone + dabs on the shoulders below.
+            ball_at(0.14, y(1.26), 0.5, SNOW_CAP_HI),
+            ball_at(0.11, Vec3::new(0.17, 0.72, 0.05), 0.5, SNOW_CAP),
+            ball_at(0.09, Vec3::new(-0.15, 0.96, -0.06), 0.5, SNOW_SHADE),
         ];
-        flat_shaded(merged(parts))
+        parts.push(icicle(0.018, 0.14, Vec3::new(0.30, 0.52, 0.05)));
+        shaded(merged(parts))
     };
     let cairn_pos = pond + Vec3::new(pond_r * 0.85, 0.0, pond_r * 0.55);
     commands.spawn((

--- a/src/biome_swamp.rs
+++ b/src/biome_swamp.rs
@@ -2,18 +2,29 @@
 //! high-variation wet mottle; dim, desaturated greenish daylight under DENSE green-grey
 //! fog; a murky green river. The scatter is built from bespoke wetland props authored
 //! right in this module (no shared `trees`/`props` reuse — the swamp wants its own
-//! gnarled, drowned look):
+//! gnarled, drowned look). Light/shadow is BAKED into the vertex colours: every prop is
+//! mud-dark at its waterline foot and brightens toward its sunlit crown:
 //!
-//!   * GNARLED MANGROVE / dead swamp tree (tree class) — a twisted dark trunk on a small
-//!     stilt-root flare, a few drooping bare limbs, sparse dark-green canopy clumps and
-//!     strands of hanging grey-green moss.
-//!   * CYPRESS-KNEE / rotten stump variant — a knobbly mossy stump ringed by little
-//!     cypress "knees" poking up out of the muck.
-//!   * CATTAIL REED clump (first non-tree class → the tree spacing fallback) — green
-//!     stalks fanning out, half topped with a brown seed head.
-//!   * Swamp TOADSTOOLS / shelf fungus + a mossy boulder, as the small accent class.
+//!   * GNARLED MANGROVE swamp tree (tree class) — a crooked three-segment trunk (dark
+//!     water-stained foot → pale sunlit top) standing on flared buttress root fins and
+//!     stilt roots, five drooping bare limbs under a broad flat layered canopy (wide dark
+//!     underside skirt, small bright lobes on top) dripping two-tone hanging-moss strands
+//!     off the limbs AND the canopy rim. Three variants vary lean / fullness / phase.
+//!   * CYPRESS-KNEE / rotten stump (tree class) — a fluted mossy bark drum on a dark mud
+//!     skirt, a damp cut top sunk with a rotten hollow, rim splinters, shelf-fungus
+//!     brackets, and a ring of knob-tipped cypress "knees" leaning back at the stump.
+//!     Two variants (variant 1 is shorter and carries one tall snapped shard).
+//!   * CATTAIL REED clump (first non-tree class → the tree spacing fallback) — stalks
+//!     fanning out of a dark wet sheath, half topped with a brown seed head + the pale
+//!     flowering spike above it, plus a few broad flattened leaf blades.
+//!   * Swamp ACCENTS — toadstool clusters with baked gill shadows / sunlit cap bumps /
+//!     pale flecks, a mud-skirted mossy boulder with stepped shelf fungus and shed
+//!     pebbles, a taller toadstool trio, and a twisted HALF-SUNKEN LOG (broken-end
+//!     shards, snag branches, moss saddle, one bracket).
 //!
-//! Ground cover: moss patches, reed sprigs, swamp mushrooms and flat lily-pad-ish discs.
+//! Ground cover: two-tone moss patches with bright sunlit tufts, reed sprigs around a
+//! miniature cattail, double swamp mushrooms, lily-pad drifts (one variant carries a pale
+//! pink lotus bud), bog cotton and lilac marsh flowers.
 //! Particle: drifting low Mist. Backdrop: a dark misty conifer treeline over low murky
 //! hills (no ocean — the land arc fills most of the horizon). Landmark: a big hollow dead
 //! tree on the land side with a knot of glowing greenish will-o'-wisp motes hovering over
@@ -35,25 +46,28 @@ use bevy::prelude::*;
 use crate::biome::{
     Backdrop, Biome, BiomeConfig, BiomeEntity, GroundDetail, ParticleKind, PropClass,
 };
-use crate::palette::lin;
+use crate::palette::{lin, lin_scaled};
 
 const TAU: f32 = std::f32::consts::TAU;
 const PI: f32 = std::f32::consts::PI;
 const FRAC_PI_2: f32 = std::f32::consts::FRAC_PI_2;
 
-/// Mangroves are authored ~1.4u tall; scale up so they loom at eye level like the forest.
+/// Mangroves are authored ~1.7u tall; scale up so they loom at eye level like the forest.
 const TREE_SCALE: f32 = 1.7;
 
 // ── Swamp palette (murky, desaturated — deep olive greens + rotting browns) ──────────
+// Most parts also pass through `lin_scaled(c, v)`: v < 1 for the mud-dark waterline /
+// underside tones, v > 1 for the sunlit crowns, so each prop bakes its own shading.
 const MANGROVE_BARK: u32 = 0x3b2c20; // twisted near-black swamp-wood trunk
 const MANGROVE_BARK_DK: u32 = 0x281d14; // shadowed underside / drooping limbs
-const MANGROVE_ROOT: u32 = 0x322619; // stilt-root flare, a touch warmer
-const CANOPY_DARK: u32 = 0x2a4a2c; // sparse deep swamp-green canopy clump
+const MANGROVE_ROOT: u32 = 0x322619; // buttress fins + stilt roots, a touch warmer
+const CANOPY_DARK: u32 = 0x2a4a2c; // deep swamp-green canopy body / underside
 const CANOPY_MID: u32 = 0x37623a; // a slightly lighter canopy lobe
-const HANGING_MOSS: u32 = 0x6f7e54; // grey-green Spanish-moss strands
+const CANOPY_LIGHT: u32 = 0x4d7d46; // bright sunlit top lobes
+const HANGING_MOSS: u32 = 0x6f7e54; // grey-green Spanish-moss strands (pale sage)
 
 const STUMP_BARK: u32 = 0x4a3826; // rotten cypress stump bark
-const STUMP_TOP: u32 = 0x5f4a30; // damp cut-top wood
+const STUMP_TOP: u32 = 0x5f4a30; // damp cut-top wood (scaled way down = the rotten hollow)
 const STUMP_MOSS: u32 = 0x4d6e3a; // moss cushion on the stump
 const KNEE_WOOD: u32 = 0x42301f; // cypress-knee root knob
 
@@ -61,7 +75,7 @@ const REED_STALK: u32 = 0x6b8a44; // marsh reed green (TS REED_MAT)
 const REED_STALK_DK: u32 = 0x4f6c34; // darker reed (TS REED_DARK_MAT)
 const CATTAIL_HEAD: u32 = 0x7a4a2a; // brown cattail seed head (TS CATTAIL_MAT)
 
-const TOAD_STEM: u32 = 0xccc2a0; // pale toadstool stem
+const TOAD_STEM: u32 = 0xccc2a0; // pale toadstool stem (also the cap flecks)
 const TOAD_CAP: u32 = 0x7a5a34; // dull swamp-brown toadstool cap
 const SHELF_FUNGUS: u32 = 0x9a7c4a; // ochre shelf fungus bracket
 const SWAMP_ROCK: u32 = 0x57614e; // mossy grey-green boulder
@@ -69,10 +83,11 @@ const SWAMP_ROCK_MOSS: u32 = 0x47633a; // moss accent on the boulder
 
 const LILY_PAD: u32 = 0x3a6a40; // murky lily-pad green
 const LILY_PAD_EDGE: u32 = 0x294d2e; // darker pad rim
+const LILY_BLOOM: u32 = 0xdcc0d8; // pale-pink closed lotus bud on a pad
 const MOSS_PATCH: u32 = 0x4a6a38; // ground moss carpet patch
 const BOG_COTTON: u32 = 0xeef0e6; // fluffy white bog-cotton head
 const SWAMP_FLOWER: u32 = 0xcdb6e6; // pale lilac marsh flower
-const SWAMP_FLOWER_CORE: u32 = 0xe8d27a; // pale gold flower centre
+const SWAMP_FLOWER_CORE: u32 = 0xe8d27a; // pale gold flower centre / lotus heart
 
 // Will-o'-wisp glow (sickly green; sRGB → linear in the emissive so it blooms).
 const WISP_GLOW: Color = Color::srgb(0.45, 1.0, 0.55);
@@ -85,12 +100,13 @@ const GLOWMUSH_GLOW: Color = Color::srgb(0.35, 1.0, 0.82); // teal-green cap glo
 const GLOWMUSH_EMISSIVE: f32 = 26.0;
 /// Local layout of one cluster: (dx, dz, scale) per mushroom. Shared by the stem + cap
 /// builders so caps land exactly on their stems.
-const GLOWMUSH_SPOTS: [(f32, f32, f32); 5] = [
+const GLOWMUSH_SPOTS: [(f32, f32, f32); 6] = [
     (0.0, 0.0, 1.3),
     (0.16, 0.06, 0.9),
     (-0.13, 0.10, 0.8),
     (0.05, -0.14, 0.7),
     (-0.08, -0.05, 0.55),
+    (0.19, -0.11, 0.5),
 ];
 
 // ── Mesh helpers (verbatim from trees.rs / decor.rs) ─────────────────────────────────
@@ -126,8 +142,9 @@ fn flat_shaded(mut m: Mesh) -> Mesh {
     m
 }
 
-/// A faceted icosphere blob (ico detail 0), optionally squashed, centred at `off`.
-fn ball_at(r: f32, off: Vec3, squash: f32, c: u32) -> Mesh {
+/// A faceted icosphere blob (ico detail 0), optionally squashed (or stretched, > 1),
+/// centred at `off`, in an explicit linear colour (callers bake light via `lin_scaled`).
+fn ball_at(r: f32, off: Vec3, squash: f32, c: [f32; 4]) -> Mesh {
     tinted(
         Sphere::new(r)
             .mesh()
@@ -135,84 +152,141 @@ fn ball_at(r: f32, off: Vec3, squash: f32, c: u32) -> Mesh {
             .expect("ico detail in range")
             .scaled_by(Vec3::new(1.0, squash, 1.0))
             .translated_by(off),
-        lin(c),
+        c,
     )
 }
 
 /// An upright cylinder whose centre sits at `cy` (a part of height `h` rooted at y=0 uses
 /// `cy = h/2`). `res` ≥ 3 (the Cylinder builder asserts resolution > 2).
-fn cyl_up(r: f32, h: f32, cy: f32, res: u32, c: u32) -> Mesh {
-    tinted(Cylinder::new(r, h).mesh().resolution(res).build().translated_by(y(cy)), lin(c))
+fn cyl_up(r: f32, h: f32, cy: f32, res: u32, c: [f32; 4]) -> Mesh {
+    tinted(Cylinder::new(r, h).mesh().resolution(res).build().translated_by(y(cy)), c)
+}
+
+/// A slim cone leaned out from upright: built along +Y with its base on the ground,
+/// tilted by `tilt` about Z, yawed by `yaw` about Y, then planted at `foot`. The base is
+/// auto-lifted by `r·sin(tilt)` so the tipped rim never dips below `foot.y` (the mesh
+/// contract: nothing under y=0). The workhorse for stalks, buttress fins, knees, snags
+/// and shards. NOTE on aim: with foot at angle `a` from the axis, `yaw = -a` + positive
+/// `tilt` leans the tip back INWARD (toward the axis) — used for buttresses/knees.
+fn lean_cone(r: f32, h: f32, res: u32, tilt: f32, yaw: f32, foot: Vec3, c: [f32; 4]) -> Mesh {
+    let lift = r * tilt.abs().sin() + 0.002;
+    tinted(
+        Cone { radius: r, height: h }
+            .mesh()
+            .resolution(res)
+            .build()
+            .translated_by(y(h * 0.5))
+            .rotated_by(Quat::from_rotation_z(tilt))
+            .rotated_by(Quat::from_rotation_y(yaw))
+            .translated_by(foot + y(lift)),
+        c,
+    )
+}
+
+/// A shelf-fungus bracket jutting out at `at`, yawed to face its host: a squashed ochre
+/// half-disc over a thin DARKER underside disc (baked under-shelf shadow). Returns both
+/// parts pre-`tinted`; callers `extend` them into the part list.
+fn shelf_bracket(at: Vec3, r: f32, yaw: f32) -> [Mesh; 2] {
+    let disc = |rr: f32, th: f32, dy: f32, c: [f32; 4]| {
+        tinted(
+            Cylinder::new(rr, th)
+                .mesh()
+                .resolution(8)
+                .build()
+                .scaled_by(Vec3::new(1.0, 1.0, 0.55))
+                .rotated_by(Quat::from_rotation_y(yaw))
+                .translated_by(at + y(dy)),
+            c,
+        )
+    };
+    [
+        disc(r, 0.028, 0.0, lin(SHELF_FUNGUS)),
+        disc(r * 0.92, 0.016, -0.024, lin_scaled(SHELF_FUNGUS, 0.6)),
+    ]
 }
 
 // ── Prop builders ────────────────────────────────────────────────────────────────────
 
-/// **Gnarled mangrove / dead swamp tree** — the tree class. A twisted dark trunk lifting
-/// off a low knot of stilt roots, a few drooping bare limbs, a couple of sparse dark-green
-/// canopy clumps and several strands of hanging grey-green moss dangling off the limbs.
-/// Authored ~1.4u tall, base flush at y=0. Two variants vary lean / canopy fullness.
+/// **Gnarled mangrove swamp tree** — the tree class. A crooked three-segment trunk (dark
+/// water-stained foot brightening to a pale sunlit top) standing on four flared buttress
+/// root fins + three stilt roots, five drooping bare limbs, and a broad flat LAYERED
+/// canopy: a wide dark underside skirt, a fuller mid layer, then small bright sunlit
+/// lobes on top. Two-tone hanging-moss strands drip off the limb tips and the canopy rim,
+/// each ending in a wispy blob. Authored ~1.7u tall, base flush at y=0. Three variants
+/// vary lean, canopy fullness and the buttress/moss phase.
 fn build_mangrove_mesh(variant: u32) -> Mesh {
-    let lean = if variant == 0 { 0.10_f32 } else { -0.14 };
+    let lean = match variant {
+        0 => 0.10_f32,
+        1 => -0.14,
+        _ => 0.06,
+    };
     let mut parts: Vec<Mesh> = Vec::new();
 
-    // ── Stilt-root flare — three short angled prop-roots splaying out at the base, so the
-    // trunk reads as standing up out of the muck on legs.
+    // ── Buttressed base — four flared root fins leaning back INTO the trunk (yaw = -a,
+    // see `lean_cone`), all in dark wet-stained root tones (the baked waterline shadow).
+    for i in 0..4 {
+        let a = (i as f32 / 4.0) * TAU + 0.9 + variant as f32 * 0.5;
+        let foot = Vec3::new(a.cos() * 0.17, 0.0, a.sin() * 0.17);
+        parts.push(lean_cone(0.075, 0.36, 5, 0.50, -a, foot, lin_scaled(MANGROVE_ROOT, 0.85)));
+    }
+    // Three stilt-roots splaying out between the fins — the tree stands "on legs".
     for i in 0..3 {
         let a = (i as f32 / 3.0) * TAU + 0.4;
-        let root = Cylinder::new(0.05, 0.34)
+        let root = Cylinder::new(0.045, 0.32)
             .mesh()
             .resolution(5)
             .build()
-            .translated_by(y(0.17))
+            .translated_by(y(0.16))
             // splay outward: lean then yaw around the base
             .rotated_by(Quat::from_rotation_z(0.66))
             .rotated_by(Quat::from_rotation_y(a))
-            .translated_by(Vec3::new(a.cos() * 0.10, 0.02, a.sin() * 0.10));
-        parts.push(tinted(root, lin(MANGROVE_ROOT)));
+            .translated_by(Vec3::new(a.cos() * 0.11, 0.035, a.sin() * 0.11));
+        parts.push(tinted(root, lin_scaled(MANGROVE_ROOT, 0.75)));
     }
     // A low knotty boss where the roots gather.
-    parts.push(ball_at(0.15, y(0.16), 0.85, MANGROVE_ROOT));
+    parts.push(ball_at(0.16, y(0.15), 0.8, lin_scaled(MANGROVE_ROOT, 0.9)));
 
-    // ── Trunk — a leaning column in two stacked cylinders for a slight crook.
-    let lower = Cylinder::new(0.10, 0.62)
-        .mesh()
-        .resolution(6)
-        .build()
-        .translated_by(y(0.31))
-        .rotated_by(Quat::from_rotation_z(lean))
-        .translated_by(y(0.14)); // lift so the leaned base still clears y=0
-    parts.push(tinted(lower, lin(MANGROVE_BARK)));
-    // Upper trunk crooks back the other way for a gnarled silhouette.
-    let upper_base = Quat::from_rotation_z(lean) * Vec3::new(0.0, 0.62, 0.0) + y(0.14);
-    let upper = Cylinder::new(0.075, 0.5)
-        .mesh()
-        .resolution(6)
-        .build()
-        .translated_by(y(0.25))
-        .rotated_by(Quat::from_rotation_z(-lean * 1.6))
-        .translated_by(upper_base);
-    parts.push(tinted(upper, lin(MANGROVE_BARK)));
-
+    // ── Trunk — three stacked crooked segments alternating lean for a gnarled silhouette,
+    // dark mud-stained at the foot and brightening toward the sunlit top (baked vertical
+    // light gradient). Knuckle bosses hide the joints so the kinks read as wood, not gaps.
+    let segs = [
+        (0.105_f32, 0.48_f32, lean, lin_scaled(MANGROVE_BARK, 0.80)),
+        (0.085, 0.42, -lean * 1.5, lin(MANGROVE_BARK)),
+        (0.063, 0.38, lean * 0.9, lin_scaled(MANGROVE_BARK, 1.14)),
+    ];
+    let mut anchor = y(0.10); // lifted so the leaned base clears y=0 (roots hide the gap)
+    for (i, &(r, h, tilt, c)) in segs.iter().enumerate() {
+        let q = Quat::from_rotation_z(tilt);
+        let seg = Cylinder::new(r, h)
+            .mesh()
+            .resolution(6)
+            .build()
+            .translated_by(y(h * 0.5))
+            .rotated_by(q)
+            .translated_by(anchor);
+        parts.push(tinted(seg, c));
+        anchor += q * Vec3::new(0.0, h, 0.0);
+        if i < 2 {
+            parts.push(ball_at(r * 1.15, anchor, 0.8, lin(MANGROVE_BARK)));
+        }
+    }
     // Crown anchor point (top of the upper trunk) — limbs & canopy hang off it.
-    let crown = Quat::from_rotation_z(lean) * Vec3::new(0.0, 0.62, 0.0)
-        + Quat::from_rotation_z(-lean * 1.6) * Vec3::new(0.0, 0.5, 0.0)
-        + y(0.14);
+    let crown = anchor;
 
-    // ── A few drooping bare limbs radiating from the crown (thin dark cylinders, angled
-    // out then sagging). Record each tip so moss can hang off it.
+    // ── Five drooping bare limbs radiating from the crown (thin cylinders tilted past
+    // horizontal so they sag). Record each tip so moss can hang off it.
     let mut limb_tips: Vec<Vec3> = Vec::new();
     let limbs = [
-        (0.5_f32, 0.9_f32, 0.34_f32), // (yaw, droop, length)
-        (2.4, 0.7, 0.30),
-        (4.3, 1.0, 0.28),
-        (3.4, 0.55, 0.24),
+        (0.5_f32, 0.90_f32, 0.36_f32), // (yaw, droop, length)
+        (1.7, 0.62, 0.30),
+        (2.9, 1.00, 0.30),
+        (4.2, 0.72, 0.34),
+        (5.4, 0.55, 0.26),
     ];
     for (i, &(yaw, droop, len)) in limbs.iter().enumerate() {
-        // Build along +Y, tilt past horizontal so it droops (FRAC_PI_2 - 0.2 + droop),
-        // yaw out, then translate to the crown.
         let tilt = Quat::from_rotation_z(FRAC_PI_2 - 0.2 + droop);
-        let spin = Quat::from_rotation_y(yaw);
-        let limb = Cylinder::new(0.026, len)
+        let spin = Quat::from_rotation_y(yaw + variant as f32 * 0.7);
+        let limb = Cylinder::new(0.024, len)
             .mesh()
             .resolution(5)
             .build()
@@ -220,85 +294,129 @@ fn build_mangrove_mesh(variant: u32) -> Mesh {
             .rotated_by(tilt)
             .rotated_by(spin)
             .translated_by(crown);
-        let c = if i % 2 == 0 { MANGROVE_BARK } else { MANGROVE_BARK_DK };
-        parts.push(tinted(limb, lin(c)));
+        let c = if i % 2 == 0 { lin(MANGROVE_BARK) } else { lin(MANGROVE_BARK_DK) };
+        parts.push(tinted(limb, c));
         // The far tip of the limb in world space.
-        let tip = crown + spin * (tilt * Vec3::new(0.0, len, 0.0));
-        limb_tips.push(tip);
+        limb_tips.push(crown + spin * (tilt * Vec3::new(0.0, len, 0.0)));
     }
 
-    // ── Sparse canopy — a couple of dark-green clumps up near the crown (drowned, thin).
-    parts.push(ball_at(0.26, crown + y(0.06), 0.8, CANOPY_DARK));
-    parts.push(ball_at(0.18, crown + Vec3::new(0.16, 0.14, -0.08), 0.8, CANOPY_MID));
-    if variant == 0 {
-        parts.push(ball_at(0.16, crown + Vec3::new(-0.18, 0.04, 0.10), 0.8, CANOPY_DARK));
+    // ── Broad flat layered canopy — a wide DARK underside skirt (ico-1 disc: the baked
+    // canopy shadow), a fuller mid layer above it, then small bright sunlit lobes on top.
+    let skirt = Sphere::new(0.36)
+        .mesh()
+        .ico(1)
+        .expect("ico detail in range")
+        .scaled_by(Vec3::new(1.0, 0.42, 1.0))
+        .translated_by(crown + y(0.04));
+    parts.push(tinted(skirt, lin_scaled(CANOPY_DARK, 0.72)));
+    let mid = Sphere::new(0.30)
+        .mesh()
+        .ico(1)
+        .expect("ico detail in range")
+        .scaled_by(Vec3::new(1.0, 0.50, 1.0))
+        .translated_by(crown + y(0.14));
+    parts.push(tinted(mid, lin(CANOPY_DARK)));
+    parts.push(ball_at(0.17, crown + Vec3::new(0.15, 0.22, -0.08), 0.6, lin(CANOPY_MID)));
+    parts.push(ball_at(0.14, crown + Vec3::new(-0.13, 0.25, 0.09), 0.6, lin(CANOPY_LIGHT)));
+    if variant != 1 {
+        parts.push(ball_at(0.12, crown + Vec3::new(0.02, 0.28, 0.14), 0.6, lin(CANOPY_LIGHT)));
     }
 
-    // ── Hanging moss — thin grey-green strands dangling straight down off the limb tips.
+    // ── Hanging moss — pale sage strands dangling straight down off the limb tips AND
+    // the canopy rim, alternating two tones, each ending in a wispy blob.
+    let mut hangs: Vec<(Vec3, f32)> = Vec::new();
     for (i, &tip) in limb_tips.iter().enumerate() {
-        if i == 3 {
+        if i == 4 {
             continue; // leave one limb bare for an asymmetric look
         }
-        let hang = 0.22 + (i as f32) * 0.04;
+        hangs.push((tip, 0.22 + (i as f32) * 0.035));
+    }
+    for i in 0..3 {
+        let a = (i as f32 / 3.0) * TAU + 1.1 + variant as f32;
+        hangs.push((crown + Vec3::new(a.cos() * 0.30, 0.02, a.sin() * 0.30), 0.18 + i as f32 * 0.05));
+    }
+    for (i, &(at, hang)) in hangs.iter().enumerate() {
+        let c = if i % 2 == 0 { lin(HANGING_MOSS) } else { lin_scaled(HANGING_MOSS, 0.78) };
         // A thin tapered cone pointing DOWN (rotate the upright cone PI about X).
         let strand = Cone { radius: 0.018, height: hang }
             .mesh()
+            .resolution(4)
             .build()
             .translated_by(y(hang * 0.5))
             .rotated_by(Quat::from_rotation_x(PI))
-            .translated_by(tip);
-        parts.push(tinted(strand, lin(HANGING_MOSS)));
-        // A little wispy blob at the bottom of the strand.
-        parts.push(ball_at(0.05, tip - y(hang), 0.6, HANGING_MOSS));
+            .translated_by(at);
+        parts.push(tinted(strand, c));
+        parts.push(ball_at(0.045, at - y(hang), 0.55, c));
     }
 
     flat_shaded(merged(parts))
 }
 
-/// **Cypress-knee stump** — the second tree-class variant: a knobbly mossy rotten stump
-/// ringed by a few little cypress "knees" (root knobs poking up out of the muck). Base at
-/// y=0, ~0.4u tall.
-fn build_cypress_stump_mesh() -> Mesh {
+/// **Cypress-knee stump** — the second tree-class prop: a fluted mossy rotten bark drum
+/// on a dark mud skirt, a damp cut top sunk with a darker rotten hollow, jagged rim
+/// splinters, shelf-fungus brackets on the shaded side, and a ring of cypress "knees"
+/// (knob-tipped root cones leaning back at the stump out of the muck). Base at y=0,
+/// ~0.4u tall. Variant 1 is a shorter drum carrying one tall snapped shard.
+fn build_cypress_stump_mesh(variant: u32) -> Mesh {
     let r = 0.32;
-    let h = 0.36;
+    let h = if variant == 0 { 0.36 } else { 0.30 };
     let mut parts = vec![
-        // Bark drum.
-        cyl_up(r, h, h * 0.5, 9, STUMP_BARK),
-        ball_at(r * 1.05, y(0.06), 0.45, STUMP_BARK), // splayed muddy foot
-        // Damp irregular cut top.
-        cyl_up(r * 0.94, 0.06, h + 0.01, 9, STUMP_TOP),
-        // A moss cushion slumped over one side of the rim.
-        ball_at(r * 0.7, Vec3::new(r * 0.45, h - 0.02, 0.0), 0.55, STUMP_MOSS),
-        ball_at(r * 0.4, Vec3::new(-r * 0.4, h + 0.02, r * 0.3), 0.6, STUMP_MOSS),
+        // Dark muddy waterline skirt, then the bark drum above it (skirt centre/squash
+        // chosen so the blob bottoms out AT y=0, not under it).
+        ball_at(r * 1.18, y(0.115), 0.30, lin_scaled(STUMP_BARK, 0.68)),
+        cyl_up(r, h, h * 0.5, 9, lin(STUMP_BARK)),
+        // Damp cut top + the darker rotten hollow sunk in its middle.
+        cyl_up(r * 0.94, 0.05, h + 0.01, 9, lin_scaled(STUMP_TOP, 1.1)),
+        cyl_up(r * 0.52, 0.022, h + 0.045, 8, lin_scaled(STUMP_TOP, 0.42)),
+        // Moss cushions slumped over the rim — brighter where the light lands on top.
+        ball_at(r * 0.62, Vec3::new(r * 0.5, h - 0.02, 0.0), 0.5, lin(STUMP_MOSS)),
+        ball_at(r * 0.38, Vec3::new(-r * 0.42, h + 0.02, r * 0.32), 0.55, lin_scaled(STUMP_MOSS, 1.18)),
+        ball_at(r * 0.30, Vec3::new(-r * 0.1, h + 0.03, -r * 0.45), 0.5, lin_scaled(STUMP_MOSS, 1.05)),
     ];
-    // A ring of little cypress knees rising out of the muck around the stump.
-    let knees = 5;
+    // Root flutes — slim cones hugging the drum so the bark reads ridged, not tubular.
+    for i in 0..4 {
+        let a = (i as f32 / 4.0) * TAU + 0.7;
+        let foot = Vec3::new(a.cos() * (r + 0.025), 0.0, a.sin() * (r + 0.025));
+        parts.push(lean_cone(0.055, h * 0.85, 4, 0.16, -a, foot, lin_scaled(STUMP_BARK, 0.88)));
+    }
+    // Jagged splinters on the rim (variant 1 swaps one for a tall sunlit snapped shard).
+    for i in 0..3 {
+        let a = (i as f32 / 3.0) * TAU + 1.2;
+        let sh = if variant == 1 && i == 0 { 0.46 } else { 0.10 + (i % 2) as f32 * 0.05 };
+        let c = if i == 0 { lin_scaled(STUMP_BARK, 1.12) } else { lin(STUMP_BARK) };
+        parts.push(lean_cone(0.05, sh, 4, 0.10, a, Vec3::new(a.cos() * r * 0.8, h, a.sin() * r * 0.8), c));
+    }
+    // Two shelf-fungus brackets stepped up one flank (ochre tops, shadowed undersides).
+    parts.extend(shelf_bracket(Vec3::new(r + 0.02, h * 0.42, 0.05), 0.12, 0.2));
+    parts.extend(shelf_bracket(Vec3::new(r - 0.01, h * 0.72, 0.10), 0.09, 0.5));
+    // A ring of little cypress knees rising out of the muck, leaning back at the stump,
+    // each tipped with a pale worn knob that catches light against the dark mud.
+    let knees = 6;
     for i in 0..knees {
         let a = (i as f32 / knees as f32) * TAU + 0.3;
-        let dist = r + 0.18 + (i % 2) as f32 * 0.10;
-        let kh = 0.16 + (i % 3) as f32 * 0.06;
-        let kx = a.cos() * dist;
-        let kz = a.sin() * dist;
-        // A short fat cone, point up, leaning slightly toward the stump.
-        let knee = Cone { radius: 0.07, height: kh }
-            .mesh()
-            .build()
-            .translated_by(y(kh * 0.5))
-            .rotated_by(Quat::from_rotation_z(0.12))
-            .rotated_by(Quat::from_rotation_y(a + FRAC_PI_2))
-            .translated_by(Vec3::new(kx, 0.0, kz));
-        parts.push(tinted(knee, lin(KNEE_WOOD)));
+        let dist = r + 0.16 + (i % 2) as f32 * 0.12;
+        let kh = 0.15 + (i % 3) as f32 * 0.07;
+        let foot = Vec3::new(a.cos() * dist, 0.0, a.sin() * dist);
+        parts.push(lean_cone(0.065, kh, 5, 0.18, -a, foot, lin(KNEE_WOOD)));
+        let tip = Quat::from_rotation_y(-a) * (Quat::from_rotation_z(0.18) * Vec3::new(0.0, kh, 0.0)) + foot;
+        parts.push(ball_at(0.035, tip, 0.8, lin_scaled(KNEE_WOOD, 1.25)));
     }
     flat_shaded(merged(parts))
 }
 
 /// **Cattail reed clump** — the FIRST non-tree class (so it is the tree-spacing fallback).
-/// A fan of tall thin green stalks leaning out, roughly half topped with a brown cattail
-/// seed head. Base at y=0, ~0.8–1.0u tall so it reads against the water. Two variants vary
-/// the stalk count / height.
+/// A fan of tall thin stalks rising out of a dark wet sheath, roughly half topped with a
+/// brown cattail seed head AND the pale flowering spike poking on above it, plus a few
+/// broad flattened leaf blades arcing out low. Base at y=0, ~0.8–1.0u tall so it reads
+/// against the water. Two variants vary the stalk count / height.
 fn build_reed_clump_mesh(variant: u32) -> Mesh {
     let count = if variant == 0 { 7 } else { 9 };
     let mut parts: Vec<Mesh> = Vec::new();
+    // Dark wet sheath where the clump rises out of the muck (baked waterline shadow).
+    parts.push(tinted(
+        Cone { radius: 0.10, height: 0.16 }.mesh().resolution(6).build().translated_by(y(0.08)),
+        lin_scaled(REED_STALK_DK, 0.65),
+    ));
     for i in 0..count {
         let a = (i as f32 / count as f32) * TAU;
         let foot = 0.11;
@@ -308,92 +426,160 @@ fn build_reed_clump_mesh(variant: u32) -> Mesh {
         let tilt = 0.05 + (i % 4) as f32 * 0.05;
         let foot_off = Vec3::new(bx, 0.0, bz);
         let lean = Quat::from_rotation_y(a) * Quat::from_rotation_z(tilt);
-        let stalk_c = if i % 2 == 0 { REED_STALK } else { REED_STALK_DK };
+        let stalk_c = if i % 2 == 0 { lin(REED_STALK) } else { lin(REED_STALK_DK) };
         // Slender flat-shaded cone leaning out: build upright, lean (Z) then yaw (Y), shift.
         let stalk = Cone { radius: 0.020, height: h }
             .mesh()
+            .resolution(5)
             .build()
             .translated_by(y(h / 2.0))
             .rotated_by(Quat::from_rotation_z(tilt))
             .rotated_by(Quat::from_rotation_y(a))
             .translated_by(foot_off);
-        parts.push(tinted(stalk, lin(stalk_c)));
+        parts.push(tinted(stalk, stalk_c));
 
-        // Half the stalks carry a brown cattail seed head near the leaned-out tip.
+        // Half the stalks carry a brown cattail seed head near the leaned-out tip, with
+        // the pale flowering spike continuing on above the sausage.
         if i % 2 == 0 {
-            let tip = lean * Vec3::new(0.0, h * 0.88, 0.0) + foot_off;
-            let head = Cylinder::new(0.034, 0.18)
+            let tip = lean * Vec3::new(0.0, h * 0.86, 0.0) + foot_off;
+            let head = Cylinder::new(0.034, 0.17)
                 .mesh()
-                .resolution(7)
+                .resolution(6)
                 .build()
                 .rotated_by(lean)
                 .translated_by(tip);
             parts.push(tinted(head, lin(CATTAIL_HEAD)));
+            let spike_at = lean * Vec3::new(0.0, h * 0.86 + 0.135, 0.0) + foot_off;
+            let spike = Cone { radius: 0.012, height: 0.10 }
+                .mesh()
+                .resolution(4)
+                .build()
+                .rotated_by(lean)
+                .translated_by(spike_at);
+            parts.push(tinted(spike, lin_scaled(REED_STALK, 1.25)));
         }
+    }
+    // Three broad leaf blades — flattened cones arcing out low, alternating dark / sunlit.
+    for i in 0..3 {
+        let a = (i as f32 / 3.0) * TAU + 0.8 + variant as f32 * 0.4;
+        let h = 0.46 + (i % 2) as f32 * 0.10;
+        let blade = Cone { radius: 0.055, height: h }
+            .mesh()
+            .resolution(4)
+            .build()
+            .scaled_by(Vec3::new(1.0, 1.0, 0.30)) // flatten the round cone into a blade
+            .translated_by(y(h * 0.5))
+            .rotated_by(Quat::from_rotation_z(0.38))
+            .rotated_by(Quat::from_rotation_y(a))
+            .translated_by(y(0.022)); // clear y=0: the tilted blade base dips ~r·sin(0.38)
+        let c = if i % 2 == 0 { lin(REED_STALK_DK) } else { lin_scaled(REED_STALK, 1.12) };
+        parts.push(tinted(blade, c));
     }
     flat_shaded(merged(parts))
 }
 
-/// **Swamp accents** — the small accent class. Variants: a cluster of dull toadstools, a
-/// mossy boulder with shelf-fungus brackets, and a tight toadstool trio. Base at y=0.
+/// **Swamp accents** — the small accent class. Variants: 0 = a toadstool cluster (baked
+/// gill shadows under the caps, sunlit crown bumps, pale flecks on the big cap); 1 = a
+/// mud-skirted mossy boulder with stepped shelf-fungus brackets and shed pebbles; 2 = a
+/// taller toadstool trio; 3 = a twisted half-sunken log (broken-end shards, snag
+/// branches, a moss saddle, one bracket). Base at y=0.
 fn build_accent_mesh(variant: u32) -> Mesh {
-    match variant % 3 {
-        // 0 — a loose cluster of dull swamp toadstools of mixed size.
+    match variant % 4 {
+        // 0 — a loose cluster of dull swamp toadstools of mixed size. Each cap is three
+        // tones: dark gill plate below, dull cap body, bright crown bump on top.
         0 => {
             let mut parts: Vec<Mesh> = Vec::new();
             let spots = [
                 (0.0_f32, 0.0_f32, 1.25_f32),
                 (0.13, 0.05, 0.9),
                 (-0.10, 0.08, 0.7),
-                (0.04, -0.12, 0.6),
+                (0.04, -0.12, 0.55),
             ];
-            for &(dx, dz, s) in &spots {
-                let stem_h = 0.11 * s;
+            for (i, &(dx, dz, s)) in spots.iter().enumerate() {
+                let stem_h = 0.12 * s;
                 let cap_r = 0.085 * s;
-                parts.push(
-                    cyl_up(0.03 * s, stem_h, stem_h * 0.5, 6, TOAD_STEM)
-                        .translated_by(Vec3::new(dx, 0.0, dz)),
-                );
-                parts.push(ball_at(cap_r, Vec3::new(dx, stem_h, dz), 0.6, TOAD_CAP));
+                let at = Vec3::new(dx, 0.0, dz);
+                parts.push(cyl_up(0.03 * s, stem_h, stem_h * 0.5, 6, lin(TOAD_STEM)).translated_by(at));
+                parts.push(ball_at(cap_r * 0.92, at + y(stem_h), 0.22, lin_scaled(TOAD_CAP, 0.55)));
+                parts.push(ball_at(cap_r, at + y(stem_h + 0.012), 0.6, lin(TOAD_CAP)));
+                parts.push(ball_at(cap_r * 0.45, at + y(stem_h + cap_r * 0.5), 0.5, lin_scaled(TOAD_CAP, 1.3)));
+                if i == 0 {
+                    // Pale flecks on the big cap.
+                    parts.push(ball_at(0.018, at + Vec3::new(cap_r * 0.5, stem_h + cap_r * 0.42, 0.02), 0.5, lin(TOAD_STEM)));
+                    parts.push(ball_at(0.014, at + Vec3::new(-cap_r * 0.4, stem_h + cap_r * 0.45, -cap_r * 0.3), 0.5, lin(TOAD_STEM)));
+                }
             }
             flat_shaded(merged(parts))
         }
-        // 1 — a mossy boulder with a couple of shelf-fungus brackets on its shaded side.
+        // 1 — a mossy boulder: dark mud skirt at the waterline, mid-tone body lumps, a
+        // bright moss cap, shelf-fungus brackets stepping up the shaded side, shed pebbles.
         1 => {
             let mut parts = vec![
-                ball_at(0.30, y(0.20), 0.82, SWAMP_ROCK),
-                ball_at(0.17, Vec3::new(0.22, 0.14, 0.06), 0.85, SWAMP_ROCK),
-                ball_at(0.14, Vec3::new(-0.18, 0.12, -0.10), 0.85, SWAMP_ROCK),
+                ball_at(0.33, y(0.10), 0.30, lin_scaled(SWAMP_ROCK, 0.62)),
+                ball_at(0.30, y(0.20), 0.82, lin(SWAMP_ROCK)),
+                ball_at(0.17, Vec3::new(0.23, 0.13, 0.06), 0.85, lin_scaled(SWAMP_ROCK, 0.9)),
+                ball_at(0.14, Vec3::new(-0.18, 0.12, -0.11), 0.85, lin_scaled(SWAMP_ROCK, 1.08)),
                 // Moss cap catching what little light there is.
-                ball_at(0.20, y(0.34), 0.55, SWAMP_ROCK_MOSS),
+                ball_at(0.20, y(0.36), 0.5, lin(SWAMP_ROCK_MOSS)),
+                ball_at(0.12, Vec3::new(0.08, 0.40, -0.06), 0.5, lin_scaled(SWAMP_ROCK_MOSS, 1.2)),
+                // A couple of pebbles shed at the foot.
+                ball_at(0.06, Vec3::new(0.34, 0.035, -0.16), 0.7, lin_scaled(SWAMP_ROCK, 0.85)),
+                ball_at(0.045, Vec3::new(-0.30, 0.03, 0.18), 0.7, lin(SWAMP_ROCK)),
             ];
-            // Two flat shelf-fungus brackets jutting off one side (squashed thin discs).
-            for &(hy, hr, dx) in &[(0.18_f32, 0.14_f32, 0.28_f32), (0.30, 0.10, 0.24)] {
-                let shelf = Cylinder::new(hr, 0.03)
-                    .mesh()
-                    .resolution(10)
-                    .build()
-                    .scaled_by(Vec3::new(1.0, 1.0, 0.6))
-                    .translated_by(Vec3::new(dx, hy, 0.0));
-                parts.push(tinted(shelf, lin(SHELF_FUNGUS)));
-            }
+            parts.extend(shelf_bracket(Vec3::new(0.27, 0.17, 0.02), 0.13, 0.15));
+            parts.extend(shelf_bracket(Vec3::new(0.25, 0.27, 0.05), 0.10, 0.3));
+            parts.extend(shelf_bracket(Vec3::new(-0.24, 0.22, -0.08), 0.09, PI * 0.5));
             flat_shaded(merged(parts))
         }
-        // 2 — a tight toadstool trio (taller, paler stems).
-        _ => {
+        // 2 — a tight toadstool trio (taller, paler stems, same three-tone caps).
+        2 => {
             let mut parts: Vec<Mesh> = Vec::new();
             for i in 0..3 {
                 let a = (i as f32 / 3.0) * TAU;
-                let dx = a.cos() * 0.07;
-                let dz = a.sin() * 0.07;
-                let s = 1.0 + (i % 2) as f32 * 0.3;
-                let stem_h = 0.13 * s;
-                parts.push(
-                    cyl_up(0.028 * s, stem_h, stem_h * 0.5, 6, TOAD_STEM)
-                        .translated_by(Vec3::new(dx, 0.0, dz)),
-                );
-                parts.push(ball_at(0.075 * s, Vec3::new(dx, stem_h, dz), 0.55, TOAD_CAP));
+                let at = Vec3::new(a.cos() * 0.08, 0.0, a.sin() * 0.08);
+                let s = 1.0 + (i % 2) as f32 * 0.35;
+                let stem_h = 0.15 * s;
+                parts.push(cyl_up(0.026 * s, stem_h, stem_h * 0.5, 6, lin(TOAD_STEM)).translated_by(at));
+                parts.push(ball_at(0.068 * s, at + y(stem_h), 0.2, lin_scaled(TOAD_CAP, 0.5)));
+                parts.push(ball_at(0.072 * s, at + y(stem_h + 0.01), 0.55, lin(TOAD_CAP)));
+                parts.push(ball_at(0.032 * s, at + y(stem_h + 0.045 * s), 0.5, lin_scaled(TOAD_CAP, 1.28)));
             }
+            flat_shaded(merged(parts))
+        }
+        // 3 — a twisted half-sunken log: a squashed dark drum lying with one end lifted
+        // out of the muck, jagged shards on the broken raised end, two snag branches, a
+        // bright moss saddle along its back and a shelf bracket on the flank.
+        _ => {
+            let mut parts: Vec<Mesh> = Vec::new();
+            let r = 0.13;
+            let len = 0.95;
+            let squash = 0.78;
+            let tilt = 0.10_f32; // raise the -Z (broken) end slightly out of the muck
+            let lift = r * squash + len * 0.5 * tilt.sin() + 0.005;
+            let log = Cylinder::new(r, len)
+                .mesh()
+                .resolution(7)
+                .build()
+                .rotated_by(Quat::from_rotation_x(FRAC_PI_2)) // lay the axis along Z
+                .scaled_by(Vec3::new(1.0, squash, 1.0)) // settle it into the mud
+                .rotated_by(Quat::from_rotation_x(tilt))
+                .translated_by(y(lift));
+            parts.push(tinted(log, lin_scaled(MANGROVE_BARK, 0.85)));
+            // Jagged shards fanning off the raised broken end.
+            let end = Quat::from_rotation_x(tilt) * Vec3::new(0.0, 0.0, -len * 0.5) + y(lift);
+            for i in 0..3 {
+                let a = (i as f32 / 3.0) * TAU + 0.4;
+                let sh = 0.10 + (i % 2) as f32 * 0.06;
+                parts.push(lean_cone(0.035, sh, 4, 0.9, a, end, lin(MANGROVE_BARK_DK)));
+            }
+            // Two dead snag branches reaching up off the log's back.
+            let back = lift + r * squash;
+            parts.push(lean_cone(0.028, 0.32, 4, 0.55, 1.8, Vec3::new(0.0, back - 0.02, -0.08), lin(MANGROVE_BARK_DK)));
+            parts.push(lean_cone(0.022, 0.22, 4, 0.85, 4.0, Vec3::new(0.0, back - 0.02, 0.16), lin(MANGROVE_BARK)));
+            // Moss saddle along the top — brighter than the mud-dark drum.
+            parts.push(ball_at(0.11, Vec3::new(0.0, back - 0.01, 0.05), 0.4, lin(STUMP_MOSS)));
+            parts.push(ball_at(0.08, Vec3::new(0.02, back, -0.18), 0.4, lin_scaled(STUMP_MOSS, 1.15)));
+            parts.extend(shelf_bracket(Vec3::new(0.12, lift, 0.10), 0.08, FRAC_PI_2));
             flat_shaded(merged(parts))
         }
     }
@@ -401,189 +587,292 @@ fn build_accent_mesh(variant: u32) -> Mesh {
 
 // ── Ground-cover builders (small, flat dressing) ─────────────────────────────────────
 
-/// A low moss patch — a clump of very squashed green balls hugging the ground (~0.06u).
+/// A low moss patch — squashed green lobes hugging the ground (~0.06u), edges scaled
+/// darker than the centre, with two bright sunlit tufts riding the crown.
 fn build_moss_patch_mesh() -> Mesh {
     let mut parts: Vec<Mesh> = Vec::new();
     let lobes = [
-        (0.0_f32, 0.0_f32, 0.13_f32),
-        (0.12, 0.04, 0.10),
-        (-0.10, 0.08, 0.09),
-        (0.05, -0.11, 0.08),
+        (0.0_f32, 0.0_f32, 0.13_f32, 1.0_f32), // (dx, dz, r, brightness)
+        (0.12, 0.04, 0.10, 0.85),
+        (-0.10, 0.08, 0.09, 0.9),
+        (0.05, -0.11, 0.08, 0.8),
+        (-0.06, -0.07, 0.07, 0.95),
     ];
-    for &(dx, dz, r) in &lobes {
-        parts.push(ball_at(r, Vec3::new(dx, 0.03, dz), 0.28, MOSS_PATCH));
+    for &(dx, dz, r, v) in &lobes {
+        parts.push(ball_at(r, Vec3::new(dx, 0.03, dz), 0.28, lin_scaled(MOSS_PATCH, v)));
     }
+    parts.push(ball_at(0.05, Vec3::new(0.02, 0.055, 0.01), 0.4, lin_scaled(MOSS_PATCH, 1.35)));
+    parts.push(ball_at(0.04, Vec3::new(0.11, 0.045, 0.05), 0.4, lin_scaled(MOSS_PATCH, 1.22)));
     flat_shaded(merged(parts))
 }
 
-/// A small reed sprig — 4 short blades fanned out, for sub-cell cover near the water.
+/// A small reed sprig — six short blades fanned out of a dark muck foot, with one
+/// near-upright centre stalk topped by a miniature cattail head.
 fn build_reed_sprig_mesh() -> Mesh {
     let mut parts: Vec<Mesh> = Vec::new();
-    for i in 0..4 {
-        let a = (i as f32 / 4.0) * TAU;
-        let h = 0.30 + (i % 2) as f32 * 0.08;
-        let blade = Cone { radius: 0.016, height: h }
+    parts.push(ball_at(0.045, y(0.012), 0.4, lin_scaled(REED_STALK_DK, 0.6)));
+    for i in 0..6 {
+        let a = (i as f32 / 6.0) * TAU;
+        let h = 0.26 + ((i * 5) % 3) as f32 * 0.07;
+        let blade = Cone { radius: 0.015, height: h }
             .mesh()
+            .resolution(4)
             .build()
-            .translated_by(y(h / 2.0))
-            .rotated_by(Quat::from_rotation_z(0.14))
+            .translated_by(y(h * 0.5 + 0.004))
+            .rotated_by(Quat::from_rotation_z(0.12 + (i % 3) as f32 * 0.06))
             .rotated_by(Quat::from_rotation_y(a));
-        let c = if i % 2 == 0 { REED_STALK } else { REED_STALK_DK };
-        parts.push(tinted(blade, lin(c)));
+        let c = if i % 2 == 0 { lin(REED_STALK) } else { lin(REED_STALK_DK) };
+        parts.push(tinted(blade, c));
     }
+    // The miniature cattail on the centre stalk.
+    let h = 0.40;
+    parts.push(tinted(
+        Cone { radius: 0.013, height: h }.mesh().resolution(4).build().translated_by(y(h * 0.5)),
+        lin(REED_STALK),
+    ));
+    parts.push(cyl_up(0.020, 0.085, h * 0.82, 5, lin(CATTAIL_HEAD)));
     flat_shaded(merged(parts))
 }
 
-/// A single small swamp mushroom (pale stem + dull brown cap), ~0.14u tall.
+/// A small swamp mushroom pair — a pale stem under a three-tone cap (dark gill plate /
+/// dull body / bright crown bump) with a tiny button mushroom at its foot, ~0.14u tall.
 fn build_swamp_mushroom_mesh() -> Mesh {
     let stem_h = 0.09;
     flat_shaded(merged(vec![
-        cyl_up(0.026, stem_h, stem_h * 0.5, 6, TOAD_STEM),
-        ball_at(0.07, y(stem_h), 0.55, TOAD_CAP),
+        cyl_up(0.026, stem_h, stem_h * 0.5, 6, lin(TOAD_STEM)),
+        ball_at(0.064, y(stem_h), 0.22, lin_scaled(TOAD_CAP, 0.55)),
+        ball_at(0.07, y(stem_h + 0.008), 0.55, lin(TOAD_CAP)),
+        ball_at(0.03, y(stem_h + 0.035), 0.5, lin_scaled(TOAD_CAP, 1.3)),
+        // The tiny button at its foot.
+        cyl_up(0.014, 0.045, 0.0225, 5, lin(TOAD_STEM)).translated_by(Vec3::new(0.07, 0.0, 0.03)),
+        ball_at(0.032, Vec3::new(0.07, 0.05, 0.03), 0.6, lin_scaled(TOAD_CAP, 0.9)),
     ]))
 }
 
-/// **Swamp ground accent** (cover). `variant`: 0 = bog cotton (green stems topped with
-/// fluffy white heads), 1 = a pale lilac marsh flower (petal ring + gold core). The soft
-/// pale touches that lift the murky floor. Base at y=0, ~0.14–0.24u tall.
+/// **Swamp ground accent** (cover). `variant`: 0 = bog cotton (green stems each topped
+/// with a two-blob fluffy head — shaded core under a bright crown — over a dark muck
+/// tuft), 1 = a pale lilac marsh flower (petal ring + gold core + two leaf blades). The
+/// soft pale touches that lift the murky floor. Base at y=0, ~0.14–0.24u tall.
 fn build_swamp_cover_extra_mesh(variant: u32) -> Mesh {
     match variant % 2 {
-        // Bog cotton — three green stems each tipped with a fluffy white head.
+        // Bog cotton — three stems out of a dark tuft, fluffy two-tone heads on top.
         0 => {
-            let mut parts: Vec<Mesh> = Vec::new();
+            let mut parts: Vec<Mesh> = vec![ball_at(0.035, y(0.01), 0.4, lin_scaled(REED_STALK_DK, 0.7))];
             for i in 0..3 {
                 let a = (i as f32 / 3.0) * TAU;
-                let (bx, bz) = (a.cos() * 0.04, a.sin() * 0.04);
-                let h = 0.18 + (i % 2) as f32 * 0.05;
-                parts.push(cyl_up(0.010, h, h * 0.5, 5, REED_STALK).translated_by(Vec3::new(bx, 0.0, bz)));
-                parts.push(ball_at(0.04, Vec3::new(bx, h, bz), 0.85, BOG_COTTON));
+                let (bx, bz) = (a.cos() * 0.045, a.sin() * 0.045);
+                let h = 0.17 + (i % 2) as f32 * 0.06;
+                parts.push(cyl_up(0.009, h, h * 0.5, 4, lin(REED_STALK)).translated_by(Vec3::new(bx, 0.0, bz)));
+                parts.push(ball_at(0.038, Vec3::new(bx, h, bz), 0.85, lin_scaled(BOG_COTTON, 0.92)));
+                parts.push(ball_at(0.026, Vec3::new(bx, h + 0.028, bz), 0.8, lin(BOG_COTTON)));
             }
             flat_shaded(merged(parts))
         }
-        // Pale lilac marsh flower — a slim stem, gold core, ring of pale petals.
+        // Pale lilac marsh flower — slim stem, two leaf blades, gold core, petal ring.
         _ => {
-            let head_y = 0.14;
+            let head_y = 0.15;
             let mut parts = vec![
                 tinted(
-                    Cone { radius: 0.009, height: head_y }.mesh().build().translated_by(y(head_y * 0.5)),
+                    Cone { radius: 0.009, height: head_y }.mesh().resolution(4).build().translated_by(y(head_y * 0.5)),
                     lin(REED_STALK_DK),
                 ),
-                ball_at(0.016, y(head_y), 0.7, SWAMP_FLOWER_CORE),
+                ball_at(0.017, y(head_y + 0.004), 0.7, lin(SWAMP_FLOWER_CORE)),
             ];
+            for &(a, lh) in &[(0.9_f32, 0.09_f32), (3.8, 0.07)] {
+                parts.push(lean_cone(0.012, lh, 4, 0.7, a, y(0.012), lin(REED_STALK_DK)));
+            }
             for i in 0..5 {
                 let a = (i as f32 / 5.0) * TAU;
-                parts.push(ball_at(0.026, Vec3::new(a.cos() * 0.038, head_y, a.sin() * 0.038), 0.5, SWAMP_FLOWER));
+                parts.push(ball_at(0.027, Vec3::new(a.cos() * 0.04, head_y, a.sin() * 0.04), 0.45, lin(SWAMP_FLOWER)));
             }
             flat_shaded(merged(parts))
         }
     }
 }
 
-/// A flat lily-pad-ish disc — a darker rim under a green top, lying flat on the muck.
-/// The `Circle` mesh lies in the XY plane (normal +Z); rotate −90° about X to lie flat.
-fn build_lily_disc_mesh() -> Mesh {
+/// A lily-pad drift — each pad is a darker rim disc under a green top, lying flat on the
+/// muck (the `Circle` mesh lies in the XY plane, normal +Z; rotate −90° about X to lie
+/// flat). `variant`: 0 = a big pad with two satellites and a pale-pink closed lotus bud
+/// (gold heart wrapped in petal blobs); 1 = a plain drift of three mixed-size pads.
+fn build_lily_disc_mesh(variant: u32) -> Mesh {
     let flat = |m: Mesh| -> Mesh { m.rotated_by(Quat::from_rotation_x(-FRAC_PI_2)) };
-    let pad_r = 0.24;
-    flat_shaded(merged(vec![
-        tinted(
-            flat(Circle::new(pad_r).mesh().resolution(12).build()).translated_by(y(0.004)),
-            lin(LILY_PAD_EDGE),
-        ),
-        tinted(
-            flat(Circle::new(pad_r * 0.88).mesh().resolution(12).build()).translated_by(y(0.012)),
-            lin(LILY_PAD),
-        ),
-    ]))
+    let pad = |at: Vec3, r: f32| -> [Mesh; 2] {
+        [
+            tinted(
+                flat(Circle::new(r).mesh().resolution(10).build()).translated_by(at + y(0.004)),
+                lin(LILY_PAD_EDGE),
+            ),
+            tinted(
+                flat(Circle::new(r * 0.86).mesh().resolution(10).build()).translated_by(at + y(0.012)),
+                lin(LILY_PAD),
+            ),
+        ]
+    };
+    let mut parts: Vec<Mesh> = Vec::new();
+    match variant % 2 {
+        0 => {
+            parts.extend(pad(Vec3::ZERO, 0.24));
+            parts.extend(pad(Vec3::new(0.30, 0.0, 0.12), 0.13));
+            parts.extend(pad(Vec3::new(-0.20, 0.0, -0.22), 0.10));
+            // The closed lotus bud riding the big pad.
+            let bud = Vec3::new(0.06, 0.02, -0.04);
+            parts.push(ball_at(0.030, bud + y(0.035), 1.3, lin(SWAMP_FLOWER_CORE)));
+            for i in 0..4 {
+                let a = (i as f32 / 4.0) * TAU + 0.4;
+                parts.push(ball_at(0.030, bud + Vec3::new(a.cos() * 0.030, 0.030, a.sin() * 0.030), 1.15, lin(LILY_BLOOM)));
+            }
+        }
+        _ => {
+            parts.extend(pad(Vec3::ZERO, 0.20));
+            parts.extend(pad(Vec3::new(0.26, 0.0, -0.10), 0.14));
+            parts.extend(pad(Vec3::new(-0.14, 0.0, 0.24), 0.11));
+        }
+    }
+    flat_shaded(merged(parts))
 }
 
-/// **Big hollow dead swamp tree** (landmark) — a wide hollow trunk (an arc of thick bark
-/// slabs leaving a dark gap), a jagged broken top, a couple of stubbed limbs and moss.
-/// Base at y=0, ~3u tall, authored at full scale (the landmark spawns it un-scaled).
+/// **Big hollow dead swamp tree** (landmark) — five bark slabs bowed around the trunk
+/// axis leaving a dark gap (the hollow), each split at the waterline into a mud-stained
+/// dark lower block under a paler upper; a dark rotten heartwood column shows through the
+/// gap. Buttress fins + a flared mossy base root it in the muck, a jagged two-tone broken
+/// top crowns it, and two stubbed limbs drip hanging-moss strands. Shelf-fungus brackets
+/// step up the shaded flank under clinging moss. Base at y=0, ~3u tall, authored at full
+/// scale (the landmark spawns it un-scaled).
 fn build_hollow_dead_tree_mesh() -> Mesh {
     let mut parts: Vec<Mesh> = Vec::new();
     let trunk_h = 2.6;
     let radius = 0.55;
-    // Four thick bark slabs bowed around the trunk axis, leaving a gap (the hollow).
+    // Five bark slabs around the trunk ring, leaving a gap (the hollow). Lower blocks are
+    // mud-dark (waterline stain), uppers alternate two paler bark tones.
     let slabs = [
         (0.9_f32, 1.0_f32), // (yaw centre, width factor)
-        (2.3, 0.9),
-        (3.9, 1.0),
-        (5.0, 0.8),
+        (2.1, 0.85),
+        (3.2, 1.0),
+        (4.3, 0.8),
+        (5.2, 0.9),
     ];
-    for &(yaw, wf) in &slabs {
-        let slab = Cuboid::new(0.34 * wf, trunk_h, 0.30)
+    for (i, &(yaw, wf)) in slabs.iter().enumerate() {
+        let low_h = 0.8;
+        let lower = Cuboid::new(0.34 * wf, low_h, 0.30)
             .mesh()
             .build()
-            .translated_by(y(trunk_h * 0.5))
+            .translated_by(y(low_h * 0.5))
             .translated_by(Vec3::new(0.0, 0.0, radius)) // push out onto the trunk ring
             .rotated_by(Quat::from_rotation_y(yaw));
-        parts.push(tinted(slab, lin(MANGROVE_BARK)));
+        parts.push(tinted(lower, lin_scaled(MANGROVE_BARK, 0.72)));
+        let up_h = trunk_h - low_h;
+        let bright = if i % 2 == 0 { 1.0 } else { 1.12 };
+        let upper = Cuboid::new(0.30 * wf, up_h, 0.26)
+            .mesh()
+            .build()
+            .translated_by(y(low_h + up_h * 0.5))
+            .translated_by(Vec3::new(0.0, 0.0, radius + 0.02))
+            .rotated_by(Quat::from_rotation_y(yaw));
+        parts.push(tinted(upper, lin_scaled(MANGROVE_BARK, bright)));
     }
-    // Flared mossy base so it sits in the muck convincingly.
-    parts.push(ball_at(radius * 1.4, y(0.18), 0.4, MANGROVE_ROOT));
-    parts.push(ball_at(radius * 1.1, Vec3::new(radius, 0.16, radius * 0.4), 0.5, MANGROVE_ROOT));
+    // The dark rotten heartwood column showing through the hollow gap (inset, sub-rim).
+    parts.push(cyl_up(0.34, trunk_h * 0.92, trunk_h * 0.46, 7, lin_scaled(STUMP_TOP, 0.40)));
+    // Buttress fins leaning back into the trunk + a flared mossy base, all mud-dark.
+    for i in 0..4 {
+        let a = (i as f32 / 4.0) * TAU + 0.6;
+        let foot = Vec3::new(a.cos() * (radius + 0.25), 0.0, a.sin() * (radius + 0.25));
+        parts.push(lean_cone(0.16, 0.85, 5, 0.42, -a, foot, lin_scaled(MANGROVE_ROOT, 0.85)));
+    }
+    // (flare squash kept shallow so the blob bottoms rest AT y=0 — r·squash ≤ centre y)
+    parts.push(ball_at(radius * 1.45, y(0.16), 0.20, lin_scaled(MANGROVE_ROOT, 0.8)));
+    parts.push(ball_at(radius * 1.05, Vec3::new(radius, 0.15, radius * 0.4), 0.26, lin_scaled(MANGROVE_ROOT, 0.9)));
 
-    // Jagged broken top — tall thin shards of differing height around the rim.
-    for i in 0..5 {
-        let a = (i as f32 / 5.0) * TAU + 0.5;
-        let sh = 0.5 + (i % 3) as f32 * 0.35;
-        let shard = Cone { radius: 0.18, height: sh }
+    // Jagged broken top — shards of differing height around the rim, alternating shadowed
+    // and sun-bleached tones.
+    for i in 0..6 {
+        let a = (i as f32 / 6.0) * TAU + 0.5;
+        let sh = 0.45 + ((i * 7) % 4) as f32 * 0.28;
+        let c = if i % 2 == 0 { lin(MANGROVE_BARK_DK) } else { lin_scaled(MANGROVE_BARK, 1.18) };
+        let shard = Cone { radius: 0.16, height: sh }
             .mesh()
             .resolution(5)
             .build()
             .translated_by(y(sh * 0.5))
-            .translated_by(Vec3::new(a.cos() * radius * 0.7, trunk_h, a.sin() * radius * 0.7));
-        parts.push(tinted(shard, lin(MANGROVE_BARK_DK)));
+            .translated_by(Vec3::new(a.cos() * radius * 0.72, trunk_h, a.sin() * radius * 0.72));
+        parts.push(tinted(shard, c));
     }
-    // Two stubbed broken limbs jutting out partway up.
+    // Two stubbed broken limbs jutting out partway up, each dripping two moss strands
+    // (down-cones + wispy tip blobs) — the landmark-scale echo of the mangrove moss.
     for &(yaw, hgt, len) in &[(0.6_f32, 1.7_f32, 0.9_f32), (3.6, 2.0, 0.7)] {
-        let limb = Cylinder::new(0.10, len)
+        let tiltq = Quat::from_rotation_z(FRAC_PI_2 - 0.3);
+        let spin = Quat::from_rotation_y(yaw);
+        let limb = Cylinder::new(0.09, len)
             .mesh()
             .resolution(5)
             .build()
             .translated_by(y(len * 0.5))
-            .rotated_by(Quat::from_rotation_z(FRAC_PI_2 - 0.3))
-            .rotated_by(Quat::from_rotation_y(yaw))
+            .rotated_by(tiltq)
+            .rotated_by(spin)
             .translated_by(y(hgt));
         parts.push(tinted(limb, lin(MANGROVE_BARK)));
+        for &(t, hang) in &[(1.0_f32, 0.6_f32), (0.55, 0.42)] {
+            let at = spin * (tiltq * Vec3::new(0.0, len * t, 0.0)) + y(hgt);
+            let c = if t > 0.9 { lin(HANGING_MOSS) } else { lin_scaled(HANGING_MOSS, 0.8) };
+            let strand = Cone { radius: 0.045, height: hang }
+                .mesh()
+                .resolution(4)
+                .build()
+                .translated_by(y(hang * 0.5))
+                .rotated_by(Quat::from_rotation_x(PI))
+                .translated_by(at);
+            parts.push(tinted(strand, c));
+            parts.push(ball_at(0.09, at - y(hang), 0.55, c));
+        }
     }
-    // Moss clinging up one side.
-    parts.push(ball_at(0.32, Vec3::new(-radius * 0.6, 1.0, radius * 0.3), 0.7, STUMP_MOSS));
-    parts.push(ball_at(0.24, Vec3::new(-radius * 0.5, 1.8, radius * 0.2), 0.7, STUMP_MOSS));
+    // Shelf-fungus brackets stepping up the shaded flank, moss clinging above them.
+    parts.extend(shelf_bracket(Vec3::new(-radius - 0.10, 0.6, radius * 0.25), 0.20, 2.6));
+    parts.extend(shelf_bracket(Vec3::new(-radius - 0.06, 1.0, radius * 0.30), 0.16, 2.8));
+    parts.extend(shelf_bracket(Vec3::new(-radius - 0.02, 1.35, radius * 0.22), 0.12, 2.4));
+    parts.push(ball_at(0.30, Vec3::new(-radius * 0.62, 1.7, radius * 0.3), 0.65, lin(STUMP_MOSS)));
+    parts.push(ball_at(0.22, Vec3::new(-radius * 0.5, 2.15, radius * 0.2), 0.65, lin_scaled(STUMP_MOSS, 1.15)));
 
     flat_shaded(merged(parts))
 }
 
 // ── Glowing mushroom cluster (a swamp landmark accent, split by material) ─────────────
 //
-// A cluster of 5 mushrooms of mixed size. The STEMS are a separate pale vertex-coloured
+// A cluster of 6 mushrooms of mixed size. The STEMS are a separate pale vertex-coloured
 // mesh (rides the shared white mat); the CAPS are a separate mesh carrying NO colour
 // attribute, so an emissive glow material lights them up and feeds bloom. The two meshes
 // share `GLOWMUSH_SPOTS`, so a cap sits exactly atop each stem when spawned at one
 // transform. Base flush at y=0.
 
-/// Pale stems for the glowmush cluster (shared white vertex-colour mat).
+/// Pale stems for the glowmush cluster (shared white vertex-colour mat): each stem wears
+/// a slightly darker collar ring just under its cap (baked under-cap shadow), and the
+/// bigger stems get a damp moss tuft at the foot.
 fn build_glowmush_stems_mesh() -> Mesh {
     let mut parts: Vec<Mesh> = Vec::new();
     for &(dx, dz, s) in &GLOWMUSH_SPOTS {
         let sh = 0.14 * s;
-        parts.push(cyl_up(0.03 * s, sh, sh * 0.5, 6, GLOWMUSH_STEM).translated_by(Vec3::new(dx, 0.0, dz)));
+        let at = Vec3::new(dx, 0.0, dz);
+        parts.push(cyl_up(0.03 * s, sh, sh * 0.5, 6, lin(GLOWMUSH_STEM)).translated_by(at));
+        parts.push(cyl_up(0.042 * s, 0.02, sh - 0.016, 6, lin_scaled(GLOWMUSH_STEM, 0.72)).translated_by(at));
+        if s >= 0.85 {
+            parts.push(ball_at(0.05 * s, at + Vec3::new(0.035, 0.024, -0.02), 0.35, lin_scaled(MOSS_PATCH, 0.9)));
+        }
     }
     flat_shaded(merged(parts))
 }
 
 /// Glowing caps for the glowmush cluster — domed squashed blobs with NO colour attribute
-/// (the emissive material owns the colour). Built to match the stem layout/heights.
+/// (the emissive material owns the colour). Big caps use ico-1 for a rounder dome, the
+/// small ones stay chunky ico-0. Built to match the stem layout/heights.
 fn build_glowmush_caps_mesh() -> Mesh {
     let mut parts: Vec<Mesh> = Vec::new();
     for &(dx, dz, s) in &GLOWMUSH_SPOTS {
         let sh = 0.14 * s;
+        let detail = if s >= 1.0 { 1 } else { 0 };
         parts.push(
             Sphere::new(0.085 * s)
                 .mesh()
-                .ico(0)
+                .ico(detail)
                 .expect("ico detail in range")
-                .scaled_by(Vec3::new(1.0, 0.6, 1.0))
+                .scaled_by(Vec3::new(1.0, 0.62, 1.0))
                 .translated_by(Vec3::new(dx, sh, dz)),
         );
     }
@@ -631,12 +920,14 @@ pub fn config() -> BiomeConfig {
         seed: 5005,
         tree_min_dist: 2.6,
         classes: vec![
-            // Trees: 70% gnarled mangrove (2 variants) / 30% cypress-knee stump.
+            // Trees: 70% gnarled mangrove (3 variants) / 30% cypress stump (2 variants).
             PropClass {
                 variants: vec![
-                    (build_mangrove_mesh(0), 0.42),
-                    (build_mangrove_mesh(1), 0.28),
-                    (build_cypress_stump_mesh(), 0.30),
+                    (build_mangrove_mesh(0), 0.28),
+                    (build_mangrove_mesh(1), 0.22),
+                    (build_mangrove_mesh(2), 0.20),
+                    (build_cypress_stump_mesh(0), 0.18),
+                    (build_cypress_stump_mesh(1), 0.12),
                 ],
                 chance: 0.085,
                 scale: (0.85 * TREE_SCALE, 1.25 * TREE_SCALE),
@@ -654,9 +945,9 @@ pub fn config() -> BiomeConfig {
                 tree: false,
                 block_radius: 0.0,
             },
-            // Toadstools / shelf fungus / mossy rock accents.
+            // Toadstools / mossy rock / toadstool trio / half-sunken log accents.
             PropClass {
-                variants: (0..3).map(|v| (build_accent_mesh(v), 1.0)).collect(),
+                variants: (0..4).map(|v| (build_accent_mesh(v), 1.0)).collect(),
                 chance: 0.04,
                 scale: (0.7, 1.5),
                 tree: false,
@@ -685,8 +976,12 @@ pub fn config() -> BiomeConfig {
                 tree: false,
                 block_radius: 0.0,
             },
+            // Lily-pad drifts — one in two carries the pale lotus bud.
             PropClass {
-                variants: vec![(build_lily_disc_mesh(), 1.0)],
+                variants: vec![
+                    (build_lily_disc_mesh(0), 1.0),
+                    (build_lily_disc_mesh(1), 1.0),
+                ],
                 chance: 0.10,
                 scale: (0.7, 1.3),
                 tree: false,

--- a/src/castle.rs
+++ b/src/castle.rs
@@ -312,28 +312,45 @@ fn tex_soil(hex: u32) -> Image {
 }
 
 /// Packed earth — the bare courtyard "klepisko" the young settlement stands on before the walls
-/// are raised. Trodden flat (no furrows — that's tilled `tex_soil`): broad damp/dry mottling plus
-/// sparse trodden-in pebbles, so it reads as a real, walked-over dirt yard rather than flat brown.
+/// are raised. Trodden flat (no furrows — that's tilled `tex_soil`): big SOFT damp/dry mottling
+/// (overlapping low-alpha discs, no hard rectangles — those read as a repeating grid once tiled),
+/// faint surviving grass flecks trodden into the dirt, and a few small pebbles. Deliberately low
+/// contrast: the worn-ground feel comes from broad value drift, not busy noise.
 fn tex_packed(hex: u32) -> Image {
     let c = rgb(hex);
     let mut cv = Canvas::new(shade(c, 0.0));
     let mut r = Rng(0x9e3 ^ hex);
-    // Broad mottled patches (damp vs sun-dried earth).
+    // Broad soft mottled patches (damp vs sun-dried earth) — large overlapping discs at low
+    // alpha so tones flow into each other instead of tiling as visible blocks.
+    for _ in 0..46 {
+        let x = r.f() * TN as f32;
+        let y = r.f() * TN as f32;
+        let rad = 7.0 + r.f() * 18.0;
+        cv.disc(x, y, rad, shade(c, (r.f() - 0.5) * 0.13), 0.22 + r.f() * 0.16);
+    }
+    // Trodden-in grass remnants — small muted green-tan flecks where the lawn survives the
+    // foot traffic ("przebłyski trawy"), denser as soft discs + a few single-pixel blades.
+    let grass = [c[0] * 0.78 + 18.0, c[1] * 0.9 + 42.0, c[2] * 0.75];
+    for _ in 0..26 {
+        let x = r.f() * TN as f32;
+        let y = r.f() * TN as f32;
+        cv.disc(x, y, 1.0 + r.f() * 2.2, shade(grass, (r.f() - 0.4) * 0.12), 0.4 + r.f() * 0.3);
+    }
     for _ in 0..70 {
+        let x = (r.f() * TN as f32).floor();
+        let y = (r.f() * TN as f32).floor();
+        cv.rect(x, y, 1.0, 1.0 + r.f() * 2.0, shade(grass, (r.f() - 0.3) * 0.15));
+    }
+    // Sparse trodden-in pebbles (a light stone over its own little shadow) — fewer + smaller
+    // than before so they read as grit, not confetti.
+    for _ in 0..40 {
         let x = r.f() * TN as f32;
         let y = r.f() * TN as f32;
-        let (w, h) = (6.0 + r.f() * 22.0, 6.0 + r.f() * 22.0);
-        cv.rect(x, y, w, h, shade(c, (r.f() - 0.5) * 0.16));
+        let s = 1.0 + r.f() * 1.6;
+        cv.rect(x, y + s, s, s * 0.5, shade(c, -0.12)); // contact shadow
+        cv.rect(x, y, s, s, shade(c, 0.10 + r.f() * 0.10)); // pebble
     }
-    // Sparse trodden-in pebbles (a light stone over its own little shadow).
-    for _ in 0..90 {
-        let x = r.f() * TN as f32;
-        let y = r.f() * TN as f32;
-        let s = 1.5 + r.f() * 2.0;
-        cv.rect(x, y + s, s, s * 0.5, shade(c, -0.14)); // contact shadow
-        cv.rect(x, y, s, s, shade(c, 0.14 + r.f() * 0.12)); // pebble
-    }
-    speckle(&mut cv, &mut r, 600, c);
+    speckle(&mut cv, &mut r, 450, c);
     cv.into_image()
 }
 
@@ -365,8 +382,24 @@ fn build_mats(images: &mut Assets<Image>, std_mats: &mut Assets<StandardMaterial
     tex(tex_shingle(ROOF), 0.85, M::Roof);
     tex(tex_shingle(H_ROOF), 0.85, M::HouseRoof);
     tex(tex_soil(SOIL), 1.0, M::Soil);
-    tex(tex_cobble(COBBLE), 0.95, M::Cobble);
-    tex(tex_packed(PACKED), 1.0, M::Packed);
+
+    // Yard grounds (Packed klepisko / Cobble courtyard) alpha-blend: their `worn_slab`
+    // mesh fades vertex alpha across a noisy rim band, so the surface dissolves
+    // irregularly into the lawn instead of ending on a hard rectangle edge.
+    let mut ground_tex = |img: Image, rough: f32, m: M| {
+        let t = images.add(img);
+        h.insert(m as u8, std_mats.add(StandardMaterial {
+            base_color: Color::WHITE,
+            base_color_texture: Some(t),
+            perceptual_roughness: rough,
+            alpha_mode: AlphaMode::Blend,
+            cull_mode: None,
+            double_sided: true,
+            ..default()
+        }));
+    };
+    ground_tex(tex_cobble(COBBLE), 0.95, M::Cobble);
+    ground_tex(tex_packed(PACKED), 1.0, M::Packed);
 
     let mut solid = |hex: u32, rough: f32, metal: f32, m: M| {
         h.insert(m as u8, std_mats.add(StandardMaterial {
@@ -495,7 +528,72 @@ pub(crate) fn gable(span_x: f32, span_z: f32, rise: f32, base_y: f32) -> Mesh {
     flat(m)
 }
 
+/// Smooth low-frequency field used to fray the yard rim and drift its brightness —
+/// a few sin octaves (≈1–3-unit features), cheap and seamless in world space.
+fn wear_noise(x: f32, z: f32) -> f32 {
+    (x * 1.31 + 1.7).sin() * (z * 1.13 - 2.3).cos()
+        + (x * 0.53 + z * 0.61 + 4.5).sin() * 0.6
+        + (x * 2.70 - z * 2.20 + 0.8).sin() * 0.25
+}
+
+/// The yard ground sheet — a vertex grid whose rim ALPHA-fades into the grass over a noisy
+/// `fray`-wide wear band (trodden fingers of dirt reach into the lawn and grass bites back
+/// into the yard — no hard rectangle edge), and whose interior carries a low-frequency
+/// brightness mottle in the vertex colour so the tiling texture stops reading as a grid.
+/// Drawn with the alpha-blended ground materials (see `build_mats`). `noise_amp` scales how
+/// ragged the rim is; `mottle` the interior value drift.
+fn worn_slab(w: f32, d: f32, y: f32, fray: f32, noise_amp: f32, mottle: f32) -> Mesh {
+    let hw = w / 2.0 + fray;
+    let hd = d / 2.0 + fray;
+    let step = 0.5_f32;
+    let nx = (2.0 * hw / step).ceil() as usize;
+    let nz = (2.0 * hd / step).ceil() as usize;
+    let mut pos: Vec<[f32; 3]> = Vec::with_capacity((nx + 1) * (nz + 1));
+    let mut nrm: Vec<[f32; 3]> = Vec::with_capacity(pos.capacity());
+    let mut uv: Vec<[f32; 2]> = Vec::with_capacity(pos.capacity());
+    let mut col: Vec<[f32; 4]> = Vec::with_capacity(pos.capacity());
+    for iz in 0..=nz {
+        for ix in 0..=nx {
+            // Spread the grid exactly across [-hw, hw] (no clamped duplicate columns).
+            let x = -hw + 2.0 * hw * ix as f32 / nx as f32;
+            let z = -hd + 2.0 * hd * iz as f32 / nz as f32;
+            // Distance inside the OUTER rect; the wear band spans ~2×fray of it.
+            let d_in = (hw - x.abs()).min(hd - z.abs());
+            let t = d_in / (fray * 2.0) + wear_noise(x, z) * noise_amp - 0.5 * noise_amp;
+            let mut a = (t.clamp(0.0, 1.0) * t.clamp(0.0, 1.0) * (3.0 - 2.0 * t.clamp(0.0, 1.0))).clamp(0.0, 1.0);
+            // Guarantee full transparency AT the mesh edge (noise can't push it back up).
+            a *= (d_in / 0.8).clamp(0.0, 1.0);
+            // Low-frequency brightness drift breaks the texture's tile repetition.
+            let b = 1.0
+                + mottle * (x * 0.37 + 1.1).sin() * (z * 0.41 - 0.6).cos()
+                + mottle * 0.7 * (x * 0.13 - z * 0.17 + 2.0).sin();
+            pos.push([x, y, z]);
+            nrm.push([0.0, 1.0, 0.0]);
+            uv.push([x / TILE, z / TILE]);
+            col.push([b, b, b, a]);
+        }
+    }
+    let mut idx: Vec<u32> = Vec::with_capacity(nx * nz * 6);
+    let row = (nx + 1) as u32;
+    for iz in 0..nz as u32 {
+        for ix in 0..nx as u32 {
+            let i0 = iz * row + ix;
+            let (i1, i2, i3) = (i0 + 1, i0 + row + 1, i0 + row);
+            // Same up-facing winding as `slab`.
+            idx.extend_from_slice(&[i0, i2, i1, i0, i3, i2]);
+        }
+    }
+    let mut m = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
+    m.insert_attribute(Mesh::ATTRIBUTE_POSITION, pos);
+    m.insert_attribute(Mesh::ATTRIBUTE_NORMAL, nrm);
+    m.insert_attribute(Mesh::ATTRIBUTE_UV_0, uv);
+    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, col);
+    m.insert_indices(Indices::U32(idx));
+    m
+}
+
 /// A flat upward-facing slab quad at height `y` (cobble courtyard), UV tiled.
+#[allow(dead_code)] // superseded by `worn_slab` for the yard; kept for flat textured sheets
 fn slab(w: f32, d: f32, y: f32) -> Mesh {
     let (hw, hd) = (w / 2.0, d / 2.0);
     let pos = vec![[-hw, y, -hd], [hw, y, -hd], [hw, y, hd], [-hw, y, hd]];
@@ -908,17 +1006,20 @@ pub fn build(
     };
 
     // Ground: a bare packed-earth yard ("klepisko") while the keep stands wall-less, swapped for the
-    // cobbled courtyard the moment the Palisade Walls go up. The two slabs share the footprint but
-    // are mutually exclusive (PreWalls vs Walls), so they never z-fight.
+    // cobbled courtyard the moment the Palisade Walls go up. The two sheets share the footprint but
+    // are mutually exclusive (PreWalls vs Walls), so they never z-fight. Both are `worn_slab`s —
+    // their rims alpha-dissolve into the lawn instead of cutting a hard rectangle: the bare yard
+    // gets a wide ragged wear band (trodden earth fading out where feet stop passing), the cobbled
+    // court a tighter fringe (built paving, but its edge stones still sink into the turf).
     spawn(
-        vec![(slab((HALF_X - 0.3) * 2.0, (HALF_Z - 0.3) * 2.0, 0.02), M::Packed)],
+        vec![(worn_slab((HALF_X - 1.2) * 2.0, (HALF_Z - 1.2) * 2.0, 0.02, 2.6, 0.38, 0.06), M::Packed)],
         Vec3::ZERO,
         0.0,
         Vec3::ONE,
         CastleKind::PreWalls,
     );
     spawn(
-        vec![(slab((HALF_X - 0.3) * 2.0, (HALF_Z - 0.3) * 2.0, 0.02), M::Cobble)],
+        vec![(worn_slab((HALF_X - 0.9) * 2.0, (HALF_Z - 0.9) * 2.0, 0.02, 1.0, 0.16, 0.035), M::Cobble)],
         Vec3::ZERO,
         0.0,
         Vec3::ONE,
@@ -960,6 +1061,65 @@ pub fn build(
     spawn(hay_corner_parts(), Vec3::new(10.0, 0.0, 6.0), -0.5, Vec3::ONE, CastleKind::PreWalls);
     spawn(cart_corner_parts(), Vec3::new(-10.0, 0.0, -6.0), 2.3, Vec3::ONE, CastleKind::PreWalls);
     spawn(well_parts(), Vec3::new(10.0, 0.0, -6.0), 0.4, Vec3::ONE, CastleKind::PreWalls);
+
+    // Grass biting back through the yard rim — sparse tufts + clover scattered over the wear
+    // band (and a few worn survivor patches inside the yard) so the trodden earth reads as
+    // walked-over lawn, not a stamped-out shape. PreWalls: the cobbled court replaces them.
+    {
+        let cover_mat = std_mats.add(StandardMaterial {
+            base_color: Color::WHITE, // vertex colour carries the hue (groundcover contract)
+            perceptual_roughness: 0.62,
+            reflectance: 0.5,
+            ..default()
+        });
+        let tuft = meshes.add(crate::groundcover::build_grass_tuft_mesh());
+        let clover = meshes.add(crate::groundcover::build_clover_mesh());
+        let mut r = Rng(0x9ea5);
+        let sprig = |x: f32, z: f32, mesh: &Handle<Mesh>, s: f32, r: &mut Rng, commands: &mut Commands| {
+            commands.spawn((
+                Mesh3d(mesh.clone()),
+                MeshMaterial3d(cover_mat.clone()),
+                Transform {
+                    translation: Vec3::new(x, 0.02, z),
+                    rotation: Quat::from_rotation_y(r.f() * std::f32::consts::TAU),
+                    scale: Vec3::splat(s),
+                },
+                bevy::light::NotShadowCaster,
+                CastlePart { kind: CastleKind::PreWalls },
+                BiomeEntity,
+            ));
+        };
+        // Rim band: walk the yard perimeter, jittering across the fray band; skip the four
+        // gate lanes (the approach roads keep their trodden-bare mouths).
+        let (bx_, bz_) = (HALF_X - 1.2, HALF_Z - 1.2);
+        for i in 0..64 {
+            let t = i as f32 / 64.0;
+            let p = t * 2.0 * (bx_ + bz_); // half-perimeter parameter (mirrored to ±)
+            let (mut x, mut z) = if p < bx_ * 2.0 { (p - bx_, bz_) } else { (bx_, p - bx_ * 2.0 - bz_) };
+            if r.f() < 0.5 { x = -x; }
+            if r.f() < 0.5 { z = -z; }
+            x += (r.f() - 0.5) * 3.4;
+            z += (r.f() - 0.5) * 3.4;
+            let near_gate = (x.abs() < 2.4 && z.abs() > bz_ - 1.5) || (z.abs() < 2.4 && x.abs() > bx_ - 1.5);
+            if near_gate {
+                continue;
+            }
+            let mesh = if r.f() < 0.55 { &tuft } else { &clover };
+            let s = 0.45 + r.f() * 0.45;
+            sprig(x, z, mesh, s, &mut r, commands);
+        }
+        // Survivor patches inside the yard — small, sparse, low ("gdzie niegdzie").
+        for _ in 0..14 {
+            let x = (r.f() - 0.5) * 2.0 * (bx_ - 2.0);
+            let z = (r.f() - 0.5) * 2.0 * (bz_ - 2.0);
+            if x.abs() < 4.5 && z.abs() < 4.0 {
+                continue; // keep the keep's doorstep bare
+            }
+            let mesh = if r.f() < 0.35 { &tuft } else { &clover };
+            let s = 0.35 + r.f() * 0.3;
+            sprig(x, z, mesh, s, &mut r, commands);
+        }
+    }
 
     // Chimney smoke above each house.
     let smoke_mat = std_mats.add(StandardMaterial {

--- a/src/groundcover.rs
+++ b/src/groundcover.rs
@@ -101,11 +101,13 @@ fn ball_at(r: f32, off: Vec3, squash: f32, c: u32) -> Mesh {
 }
 
 /// A thin flat-shaded cone blade rooted at y≈0, leaned outward by `tilt` (about Z)
-/// then yawed by `yaw` (about Y) so a clump of them fans out. Flat-shaded so the blade
-/// reads as a crisp spike, not a soft round cone.
+/// then yawed by `yaw` (about Y) so a clump of them fans out. 4-sided: ground cover is
+/// scattered by the thousand, and the crisp low-poly facet IS the look — the default
+/// 32-segment cone was both soft-looking and ~8× the vertices.
 fn blade(yaw: f32, tilt: f32, h: f32, r: f32, c: u32) -> Mesh {
     let mut m = Cone { radius: r, height: h }
         .mesh()
+        .resolution(4)
         .build()
         .translated_by(y(h / 2.0))
         .rotated_by(Quat::from_rotation_z(tilt))
@@ -117,35 +119,34 @@ fn blade(yaw: f32, tilt: f32, h: f32, r: f32, c: u32) -> Mesh {
 
 // ── Grass tuft ─────────────────────────────────────────────────────────────────
 
-/// Grass tuft: 5 thin tapered cone blades fanned around the clump, ~0.26u tall, leaned
-/// + yawed out so it reads as a spiky clump (port of `Scatter.tsx` PARTS.tuft — 5 cones,
-/// radii 0.025→0.02, heights 0.26→0.17, exact offsets/rotations from the spec). Green
-/// base (#3aa044) → lighter tip (#5fc060): the two taller central blades use the base
-/// tone, the shorter outer blades the lighter tip tone, so the clump reads two-tone.
+/// Grass tuft: 8 thin tapered cone blades in two rings — a taller deep-green core fan +
+/// a shorter light-tipped outer fringe leaning well out — so the clump reads dense at
+/// the heart and feathered at the rim, ~0.28u tall. Cheaper per-blade than the old
+/// 5-blade build (4-sided blades) despite the fuller silhouette.
 pub fn build_grass_tuft_mesh() -> Mesh {
-    // (yaw, tilt, height, radius, colour) — spec blade table, with the tilt encoding
-    // each blade's lean (the spec's combined x/z euler tilts folded into one Z lean).
-    let specs = [
-        (0.0_f32, 0.00_f32, 0.26_f32, 0.025_f32, TUFT_GREEN),
-        (0.5, 0.22, 0.22, 0.022, TUFT_GREEN),
-        (-0.4, -0.20, 0.20, 0.022, TUFT_TIP),
-        (1.9, 0.15, 0.18, 0.020, TUFT_TIP),
-        (-1.7, -0.18, 0.17, 0.020, TUFT_TIP),
-    ];
-    let parts = specs
-        .iter()
-        .map(|&(yaw, tilt, h, r, c)| blade(yaw, tilt, h, r, c))
-        .collect();
+    let mut parts: Vec<Mesh> = Vec::with_capacity(8);
+    // Core fan: three tall dark blades, nearly upright, fanned by thirds.
+    for i in 0..3 {
+        let yaw = (i as f32 / 3.0) * std::f32::consts::TAU + 0.3;
+        let tilt = 0.10 + (i % 2) as f32 * 0.08;
+        parts.push(blade(yaw, tilt, 0.26 - i as f32 * 0.02, 0.024, TUFT_GREEN));
+    }
+    // Outer fringe: five lighter, shorter blades leaning out around the clump.
+    for i in 0..5 {
+        let yaw = (i as f32 / 5.0) * std::f32::consts::TAU;
+        let tilt = 0.28 + (i % 3) as f32 * 0.07;
+        parts.push(blade(yaw, tilt, 0.16 + (i % 2) as f32 * 0.04, 0.020, TUFT_TIP));
+    }
     merged(parts)
 }
 
 // ── Fern ───────────────────────────────────────────────────────────────────────
 
-/// Fern: a low spray of several angled fronds radiating from the base, deep green,
-/// ~0.3u tall. Each frond is a thin flattened box (a leaf blade) tilted up + outward;
-/// they fan around the clump in a low rosette. A short darker central stalk anchors it.
+/// Fern: a rosette of 8 tapering leaf-shaped fronds in two tiers — a low outer spray +
+/// a steeper inner ring — around a darker rachis, ~0.3u tall. Each frond is a squashed
+/// 4-sided cone (wide at the base, tapering to the tip) laid outward, so it reads as a
+/// pointed leaf blade rather than the old rectangular box.
 pub fn build_fern_mesh() -> Mesh {
-    const FROND_LEN: f32 = 0.30;
     let mut parts = vec![
         // Short central rachis (a thin upright box) so the fronds read as rooted.
         tinted(
@@ -153,24 +154,30 @@ pub fn build_fern_mesh() -> Mesh {
             lin(FERN_STEM),
         ),
     ];
-    // 6 fronds fanned around the clump: a thin flattened box, pivoted at the base, laid
-    // out almost flat (low spray) with a slight upward lift, alternating two green tones.
-    for i in 0..6 {
-        let yaw = (i as f32 / 6.0) * std::f32::consts::TAU;
-        let lift = if i % 2 == 0 { 0.62 } else { 0.50 }; // radians from horizontal
-        let c = if i % 2 == 0 { FERN_GREEN } else { FERN_TIP };
-        // Build a thin flat leaf along +Y (length FROND_LEN), shift so its base is at the
-        // origin, tilt it down toward horizontal (about X), then yaw it around the clump.
-        let frond = Cuboid::new(0.05, FROND_LEN, 0.012)
+    // A tapering frond: a 4-sided cone squashed flat (z) and widened (x), base-pivoted,
+    // tilted toward horizontal then yawed around the rosette.
+    let frond = |len: f32, yaw: f32, lift: f32, c: u32| -> Mesh {
+        let m = Cone { radius: 0.045, height: len }
             .mesh()
+            .resolution(4)
             .build()
-            .translated_by(y(FROND_LEN * 0.5))
-            // tilt away from vertical: PI/2 - lift leans it toward the ground (low spray).
+            .scaled_by(Vec3::new(1.6, 1.0, 0.30))
+            .translated_by(y(len * 0.5))
             .rotated_by(Quat::from_rotation_x(std::f32::consts::FRAC_PI_2 - lift))
             .rotated_by(Quat::from_rotation_y(yaw))
-            // lift the whole frond a touch so it sprays from ~0.05 above ground, base ≥ 0.
             .translated_by(y(0.05));
-        parts.push(tinted(frond, lin(c)));
+        tinted(m, lin(c))
+    };
+    // Outer tier: five long fronds laid low.
+    for i in 0..5 {
+        let yaw = (i as f32 / 5.0) * std::f32::consts::TAU;
+        let c = if i % 2 == 0 { FERN_GREEN } else { FERN_TIP };
+        parts.push(frond(0.30, yaw, 0.50 + (i % 2) as f32 * 0.10, c));
+    }
+    // Inner tier: three shorter fronds rising steeper from the heart.
+    for i in 0..3 {
+        let yaw = (i as f32 / 3.0) * std::f32::consts::TAU + 0.6;
+        parts.push(frond(0.20, yaw, 0.95, FERN_TIP));
     }
     merged(parts)
 }
@@ -193,20 +200,33 @@ pub fn build_mushroom_mesh(variant: u32) -> Mesh {
     let cap_r = 0.09 * s;
 
     let mut parts = vec![
-        // Pale stem (slightly tapered look approximated with a thin cylinder).
-        cyl_at(0.034 * s, stem_h, stem_h * 0.5, MUSH_STEM),
-        // Domed cap: a squashed half-ball resting on the stem.
+        // Pale stem with a skirt bulge at the foot (amanita volva) so it roots visibly.
+        cyl_at(0.030 * s, stem_h, stem_h * 0.55, MUSH_STEM),
+        ball_at(0.042 * s, y(0.02 * s), 0.7, MUSH_STEM),
+        // Pale gill plate tucked under the cap rim (a wide squashed disc) — gives the
+        // overhanging cap a real underside instead of clipping into the stem.
+        ball_at(cap_r * 0.88, y(cap_y - 0.008 * s), 0.22, MUSH_STEM),
+        // Domed cap: a squashed half-ball overhanging the gills.
         ball_at(cap_r, y(cap_y), 0.62, cap),
     ];
-    // White speckles only on the red amanita cap (a few tiny boxes near the crown).
+    // White speckles only on the red amanita cap (tiny boxes ringing the crown).
     if red {
-        for &(dx, dz) in &[(0.045_f32, 0.02_f32), (-0.035, -0.04), (0.01, 0.05)] {
-            let spot = Cuboid::new(0.020 * s, 0.014 * s, 0.020 * s)
+        for &(dx, dz, dy) in &[
+            (0.045_f32, 0.02_f32, 0.040_f32),
+            (-0.035, -0.04, 0.042),
+            (0.01, 0.05, 0.048),
+            (-0.05, 0.025, 0.034),
+            (0.02, -0.055, 0.036),
+        ] {
+            let spot = Cuboid::new(0.018 * s, 0.012 * s, 0.018 * s)
                 .mesh()
                 .build()
-                .translated_by(Vec3::new(dx * s, cap_y + 0.045 * s, dz * s));
+                .translated_by(Vec3::new(dx * s, cap_y + dy * s, dz * s));
             parts.push(tinted(spot, lin(MUSH_DOT)));
         }
+        // A baby cap budding by the big one — amanitas grow in pairs.
+        parts.push(cyl_at(0.018 * s, 0.05 * s, 0.025 * s, MUSH_STEM).translated_by(Vec3::new(0.085 * s, 0.0, 0.04 * s)));
+        parts.push(ball_at(0.045 * s, Vec3::new(0.085 * s, 0.05 * s, 0.04 * s), 0.62, cap));
     }
     merged(parts)
 }
@@ -229,20 +249,35 @@ pub fn build_flower_mesh(variant: u32) -> Mesh {
         _ => (PETAL_WHITE, FLOWER_CENTER, 11, 0.23, 0.052, 0.016, 0.40), // daisy — tall, thin rays
     };
     let mut parts = vec![
-        // Thin green stem (a slender cone from the ground up to the bloom).
+        // Thin green stem (a slender 5-sided cone from the ground up to the bloom).
         tinted(
-            Cone { radius: 0.010, height: head_y }.mesh().build().translated_by(y(head_y * 0.5)),
+            Cone { radius: 0.010, height: head_y }
+                .mesh()
+                .resolution(5)
+                .build()
+                .translated_by(y(head_y * 0.5)),
             lin(FLOWER_STEM),
         ),
         // Centre disc (small squashed ball at the bloom).
         ball_at(0.024, y(head_y), 0.7, center),
     ];
-    // Ring of petals around the centre (small flattened balls).
+    // Two small leaf blades on the stem (flattened squashed balls leaning out) so the
+    // flower reads as a plant, not a lollipop on a stick.
+    for (a, ly) in [(0.9_f32, 0.35_f32), (3.8, 0.55)] {
+        parts.push(ball_at(
+            0.030,
+            Vec3::new(a.cos() * 0.035, head_y * ly, a.sin() * 0.035),
+            0.28,
+            FLOWER_STEM,
+        ));
+    }
+    // Ring of petals around the centre (small flattened balls), tipped slightly upward
+    // toward the centre so the bloom cups instead of lying dead flat.
     for i in 0..n {
         let a = (i as f32 / n as f32) * std::f32::consts::TAU;
         parts.push(ball_at(
             petal_r,
-            Vec3::new(a.cos() * ring_r, head_y, a.sin() * ring_r),
+            Vec3::new(a.cos() * ring_r, head_y + 0.006, a.sin() * ring_r),
             squash,
             petal,
         ));
@@ -302,17 +337,32 @@ pub fn build_floor_litter_mesh(variant: u32) -> Mesh {
 
 // ── Clover ────────────────────────────────────────────────────────────────────
 
-/// Clover: a tiny tri-leaf clump — 3 small flattened green discs in a triangle, very
-/// low to the ground (~0.06u), each on a stub. Base at y=0.
+/// Clover: a low five-leaf patch — small flattened green discs at two heights on thin
+/// stalk stubs, so it reads as a little living clump rather than three floating discs.
+/// ~0.07u tall, base at y=0.
 pub fn build_clover_mesh() -> Mesh {
-    const LEAF_Y: f32 = 0.05;
-    const RING_R: f32 = 0.04;
     let mut parts = Vec::new();
-    for i in 0..3 {
-        let a = (i as f32 / 3.0) * std::f32::consts::TAU;
-        let off = Vec3::new(a.cos() * RING_R, LEAF_Y, a.sin() * RING_R);
+    // (angle, ring radius, leaf y, leaf r) — three big outer leaves + two smaller inner.
+    let leaves: [(f32, f32, f32, f32); 5] = [
+        (0.0, 0.045, 0.050, 0.036),
+        (2.1, 0.042, 0.046, 0.034),
+        (4.2, 0.046, 0.052, 0.035),
+        (1.1, 0.020, 0.066, 0.026),
+        (3.3, 0.022, 0.062, 0.024),
+    ];
+    for (a, ring, ly, lr) in leaves {
+        let off = Vec3::new(a.cos() * ring, ly, a.sin() * ring);
+        // Thin stalk stub under the leaf.
+        parts.push(tinted(
+            Cylinder::new(0.005, ly)
+                .mesh()
+                .resolution(4)
+                .build()
+                .translated_by(Vec3::new(off.x * 0.6, ly * 0.5, off.z * 0.6)),
+            lin(FLOWER_STEM),
+        ));
         // Leaf: a small flattened (very squashed) ball — a low rounded disc.
-        parts.push(ball_at(0.035, off, 0.30, CLOVER_GREEN));
+        parts.push(ball_at(lr, off, 0.30, CLOVER_GREEN));
     }
     merged(parts)
 }

--- a/src/props.rs
+++ b/src/props.rs
@@ -81,15 +81,29 @@ fn ball_at(r: f32, off: Vec3, squash: f32, c: [f32; 4]) -> Mesh {
 /// `duplicate_vertices()` MUST run before `compute_flat_normals()` (the latter panics
 /// on an indexed mesh — contract §"flat-shading helpers").
 fn facet_at(r: f32, off: Vec3, squash: f32, c: [f32; 4]) -> Mesh {
+    facet_rot(r, off, Vec3::new(1.0, squash, 1.0), Quat::IDENTITY, c)
+}
+
+/// The general faceted lump: per-axis stretch + an arbitrary pre-rotation before the
+/// translate. Rotating each lump differently keeps the 20 icosahedron facets from
+/// lining up across a cluster — that repeated-orientation tell is what makes prop
+/// rocks read as copy-pasted spheres.
+fn facet_rot(r: f32, off: Vec3, stretch: Vec3, rot: Quat, c: [f32; 4]) -> Mesh {
     let mut m = Sphere::new(r)
         .mesh()
         .ico(0)
         .unwrap()
-        .scaled_by(Vec3::new(1.0, squash, 1.0))
+        .scaled_by(stretch)
+        .rotated_by(rot)
         .translated_by(off);
     m.duplicate_vertices();
     m.compute_flat_normals();
     tinted(m, c)
+}
+
+/// A draped moss patch: a very flat green disc-blob melted over a boulder's crown.
+fn moss_drape(r: f32, off: Vec3, c: [f32; 4]) -> Mesh {
+    facet_rot(r, off, Vec3::new(1.25, 0.30, 1.1), Quat::from_rotation_y(0.7), c)
 }
 
 // ─── Rocks ──────────────────────────────────────────────────────────────────────
@@ -104,43 +118,54 @@ fn facet_at(r: f32, off: Vec3, squash: f32, c: [f32; 4]) -> Mesh {
 /// 0.85–1.30 by the scatter; these boulders read at ~0.3–0.45u so they sit between
 /// the ground cover and the trees, then the scatter scales them per-instance.
 pub fn build_rock_mesh(variant: u32) -> Mesh {
+    let rot = |x: f32, yw: f32, z: f32| Quat::from_euler(EulerRot::XYZ, x, yw, z);
     match variant % NUM_ROCK_VARIANTS {
-        // Variant 0 — a squat, wide boulder: one broad squashed lump + two side cobbles.
+        // Variant 0 — a squat, wide boulder: a broad tilted body + bright crown facet,
+        // two leaning side cobbles, a moss drape over the shoulder and grit at the foot.
         0 => {
             let r = 0.34;
             merged(vec![
-                // Body — wide & squashed; slightly darkened base tone.
-                facet_at(r, y(r * 0.74), 0.78, lin_scaled(ROCK_STONE, 0.9)),
+                // Body — wide, squashed, rolled a few degrees so its facets sit unique.
+                facet_rot(r, y(r * 0.72), Vec3::new(1.15, 0.78, 1.0), rot(0.12, 0.5, -0.08), lin_scaled(ROCK_STONE, 0.9)),
                 // A bright top facet catching the light.
-                facet_at(r * 0.5, y(r * 1.18), 0.7, lin_scaled(ROCK_STONE, 1.12)),
+                facet_rot(r * 0.5, Vec3::new(-r * 0.1, r * 1.18, r * 0.06), Vec3::new(1.0, 0.7, 0.9), rot(-0.1, 1.7, 0.15), lin_scaled(ROCK_STONE, 1.12)),
                 // Two side cobbles leaning against the base.
-                facet_at(r * 0.55, Vec3::new(r * 0.92, r * 0.4, r * 0.18), 0.85, lin(ROCK_MOSS)),
-                facet_at(r * 0.46, Vec3::new(-r * 0.78, r * 0.34, -r * 0.28), 0.85, lin(ROCK_LICHEN)),
+                facet_rot(r * 0.55, Vec3::new(r * 0.92, r * 0.38, r * 0.18), Vec3::new(1.0, 0.8, 0.9), rot(0.3, 2.6, 0.2), lin_scaled(ROCK_STONE, 0.97)),
+                facet_rot(r * 0.46, Vec3::new(-r * 0.78, r * 0.32, -r * 0.28), Vec3::new(0.9, 0.85, 1.05), rot(-0.2, 4.0, -0.25), lin(ROCK_LICHEN)),
+                // Moss melted over the sunward shoulder + a grounded skirt of grit.
+                moss_drape(r * 0.55, Vec3::new(r * 0.28, r * 1.28, -r * 0.1), lin(ROCK_MOSS)),
+                facet_at(r * 0.28, Vec3::new(-r * 0.5, r * 0.16, r * 0.75), 0.55, lin_scaled(ROCK_STONE, 0.84)),
             ])
         }
-        // Variant 1 — a taller, split crag: two stacked lumps + a high bright cap.
+        // Variant 1 — a taller, split crag: stacked rotated blocks, a moss seam in the
+        // cleft, a bright peak cap and a toppled chip at the foot.
         1 => {
             let r = 0.3;
             merged(vec![
-                // Lower block.
-                facet_at(r, y(r * 0.82), 0.92, lin_scaled(ROCK_STONE, 0.88)),
-                // Upper block offset to one side (the "split").
-                facet_at(r * 0.72, Vec3::new(r * 0.34, r * 1.5, -r * 0.1), 0.95, lin(ROCK_LICHEN)),
-                // A small mossy chip wedged in the cleft.
-                facet_at(r * 0.4, Vec3::new(-r * 0.5, r * 0.7, r * 0.3), 0.85, lin(ROCK_MOSS)),
+                // Lower block, tilted into the hill.
+                facet_rot(r, y(r * 0.8), Vec3::new(1.1, 0.95, 0.95), rot(0.1, 0.3, 0.14), lin_scaled(ROCK_STONE, 0.88)),
+                // Upper block sheared to one side (the "split").
+                facet_rot(r * 0.72, Vec3::new(r * 0.36, r * 1.52, -r * 0.1), Vec3::new(0.95, 1.1, 0.9), rot(-0.12, 1.9, -0.2), lin(ROCK_LICHEN)),
+                // A mossy seam wedged in the cleft.
+                facet_rot(r * 0.4, Vec3::new(-r * 0.5, r * 0.72, r * 0.3), Vec3::new(1.1, 0.7, 0.9), rot(0.4, 3.2, 0.0), lin(ROCK_MOSS)),
                 // Bright cap on the peak.
-                facet_at(r * 0.42, Vec3::new(r * 0.3, r * 2.05, -r * 0.05), 0.8, lin_scaled(ROCK_STONE, 1.14)),
+                facet_rot(r * 0.42, Vec3::new(r * 0.32, r * 2.1, -r * 0.05), Vec3::new(0.9, 0.8, 0.85), rot(0.2, 5.1, -0.1), lin_scaled(ROCK_STONE, 1.14)),
+                // A toppled chip resting at the foot.
+                facet_rot(r * 0.3, Vec3::new(r * 0.85, r * 0.22, r * 0.55), Vec3::new(1.2, 0.55, 0.9), rot(0.0, 2.2, 0.5), lin_scaled(ROCK_STONE, 1.02)),
             ])
         }
-        // Variant 2 — a low scatter of cobbles: several small lumps spread flat.
+        // Variant 2 — a low scatter of cobbles: several small rotated lumps spread flat,
+        // moss creeping over the two biggest.
         _ => {
             let r = 0.26;
             merged(vec![
-                facet_at(r, y(r * 0.7), 0.74, lin_scaled(ROCK_STONE, 0.92)),
-                facet_at(r * 0.78, Vec3::new(r * 1.05, r * 0.5, r * 0.25), 0.78, lin(ROCK_LICHEN)),
-                facet_at(r * 0.66, Vec3::new(-r * 0.95, r * 0.42, -r * 0.4), 0.78, lin(ROCK_MOSS)),
-                facet_at(r * 0.5, Vec3::new(r * 0.1, r * 0.4, -r * 1.0), 0.8, lin_scaled(ROCK_STONE, 1.06)),
-                facet_at(r * 0.4, Vec3::new(-r * 0.2, r * 0.36, r * 0.95), 0.8, lin(ROCK_MOSS)),
+                facet_rot(r, y(r * 0.68), Vec3::new(1.2, 0.74, 1.0), rot(0.1, 0.9, -0.1), lin_scaled(ROCK_STONE, 0.92)),
+                facet_rot(r * 0.78, Vec3::new(r * 1.05, r * 0.46, r * 0.25), Vec3::new(1.0, 0.78, 1.1), rot(-0.15, 2.0, 0.2), lin(ROCK_LICHEN)),
+                facet_rot(r * 0.66, Vec3::new(-r * 0.95, r * 0.4, -r * 0.4), Vec3::new(0.95, 0.78, 0.9), rot(0.25, 3.4, 0.0), lin_scaled(ROCK_STONE, 1.0)),
+                facet_rot(r * 0.5, Vec3::new(r * 0.1, r * 0.38, -r * 1.0), Vec3::new(1.1, 0.8, 0.95), rot(0.0, 4.6, -0.3), lin_scaled(ROCK_STONE, 1.06)),
+                facet_rot(r * 0.4, Vec3::new(-r * 0.2, r * 0.34, r * 0.95), Vec3::new(0.9, 0.8, 1.0), rot(0.3, 5.6, 0.15), lin_scaled(ROCK_STONE, 0.95)),
+                moss_drape(r * 0.5, y(r * 1.02), lin(ROCK_MOSS)),
+                moss_drape(r * 0.34, Vec3::new(r * 1.05, r * 0.78, r * 0.25), lin(ROCK_MOSS)),
             ])
         }
     }
@@ -170,15 +195,14 @@ pub fn build_bush_mesh(variant: u32) -> Mesh {
     let mid = lin(base); // body
     let light = lin_scaled(base, 1.16); // sunlit crown
 
-    // Flat-shaded so the bush reads as crisp low-poly facets (like the TS game), not a
-    // soft blob.
-    flat_shaded(merged(vec![
+    let mut parts = vec![
         // ── Dark base skirt — wide low lobes that give the bush its grounded spread.
         // Mirrors the TS part radii/offsets (0.24 centre + 0.20/0.18/0.19 lobes),
         // squashed into domes and kept low so the silhouette is rounder than a tree.
         ball_at(0.24, y(0.17), 0.82, dark),
         ball_at(0.2, Vec3::new(0.2, 0.14, 0.05), 0.82, dark),
         ball_at(0.18, Vec3::new(-0.17, 0.13, 0.1), 0.82, dark),
+        ball_at(0.15, Vec3::new(0.02, 0.12, -0.19), 0.82, dark),
         // ── Mid body — fills the centre of the mound.
         ball_at(0.21, y(0.27), 0.86, mid),
         ball_at(0.16, Vec3::new(0.13, 0.3, -0.13), 0.86, mid),
@@ -187,7 +211,45 @@ pub fn build_bush_mesh(variant: u32) -> Mesh {
         ball_at(0.16, y(0.38), 0.9, light),
         ball_at(0.12, Vec3::new(0.09, 0.42, 0.08), 0.9, light),
         ball_at(0.11, Vec3::new(-0.08, 0.41, -0.07), 0.9, light),
-    ]))
+    ];
+    // A couple of woody twig stubs poking through the canopy — shrubs aren't solid.
+    for (a, tilt, len) in [(0.7_f32, 0.5_f32, 0.14_f32), (3.6, -0.6, 0.12)] {
+        parts.push(tinted(
+            Cylinder::new(0.012, len)
+                .mesh()
+                .resolution(4)
+                .build()
+                .translated_by(y(len * 0.5))
+                .rotated_by(Quat::from_rotation_z(tilt))
+                .rotated_by(Quat::from_rotation_y(a))
+                .translated_by(y(0.40)),
+            lin(0x6b4a2c),
+        ));
+    }
+    // Per-variant fruiting accent: the dark bush carries red berries, the mid one white
+    // blossom dots, the light one stays plain — three shrubs, three reads.
+    let accent = match variant % NUM_BUSH_VARIANTS {
+        0 => Some(lin(0xc83a3a)), // holly-red berries
+        1 => Some(lin(0xf2efe0)), // white blossom
+        _ => None,
+    };
+    if let Some(acc) = accent {
+        for (i, &(dx, dy, dz)) in [
+            (0.14_f32, 0.40_f32, 0.06_f32),
+            (-0.10, 0.42, -0.09),
+            (0.03, 0.46, 0.12),
+            (0.20, 0.32, -0.10),
+            (-0.18, 0.34, 0.08),
+        ]
+        .iter()
+        .enumerate()
+        {
+            parts.push(ball_at(0.022 + (i % 2) as f32 * 0.006, Vec3::new(dx, dy, dz), 1.0, acc));
+        }
+    }
+    // Flat-shaded so the bush reads as crisp low-poly facets (like the TS game), not a
+    // soft blob.
+    flat_shaded(merged(parts))
 }
 
 /// Un-index + recompute per-face normals so a merged mesh shows hard, flat-shaded

--- a/src/terrain.rs
+++ b/src/terrain.rs
@@ -84,7 +84,11 @@ pub fn make_material(
 
 // ── Detail texture (port of terrainDetail.ts; parameterised per biome) ───────────
 
-const DETAIL_PX: u32 = 256;
+// 512²: the 256 texture's grain went soft and its repeat read as a visible grid at
+// gameplay zoom; doubling the lattice resolution (with an extra macro octave below)
+// keeps the blades crisp and pushes the repetition below notice. Still a one-off
+// CPU bake per biome (≈0.26 Mpx).
+const DETAIL_PX: u32 = 512;
 
 fn hash2(ix: f32, iy: f32, seed: f32) -> f32 {
     let d = ix * 127.1 + iy * 311.7 + seed * 74.7;
@@ -130,14 +134,20 @@ fn detail_image(d: &GroundDetail) -> (Image, f32) {
         for px in 0..n {
             let u = px as f32 / n as f32;
             let v = py as f32 / n as f32;
+            let macro_ = value_noise(u, v, 3, 3, seed + 53.0); // broad worn/lush drift
             let patch = value_noise(u, v, 7, 7, seed);
             let mid = value_noise(u, v, 18, 18, seed + 11.0);
+            let mid2 = value_noise(u, v, 37, 37, seed + 71.0); // clump break-up
             let grain = value_noise(u, v, 96, 96, seed + 23.0);
             let streak = value_noise(u, v, 64, 7, seed + 37.0); // vertical blades
-            let mut t = patch * 0.55 + mid * 0.30 + grain * 0.15;
+            let mut t = macro_ * 0.18 + patch * 0.40 + mid * 0.22 + mid2 * 0.10 + grain * 0.10;
             if streak > 0.0 {
                 t += (streak - 0.5) * d.streak;
             }
+            // A second, coarser streak set at an offset phase so the blade pattern
+            // doesn't read as one repeating comb.
+            let streak2 = value_noise(u, v, 23, 5, seed + 91.0);
+            t += (streak2 - 0.5) * d.streak * 0.4;
             let t = t.clamp(0.0, 1.0);
             let col = if t < 0.5 {
                 let s = t * 2.0;

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -160,155 +160,199 @@ pub const TREE_TINTS: [[f32; 3]; 3] = [
     [0.80, 0.92, 0.86],
 ];
 
-// ── Broadleaf "tree" — tapered trunk + 6 icosphere foliage layers (ico detail 1) ──
+/// A root flare: short fat cylinders leaning out from the trunk foot, base sunk to y≈0,
+/// so the bole reads grounded and gnarled instead of a pole stuck in the lawn.
+fn root_flare(trunk_r: f32, n: usize, len: f32, color: [f32; 4], phase: f32) -> Vec<Mesh> {
+    (0..n)
+        .map(|i| {
+            let a = phase + (i as f32 / n as f32) * std::f32::consts::TAU;
+            let m = Cylinder::new(trunk_r * 0.42, len)
+                .mesh()
+                .resolution(5)
+                .build()
+                .translated_by(Vec3::new(0.0, len * 0.5, 0.0))
+                // Lean well out from vertical so the root crawls along the ground...
+                .rotated_by(Quat::from_rotation_z(1.05))
+                .rotated_by(Quat::from_rotation_y(a))
+                // ...rooted right at the trunk foot.
+                .translated_by(Vec3::new(a.cos() * trunk_r * 0.55, 0.02, -a.sin() * trunk_r * 0.55));
+            tinted(m, color)
+        })
+        .collect()
+}
+
+/// A short branch reaching from the trunk up into the canopy: a thin cylinder rotated by
+/// `(tilt about Z, then yaw about Y)` with its BASE pivoted at `base` (not its centre).
+fn branch_part(r: f32, len: f32, tilt: f32, yaw: f32, base: Vec3, color: [f32; 4]) -> Mesh {
+    let m = Cylinder::new(r, len)
+        .mesh()
+        .resolution(5)
+        .build()
+        .translated_by(Vec3::new(0.0, len * 0.5, 0.0))
+        .rotated_by(Quat::from_rotation_z(tilt))
+        .rotated_by(Quat::from_rotation_y(yaw))
+        .translated_by(base);
+    tinted(m, color)
+}
+
+// ── Broadleaf "tree" — flared tapered trunk + branches + a 9-blob three-tone crown ──
 //
-// Trunk: CylinderGeometry(0.09, 0.12, 0.5, 6) at [0,0.25,0], #5a3a22.
-// Six foliage layers (dark/dark, mid/mid, light/light) per the spec, building a
-// layered three-tone crown so it reads lush and 3D rather than a flat sphere.
+// Upgraded from the original 6-layer spec build: the trunk is now two stacked tapering
+// segments with a root flare and two visible limbs climbing into the foliage, and the
+// crown is nine icospheres (dark base mass → mid body → light cap) pushed asymmetric so
+// the silhouette reads grown, not stacked. Same palette + ~1.5u height as the original.
 fn build_broadleaf() -> Mesh {
-    let trunk = tinted(
-        trunk_part(0.09, 0.12, 0.5, 6, Vec3::new(0.0, 0.25, 0.0)),
-        lin(TREE_TRUNK),
-    );
+    let bark = lin(TREE_TRUNK);
+    let mut parts = vec![
+        // Two-segment tapering bole (thicker foot, slimmer upper) + root flare.
+        tinted(trunk_part(0.10, 0.13, 0.34, 7, Vec3::new(0.0, 0.17, 0.0)), bark),
+        tinted(trunk_part(0.075, 0.10, 0.34, 7, Vec3::new(0.015, 0.48, 0.01)), bark),
+    ];
+    parts.extend(root_flare(0.13, 4, 0.16, bark, 0.45));
+    // Two limbs forking off the upper bole into the canopy mass.
+    parts.push(branch_part(0.045, 0.34, 0.65, 0.4, Vec3::new(0.03, 0.52, 0.0), bark));
+    parts.push(branch_part(0.04, 0.30, -0.75, 2.6, Vec3::new(-0.02, 0.46, 0.02), bark));
 
-    // Layer 1+2: dark base mass (#2f7a36)
-    let l1 = tinted(foliage(0.46, 1, Vec3::new(0.0, 0.64, 0.0)), lin(FOLIAGE_DARK));
-    let l2 = tinted(
-        foliage(0.26, 1, Vec3::new(0.24, 0.6, 0.06)),
-        lin(FOLIAGE_DARK),
-    );
-    // Layer 3+4: mid tone (#3a9442)
-    let l3 = tinted(foliage(0.4, 1, Vec3::new(0.0, 0.86, 0.0)), lin(FOLIAGE_MID));
-    let l4 = tinted(
-        foliage(0.24, 1, Vec3::new(-0.22, 0.82, -0.08)),
-        lin(FOLIAGE_MID),
-    );
-    // Layer 5+6: light crown cap + tip (#4cb358)
-    let l5 = tinted(
-        foliage(0.33, 1, Vec3::new(0.0, 1.06, 0.0)),
-        lin(FOLIAGE_LIGHT),
-    );
-    let l6 = tinted(
-        foliage(0.22, 1, Vec3::new(0.0, 1.24, 0.0)),
-        lin(FOLIAGE_LIGHT),
-    );
-
-    merged(vec![trunk, l1, l2, l3, l4, l5, l6])
+    // Crown: dark grounded mass → mid body → sunlit cap, with off-axis side lobes so no
+    // two silhouettes line up. (radius, centre, tone)
+    let blobs: [(f32, Vec3, u32); 9] = [
+        (0.46, Vec3::new(0.0, 0.66, 0.0), FOLIAGE_DARK),
+        (0.27, Vec3::new(0.27, 0.60, 0.10), FOLIAGE_DARK),
+        (0.25, Vec3::new(-0.20, 0.58, -0.18), FOLIAGE_DARK),
+        (0.40, Vec3::new(0.02, 0.88, 0.0), FOLIAGE_MID),
+        (0.25, Vec3::new(-0.26, 0.84, 0.10), FOLIAGE_MID),
+        (0.23, Vec3::new(0.22, 0.92, -0.16), FOLIAGE_MID),
+        (0.32, Vec3::new(0.0, 1.08, 0.02), FOLIAGE_LIGHT),
+        (0.20, Vec3::new(0.16, 1.18, 0.10), FOLIAGE_LIGHT),
+        (0.21, Vec3::new(-0.06, 1.26, -0.06), FOLIAGE_LIGHT),
+    ];
+    for (r, c, tone) in blobs {
+        parts.push(tinted(foliage(r, 1, c), lin(tone)));
+    }
+    merged(parts)
 }
 
-// ── Birch — pale tapered trunk + 2 dark bark-mark boxes + 4 rounder foliage (ico 0) ──
+// ── Birch — tall pale trunk, banded bark marks all the way up, a side limb, airy crown ──
 //
-// Trunk: CylinderGeometry(0.06, 0.075, 0.8, 6) at [0,0.4,0], #ece8d8.
-// Marks: thin dark boxes suggesting peeling-bark stripes.
-// Foliage: 4 detail-0 icospheres (rounder than the broadleaf), dark/light alternating.
+// Upgraded from the 2-mark/4-blob original: the trunk keeps its pale tapered column but
+// now carries five staggered peeling-bark bands (alternating sides, varied widths — the
+// classic birch "ladder"), a slim limb lifting a satellite leaf puff clear of the crown,
+// and a six-blob crown (rounder ico-0 masses, dark under / light over) that drifts off
+// axis for an airy, open silhouette. Same palette, slightly taller (~1.35u).
 fn build_birch() -> Mesh {
-    let trunk = tinted(
-        trunk_part(0.06, 0.075, 0.8, 6, Vec3::new(0.0, 0.4, 0.0)),
+    let mut parts = vec![tinted(
+        trunk_part(0.055, 0.075, 0.86, 7, Vec3::new(0.0, 0.43, 0.0)),
         lin(BIRCH_TRUNK),
-    );
+    )];
+    // Shallow root flare keeps the slim pole grounded.
+    parts.extend(root_flare(0.075, 3, 0.10, lin(BIRCH_TRUNK), 1.1));
 
-    // Two dark bark-mark boxes (BoxGeometry(w,h,d) at center positions).
-    let mark1 = tinted(
-        Cuboid::new(0.005, 0.04, 0.08)
-            .mesh()
-            .build()
-            .translated_by(Vec3::new(0.075, 0.55, 0.0)),
-        lin(BIRCH_MARK),
-    );
-    let mark2 = tinted(
-        Cuboid::new(0.005, 0.03, 0.06)
-            .mesh()
-            .build()
-            .translated_by(Vec3::new(-0.075, 0.32, 0.02)),
-        lin(BIRCH_MARK),
-    );
+    // Five peeling-bark bands hugging the trunk surface, alternating faces + heights.
+    // (y, yaw, w, h) — thin boxes just proud of the bark.
+    let marks: [(f32, f32, f32, f32); 5] = [
+        (0.18, 0.3, 0.085, 0.030),
+        (0.34, 2.4, 0.070, 0.040),
+        (0.50, 4.4, 0.080, 0.026),
+        (0.63, 1.4, 0.065, 0.036),
+        (0.76, 3.5, 0.060, 0.024),
+    ];
+    for (my, yaw, w, h) in marks {
+        let r_here = 0.075 - (my / 0.86) * 0.02; // follow the taper
+        parts.push(tinted(
+            Cuboid::new(0.006, h, w)
+                .mesh()
+                .build()
+                .translated_by(Vec3::new(r_here, 0.0, 0.0))
+                .rotated_by(Quat::from_rotation_y(yaw))
+                .translated_by(Vec3::new(0.0, my, 0.0)),
+            lin(BIRCH_MARK),
+        ));
+    }
 
-    // Four foliage masses (rounder, detail 0): dark base, light bump, dark bump, light tip.
-    let f1 = tinted(foliage(0.34, 0, Vec3::new(0.0, 0.95, 0.0)), lin(BIRCH_DARK));
-    let f2 = tinted(
-        foliage(0.22, 0, Vec3::new(0.18, 1.05, 0.1)),
-        lin(BIRCH_LIGHT),
-    );
-    let f3 = tinted(
-        foliage(0.24, 0, Vec3::new(-0.16, 1.0, -0.1)),
-        lin(BIRCH_DARK),
-    );
-    let f4 = tinted(
-        foliage(0.18, 0, Vec3::new(0.05, 1.18, 0.0)),
-        lin(BIRCH_LIGHT),
-    );
+    // A slim limb carrying its own small leaf puff out beside the crown.
+    parts.push(branch_part(0.025, 0.30, 0.95, 0.9, Vec3::new(0.02, 0.62, 0.0), lin(BIRCH_TRUNK)));
+    parts.push(tinted(foliage(0.16, 0, Vec3::new(0.27, 0.80, -0.22)), lin(BIRCH_LIGHT)));
 
-    merged(vec![trunk, mark1, mark2, f1, f2, f3, f4])
+    // Airy six-blob crown: dark base masses, light top puffs, drifting off the axis.
+    let blobs: [(f32, Vec3, u32); 6] = [
+        (0.32, Vec3::new(0.0, 0.98, 0.0), BIRCH_DARK),
+        (0.22, Vec3::new(0.20, 1.06, 0.10), BIRCH_LIGHT),
+        (0.23, Vec3::new(-0.18, 1.02, -0.10), BIRCH_DARK),
+        (0.18, Vec3::new(-0.10, 1.18, 0.12), BIRCH_LIGHT),
+        (0.17, Vec3::new(0.07, 1.24, -0.08), BIRCH_LIGHT),
+        (0.13, Vec3::new(0.0, 1.34, 0.02), BIRCH_LIGHT),
+    ];
+    for (r, c, tone) in blobs {
+        parts.push(tinted(foliage(r, 0, c), lin(tone)));
+    }
+    merged(parts)
 }
 
-// ── Dead tree — bare tapered trunk + 4 angled broken-branch cylinders, no foliage ──
+// ── Dead tree — gnarled leaning snag: kinked trunk, root flare, 6 branches, deadfall ──
 //
-// Trunk: CylinderGeometry(0.06, 0.095, 0.9, 6) at [0,0.45,0], #6e6258.
-// Branches: tapered (avg-radius) cylinders, 5 segments, each rotated by the TS Euler
-// then translated to its TS centre. Two darker (#4a4238), two trunk-tone (#6e6258).
+// Upgraded from the straight-pole original: the bole is two segments with a visible kink
+// (the upper segment leans), flared roots grip the ground, six broken branches (two now
+// carry short forked twig tips) claw at the sky, the top ends in a shattered-spike cone,
+// and one fallen limb lies in the grass at the foot. Same two-tone dead-wood palette.
 fn build_dead() -> Mesh {
-    let trunk = tinted(
-        trunk_part(0.06, 0.095, 0.9, 6, Vec3::new(0.0, 0.45, 0.0)),
-        lin(DEAD_WOOD),
-    );
+    let wood = lin(DEAD_WOOD);
+    let dark = lin(DEAD_WOOD_DARK);
 
-    // Each branch: build the avg-radius cylinder at the origin, rotate by the TS Euler
-    // (XYZ radians), then translate to the TS centre position.
-    let branch = |r_top: f32,
-                  r_bottom: f32,
-                  height: f32,
-                  rot: Vec3,
-                  center: Vec3,
-                  color: [f32; 4]|
-     -> Mesh {
-        let r = (r_top + r_bottom) * 0.5;
-        let m = Cylinder::new(r, height)
+    let mut parts = vec![
+        // Lower bole (stout) + kinked upper bole leaning off plumb.
+        tinted(trunk_part(0.065, 0.10, 0.5, 6, Vec3::new(0.0, 0.25, 0.0)), wood),
+        tinted(
+            Cylinder::new(0.05, 0.48)
+                .mesh()
+                .resolution(6)
+                .build()
+                .rotated_by(Quat::from_rotation_z(-0.16))
+                .translated_by(Vec3::new(0.055, 0.71, 0.0)),
+            wood,
+        ),
+        // Shattered spike topping the snag (a narrow cone, off the lean axis).
+        tinted(
+            Cone { radius: 0.04, height: 0.22 }
+                .mesh()
+                .resolution(5)
+                .build()
+                .rotated_by(Quat::from_rotation_z(-0.2))
+                .translated_by(Vec3::new(0.12, 1.02, 0.0)),
+            dark,
+        ),
+    ];
+    parts.extend(root_flare(0.10, 4, 0.15, dark, 0.2));
+
+    // Clawing branches: (r, len, tilt, yaw, base, tone). Tilts past ±1.2 lay them near
+    // horizontal — a dead canopy's reach, not living lift.
+    let limbs: [(f32, f32, f32, f32, Vec3, [f32; 4]); 6] = [
+        (0.030, 0.42, 1.05, 0.2, Vec3::new(0.06, 0.66, 0.02), dark),
+        (0.026, 0.36, -1.15, 0.5, Vec3::new(-0.03, 0.78, -0.02), dark),
+        (0.022, 0.30, 0.85, 2.3, Vec3::new(0.04, 0.88, 0.04), wood),
+        (0.020, 0.26, -0.95, 3.9, Vec3::new(0.02, 0.94, -0.03), wood),
+        (0.018, 0.22, 1.25, 5.1, Vec3::new(0.05, 0.58, -0.04), wood),
+        (0.016, 0.18, -0.7, 1.5, Vec3::new(0.08, 1.0, 0.02), dark),
+    ];
+    for (r, len, tilt, yaw, base, tone) in limbs {
+        parts.push(branch_part(r, len, tilt, yaw, base, tone));
+    }
+    // Forked twig tips on the two big limbs (short thin stubs off the limb ends).
+    parts.push(branch_part(0.014, 0.16, 1.5, 0.4, Vec3::new(0.40, 0.85, 0.10), dark));
+    parts.push(branch_part(0.012, 0.13, -1.5, 0.7, Vec3::new(-0.30, 0.92, -0.10), dark));
+
+    // A fallen limb rotting in the grass by the foot.
+    parts.push(tinted(
+        Cylinder::new(0.028, 0.4)
             .mesh()
             .resolution(5)
             .build()
-            .rotated_by(Quat::from_euler(EulerRot::XYZ, rot.x, rot.y, rot.z))
-            .translated_by(center);
-        tinted(m, color)
-    };
+            .rotated_by(Quat::from_rotation_z(std::f32::consts::FRAC_PI_2))
+            .rotated_by(Quat::from_rotation_y(0.7))
+            .translated_by(Vec3::new(0.28, 0.03, 0.22)),
+        dark,
+    ));
 
-    // Branch 1 (upper right): rot z −0.8, darker.
-    let b1 = branch(
-        0.025,
-        0.04,
-        0.42,
-        Vec3::new(0.0, 0.0, -0.8),
-        Vec3::new(0.2, 0.7, 0.08),
-        lin(DEAD_WOOD_DARK),
-    );
-    // Branch 2 (upper left): rot z 0.7, darker.
-    let b2 = branch(
-        0.022,
-        0.035,
-        0.36,
-        Vec3::new(0.0, 0.0, 0.7),
-        Vec3::new(-0.17, 0.82, -0.04),
-        lin(DEAD_WOOD_DARK),
-    );
-    // Branch 3 (mid upper right): rot [0.4, 0, 0.2], trunk tone.
-    let b3 = branch(
-        0.018,
-        0.028,
-        0.3,
-        Vec3::new(0.4, 0.0, 0.2),
-        Vec3::new(0.06, 1.0, 0.13),
-        lin(DEAD_WOOD),
-    );
-    // Branch 4 (mid upper left): rot [−0.3, 0, −0.4], trunk tone.
-    let b4 = branch(
-        0.016,
-        0.024,
-        0.26,
-        Vec3::new(-0.3, 0.0, -0.4),
-        Vec3::new(-0.08, 1.05, -0.1),
-        lin(DEAD_WOOD),
-    );
-
-    merged(vec![trunk, b1, b2, b3, b4])
+    merged(parts)
 }
 
 // ── Pine / spruce conifer — short brown trunk + 3 stacked green cone tiers + a tip ──
@@ -318,25 +362,33 @@ fn build_dead() -> Mesh {
 // lush dark→light green spruce. Wide low tier → narrow high tier, each base overlapping
 // the one below so the boughs layer. ~1.65u tall (towers a touch over the broadleaf).
 fn build_pine() -> Mesh {
-    // Short stub trunk poking out under the lowest boughs.
-    let trunk = tinted(
-        trunk_part(0.07, 0.09, 0.40, 6, Vec3::new(0.0, 0.20, 0.0)),
-        lin(TREE_TRUNK),
-    );
+    let bark = lin(TREE_TRUNK);
+    // Stub trunk under the boughs + a shallow root flare gripping the ground.
+    let mut parts = vec![tinted(trunk_part(0.07, 0.095, 0.42, 6, Vec3::new(0.0, 0.21, 0.0)), bark)];
+    parts.extend(root_flare(0.095, 3, 0.12, bark, 0.8));
 
-    // Three green cone tiers, dark (shadowed base) → mid → light (sunlit crown). 7 sides
-    // so the cones read crisply faceted once flat-shaded. (base_y, radius, height, tone).
-    let tiers = [
-        (0.30_f32, 0.52_f32, 0.62_f32, FOLIAGE_DARK),
-        (0.66, 0.40, 0.56, FOLIAGE_MID),
-        (1.02, 0.28, 0.50, FOLIAGE_LIGHT),
+    // Five overlapping bough tiers, dark shadowed skirt → sunlit crown, each nudged a
+    // touch off the spire axis and yawed so the faceted cones never align — the jitter is
+    // what turns "stacked party hats" into a grown spruce. 8 sides for crisper facets.
+    // (base_y, radius, height, xz-nudge, yaw, tone)
+    let tiers: [(f32, f32, f32, Vec3, f32, u32); 5] = [
+        (0.26, 0.54, 0.52, Vec3::new(0.02, 0.0, -0.02), 0.0, FOLIAGE_DARK),
+        (0.52, 0.46, 0.50, Vec3::new(-0.03, 0.0, 0.02), 0.4, FOLIAGE_DARK),
+        (0.78, 0.38, 0.48, Vec3::new(0.02, 0.0, 0.03), 0.8, FOLIAGE_MID),
+        (1.04, 0.30, 0.44, Vec3::new(-0.02, 0.0, -0.02), 1.2, FOLIAGE_MID),
+        (1.28, 0.22, 0.38, Vec3::new(0.01, 0.0, 0.01), 1.6, FOLIAGE_LIGHT),
     ];
-    let mut parts = vec![trunk];
-    for (base_y, r, h, c) in tiers {
-        parts.push(tinted(cone_at(r, h, base_y, 7, Vec3::ZERO), lin(c)));
+    for (base_y, r, h, nudge, yaw, c) in tiers {
+        let m = Cone { radius: r, height: h }
+            .mesh()
+            .resolution(8)
+            .build()
+            .rotated_by(Quat::from_rotation_y(yaw))
+            .translated_by(Vec3::new(nudge.x, h * 0.5 + base_y, nudge.z));
+        parts.push(tinted(m, lin(c)));
     }
-    // A small light crown tip capping the spire.
-    parts.push(tinted(cone_at(0.14, 0.28, 1.40, 7, Vec3::ZERO), lin(FOLIAGE_LIGHT)));
+    // The sunlit leader spike capping the spire (~1.78u total).
+    parts.push(tinted(cone_at(0.12, 0.30, 1.48, 7, Vec3::ZERO), lin(FOLIAGE_LIGHT)));
 
     merged(parts)
 }

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -932,20 +932,61 @@ fn ore_crystal_mesh() -> Mesh {
     ])
 }
 
-/// Small standout apple tree: a brown trunk, a bright orchard-green canopy (lighter than the
-/// forest's pines/broadleaf so it reads as special) studded with red apples. Trunk base at y=0.
+/// Small standout apple tree: a gnarled orchard trunk forking into three limbs, a full
+/// three-tone canopy (shadowed underside → orchard green → sunlit top, brighter than the
+/// forest's pines/broadleaf so it reads as special) dusted with pale blossom, and a root
+/// flare gripping the grass. Trunk base at y=0. The canopy covers every `APPLE_SPOTS`
+/// hang point (x ±0.4, y 0.74–1.22) — the apples are separate child entities that pop off.
 fn apple_tree_mesh() -> Mesh {
     let trunk = lin(0x6b4a2a);
+    let leaf_dk = lin(0x3d7e2e);
     let leaf = lin(0x4f9c3a);
     let leaf_hi = lin(0x74c64c);
-    // Trunk + canopy only — the apples are separate child entities so they can pop off.
-    cgroup(vec![
-        ccyl(0.11, 0.74, v(0.0, 0.37, 0.0), Quat::IDENTITY, trunk),
-        csph(0.44, v(0.0, 0.98, 0.0), leaf),
-        csph(0.34, v(0.30, 0.88, 0.12), leaf_hi),
-        csph(0.32, v(-0.28, 0.90, -0.10), leaf),
-        csph(0.30, v(0.06, 1.20, -0.16), leaf_hi),
-    ])
+    let blossom = lin(0xf3e9da);
+    let mut parts = vec![
+        // Stout tapering bole, kinked a touch off plumb like a pruned orchard tree.
+        ccyl(0.115, 0.42, v(0.0, 0.21, 0.0), Quat::IDENTITY, trunk),
+        ccyl(0.085, 0.34, v(0.025, 0.52, 0.01), rz(-0.10), trunk),
+        // Three limbs forking from the bole crook up into the canopy.
+        ccyl(0.045, 0.34, v(0.20, 0.78, 0.10), rz(-0.55), trunk),
+        ccyl(0.042, 0.32, v(-0.18, 0.80, -0.05), rz(0.60), trunk),
+        ccyl(0.038, 0.28, v(0.02, 0.84, -0.14), rx(0.5), trunk),
+    ];
+    // Root flare: four stubby toes leaning out from the foot.
+    for i in 0..4 {
+        let a = 0.5 + i as f32 * std::f32::consts::FRAC_PI_2;
+        parts.push(ccyl(
+            0.045,
+            0.14,
+            v(a.cos() * 0.10, 0.045, a.sin() * 0.10),
+            ry(-a) * rz(1.0),
+            trunk,
+        ));
+    }
+    // Canopy: dark grounded underside → mid body → sunlit cap, wrapping the hang spots.
+    for (r, x, yy, z, c) in [
+        (0.40, 0.0, 0.86, 0.04, leaf_dk),   // core mass
+        (0.30, 0.32, 0.84, 0.16, leaf),     // east lobe (covers spot 1)
+        (0.30, -0.32, 0.88, 0.04, leaf),    // west lobe (covers spot 2)
+        (0.27, 0.10, 0.80, 0.34, leaf_dk),  // south lobe (covers spot 3)
+        (0.28, 0.26, 1.06, -0.08, leaf),    // upper-east (spot 4)
+        (0.26, -0.18, 1.10, 0.20, leaf_hi), // upper-west (spot 5)
+        (0.26, 0.02, 1.22, 0.02, leaf_hi),  // crown (spot 6)
+        (0.18, 0.12, 1.34, -0.06, leaf_hi), // sunlit tip
+    ] {
+        parts.push(csph(r, v(x, yy, z), c));
+    }
+    // A dusting of pale blossom over the sunny side — the orchard tree's calling card.
+    for (x, yy, z) in [
+        (0.30_f32, 1.22_f32, 0.14_f32),
+        (-0.26, 1.26, -0.06),
+        (0.06, 1.40, 0.10),
+        (0.42, 1.00, 0.20),
+        (-0.38, 1.06, 0.16),
+    ] {
+        parts.push(csph(0.045, v(x, yy, z), blossom));
+    }
+    cgroup(parts)
 }
 
 /// Gatherable swamp bramble: a squat dark-green leaf mound dotted with near-black blackberries


### PR DESCRIPTION
## Summary

This PR significantly enhances the visual fidelity and detail of biome props across snow, swamp, and rocky biomes by introducing **baked facet shading** (painterly per-face lighting baked into vertex colours) and substantially expanding prop variety, geometry, and storytelling detail. The changes maintain the low-poly aesthetic while dramatically improving the read of form and lighting through smarter mesh construction and colour baking.

## Key Changes

### Snow Biome (`biome_snow.rs`)
- **Baked facet shading system**: New `bake_facet_shading()` function darkens and cools down-facing facets toward blue (shadowed snow reads blue, not grey) while brightening up-facing facets, with a mild base-to-crown lift. Applied via the new `shaded()` finish function to every prop.
- **Pine trees**: Upgraded from simple 3-tier stacked cones to a sophisticated 3-variant system (broad+heavy, standard+light, tall slim 5-tier spire) with off-axis zig-zag silhouettes, per-tier snow draping (skirt cone + 3 squashed blobs), and proper crown detail.
- **Birch trees**: Now feature kinked two-segment trunks and two-storey twig fans.
- **Mounds**: Three variants (wind-sculpted drift, frost-tipped shrub, snow-capped stump+log) replacing the simple low-roughness class.
- **Boulders**: Angular tilted rock chunks with dark exposed footings, snow draping, and hanging icicles.
- **Snowman**: Added as a rare centrepiece prop.
- **Ground cover**: Expanded to snow tufts with dry winter grass, angular ice glints, and litter (holly sprig, pinecone, ice shards, frosted twig).
- **Frozen pond landmark**: Enhanced with frosted rim, shoreline ice-shard clumps, drift tongue, and angular snow-capped stone cairn.
- **New colour constants**: `STUMP_WOOD`, `STUMP_CUT`, `GRASS_DRY` for warm accents poking through the snowfield.

### Swamp Biome (`biome_swamp.rs`)
- **Baked light/shadow**: Every prop now bakes mud-dark waterline feet brightening toward sunlit crowns via `lin_scaled(c, v)` scaling.
- **Mangrove trees**: Upgraded to three-segment crooked trunks (dark water-stained foot → pale sunlit top) on flared buttress root fins + stilt roots, five drooping limbs, broad flat layered canopy (dark underside skirt, mid layer, bright sunlit lobes), and two-tone hanging-moss strands with wispy blobs. Three variants vary lean/fullness/phase.
- **Cypress-knee stumps**: Now feature fluted mossy bark drums on dark mud skirts, damp cut tops with rotten hollows, rim splinters, shelf-fungus brackets, and cypress knees leaning back. Two variants (one carries a tall snapped shard).
- **Cattail reeds**: Stalks fanning from dark wet sheaths, half with brown seed heads + pale flowering spikes, plus broad flattened leaf blades.
- **Swamp accents**: Toadstool clusters with baked gill shadows, sunlit cap bumps, pale flecks; mud-skirted mossy boulders with stepped shelf fungus; taller toadstool trios; half-sunken logs (broken-end shards, snag branches, moss saddle, bracket).
- **Ground cover**: Two-tone moss patches with bright sunlit tufts, reed sprigs, double swamp mushrooms, lily-pad drifts (one variant with pale pink lotus bud), bog cotton, lilac marsh flowers.
- **New helpers**: `lean_cone()` for stalks/buttresses/knees/snags, `shelf_bracket()` for fungus brackets. Colour constants now use `lin_scaled()` for baked shading.
- **Glowmush cluster**: Expanded from 5 to 6 mushrooms per cluster

https://claude.ai/code/session_01BPocgR9yi3aeo6zFHcw7zv