### PR TITLE
Enrich creature and player models with anatomical detail

### DIFF
--- a/.claude/skills/visual-debug-cloud/SKILL.md
+++ b/.claude/skills/visual-debug-cloud/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: visual-debug-cloud
+description: Render and inspect game screenshots headlessly in a cloud container (no GPU, no display). Use when verifying any visual change — models, lighting, UI, biomes — from Claude Code on the web, or when the user asks to "see" the game from a remote session. Covers container setup (apt packages, xvfb, Mesa software Vulkan), the FOREST_SHOT capture workflow, staging env vars, and framing tips.
+---
+
+# Visual debugging in the cloud (headless screenshots)
+
+The Bevy window cannot be captured externally, and a fresh cloud container has **no GPU and
+no display server**. This skill renders real in-game screenshots anyway: Xvfb provides a
+virtual X11 display, Mesa's **llvmpipe/lavapipe** provides a software Vulkan adapter, and the
+game's built-in `FOREST_SHOT` harness (`src/capture.rs`) renders ~90 frames (so lighting/IBL
+settle), saves a PNG, and exits.
+
+## 1. One-time container setup (re-run every fresh container — they're ephemeral)
+
+```bash
+sudo apt-get update && sudo apt-get install -y \
+  libwayland-dev libxkbcommon-dev libudev-dev libasound2-dev \
+  xvfb mesa-vulkan-drivers libgl1-mesa-dri libegl1 libxkbcommon-x11-0
+```
+
+- Line 1 is Bevy's standard Linux build deps (already documented in CLAUDE.md — without them
+  the *build* fails in a `wayland-client not found` build script).
+- Line 2 is the headless-render stack: `xvfb` (virtual X display), `mesa-vulkan-drivers`
+  (lavapipe — the CPU Vulkan driver wgpu picks up), `libgl1-mesa-dri`/`libegl1` (GL fallback),
+  and **`libxkbcommon-x11-0`** — without this exact package winit panics at startup under
+  X11 (`Failed loading libxkbcommon-x11.so.0`).
+
+Then build once (first build recompiles Bevy at opt-level 3, ~3 min; later builds are fast):
+
+```bash
+cargo build
+```
+
+## 2. Taking a shot
+
+```bash
+FOREST_SHOT=/tmp/shot.png FOREST_TIME=0.25 \
+  timeout 570 xvfb-run -a -s "-screen 0 1280x720x24" \
+  ./target/debug/tileworld_bevy_forest >/dev/null 2>&1
+```
+
+Then **view the PNG with the Read tool** to actually inspect it.
+
+Notes:
+- Expect **~3–5 minutes per shot** on llvmpipe (the `software rendering ... very slow`
+  warning and the X11 `XSETTINGS` warning are normal). Wrap in `timeout 570` so a hang
+  can't eat the Bash tool's 10-minute ceiling.
+- Run shots **sequentially**, not in parallel — llvmpipe saturates all cores.
+- Run from the repo root so `assets/` resolves (or set `BEVY_ASSET_ROOT`).
+- The HUD renders over the scene (the harness boots straight into Playing); ignore it.
+- Sim time during a capture is short (frame `dt` is clamped), but wandering NPCs still
+  drift a little — frame staged shots with some margin.
+
+## 3. Staging the scene
+
+All `FOREST_*` env hooks from CLAUDE.md work here; the load-bearing ones for visual checks:
+
+| Var | Use |
+|---|---|
+| `FOREST_CAM="x,y,z,tx,ty,tz"` | camera at xyz looking at txtytz — THE framing tool |
+| `FOREST_TIME=0.25` | fixed time-of-day (0.25 ≈ midday; without it a slow render drifts the sun) |
+| `FOREST_HERO="x,z"` | drop the hero at a world XZ |
+| `FOREST_EQUIP="axe,leather_armor"` | equip item ids so the hero shows that weapon/armor |
+| `FOREST_ORKLINE="x,z"` | park one ork of each variant in an idle line (model close-ups) |
+| `FOREST_WAVE=1` / `FOREST_DEFEND=1` | stage a night siege / arm defenses |
+| `FOREST_BIOME` / `FOREST_PANEL` / `FOREST_MENU` | biome view / UI panels / start screen |
+
+Useful anchors for framing (castle at world origin, 1 tile = 1 unit):
+- Hero default spawn: just outside the **north gate** at ~`(0, -15)`, facing the castle
+  (+Z). A good close-up: `FOREST_CAM="0.55,0.8,-13.85,0,0.45,-15"`. Mirror x (or use
+  `-0.55`) to see the shield side.
+- Walls run at `x=±17`, `z=±12` with gates at the axis midpoints (`castle::gate_centers`).
+- Hero is small (~0.9u tall after `HERO_SCALE`); a camera ~1.5–2u away at y≈0.8–1.0
+  looking at y≈0.45 fills the frame. Orks are ~1.3–1.6u; back off to 4–9u for a group.
+
+## 4. Verification workflow for model/visual changes
+
+1. `cargo check` + `cargo test -p tileworld_core` first — geometry mistakes (e.g. calling
+   `compute_flat_normals` on an indexed mesh) panic at *runtime*, so a shot is also the
+   crash test.
+2. Take one **default-camera sanity shot** (no `FOREST_CAM`) to confirm the app boots and
+   renders end-to-end.
+3. Then **staged close-ups** of the thing you changed. Check: feet on the ground (base at
+   y=0), no floating/orphaned parts, no obvious z-fighting (coplanar faces), colours read
+   correctly, and silhouettes still match at gameplay camera distance.
+4. Shots cost minutes — batch your look: one front-quarter close-up plus one pulled-back
+   shot usually answers everything.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Env hooks that stage a scene for a shot (combine with `FOREST_SHOT`), all read a
 | `FOREST_HERO="x,z"` | drop the hero at a world XZ (e.g. deep in a biome region) to stage its reactive atmosphere/weather |
 | `FOREST_BIOME` | boot straight into a given biome |
 | `FOREST_WAVE` / `FOREST_DEFEND=1` | stage a night siege / arm all defenses + walls |
+| `FOREST_ORKLINE="x,z"` | park one ork of each variant in an idle line at a world XZ (model close-ups) |
 | `FOREST_MENU=1` | shoot the start screen |
 | `FOREST_PANEL=tree\|inv` | seed + open the upgrade-tree / satchel panel for a shot |
 | `FOREST_EQUIP="sword_gold,gold_armor"` | equip the listed item ids at startup so the hero model shows its weapon/armor |

--- a/src/camps.rs
+++ b/src/camps.rs
@@ -238,6 +238,19 @@ pub fn build(commands: &mut Commands, meshes: &mut Assets<Mesh>, materials: &mut
 
     let armory = orks::Armory::new(meshes, materials, mat.clone());
 
+    // Screenshot hook: `FOREST_ORKLINE="x,z"` parks one ork of each variant in a line at the
+    // given world XZ, each home-anchored on its own spot so it idles in place for the shot —
+    // pair with `FOREST_CAM` to frame the warband close up.
+    if let Ok(s) = std::env::var("FOREST_ORKLINE") {
+        let p: Vec<f32> = s.split(',').filter_map(|t| t.trim().parse().ok()).collect();
+        if p.len() == 2 {
+            for (i, variant) in VARIANTS.iter().enumerate() {
+                let pos = Vec2::new(p[0] + i as f32 * 1.8 - 2.7, p[1]);
+                armory.spawn(commands, *variant, Faction::Red, pos, pos, 11 + i as u32);
+            }
+        }
+    }
+
     for (camp, site) in sites.iter().enumerate() {
         let rot_q = Quat::from_rotation_y(site.rot);
         let cy = worldmap::ground_at_world(site.centre.x, site.centre.y).unwrap_or(0.0);

--- a/src/critters.rs
+++ b/src/critters.rs
@@ -139,6 +139,7 @@ pub fn build(s: Species) -> CreatureSpec {
 // ─── Wolf ───────────────────────────────────────────────────────────────────────
 fn wolf() -> CreatureSpec {
     const FUR: u32 = 0x6b6f78;
+    const LIGHT: u32 = 0x8a8e96;
     const DARK: u32 = 0x494d55;
     const SNOUT: u32 = 0x3a3e44;
     const NOSE: u32 = 0x141414;
@@ -146,18 +147,37 @@ fn wolf() -> CreatureSpec {
     let torso = group(vec![
         bx(0.42, 0.42, 1.0, v(0.0, 0.62, 0.0), FUR),
         bx(0.44, 0.4, 0.42, v(0.0, 0.7, 0.28), FUR),
+        bx(0.5, 0.46, 0.2, v(0.0, 0.68, 0.42), DARK), // chest ruff collar
+        bx(0.12, 0.05, 0.92, v(0.0, 0.845, -0.02), DARK), // dark saddle stripe down the spine
+        bx(0.38, 0.08, 0.78, v(0.0, 0.43, 0.02), LIGHT), // pale belly
+        bx(0.15, 0.32, 0.36, v(-0.19, 0.6, -0.3), FUR), // haunches over the hind legs
+        bx(0.15, 0.32, 0.36, v(0.19, 0.6, -0.3), FUR),
     ]);
     let head = group(vec![
         bx(0.32, 0.3, 0.32, v(0.0, 0.0, 0.0), FUR),
         bx(0.16, 0.14, 0.22, v(0.0, -0.06, 0.22), SNOUT),
+        bx(0.14, 0.05, 0.16, v(0.0, -0.14, 0.21), LIGHT), // lower jaw
         bx(0.08, 0.06, 0.05, v(0.0, -0.04, 0.34), NOSE),
         cone(0.07, 0.18, v(-0.11, 0.22, -0.02), rz(-0.1), DARK),
         cone(0.07, 0.18, v(0.11, 0.22, -0.02), rz(0.1), DARK),
-        bx(0.04, 0.04, 0.01, v(-0.09, 0.03, 0.15), EYE),
-        bx(0.04, 0.04, 0.01, v(0.09, 0.03, 0.15), EYE),
+        bx(0.07, 0.03, 0.05, v(-0.09, 0.07, 0.145), DARK), // brow ridges
+        bx(0.07, 0.03, 0.05, v(0.09, 0.07, 0.145), DARK),
+        bx(0.04, 0.04, 0.01, v(-0.09, 0.03, 0.165), EYE),
+        bx(0.04, 0.04, 0.01, v(0.09, 0.03, 0.165), EYE),
+        bx(0.05, 0.16, 0.20, v(-0.165, -0.07, 0.02), LIGHT), // cheek fur tufts
+        bx(0.05, 0.16, 0.20, v(0.165, -0.07, 0.02), LIGHT),
     ]);
-    let tail = group(vec![bxr(0.13, 0.13, 0.4, v(0.0, 0.04, -0.18), rx(0.7), DARK)]);
-    let mut parts = legs(0.52, 0.16, 0.34, -0.34, &|| bx(0.12, 0.5, 0.13, v(0.0, -0.25, 0.0), DARK));
+    let tail = group(vec![
+        bxr(0.13, 0.13, 0.4, v(0.0, 0.04, -0.18), rx(0.7), DARK),
+        bxr(0.10, 0.10, 0.16, v(0.0, 0.215, -0.345), rx(0.7), LIGHT), // pale brush tip
+    ]);
+    let leg = || {
+        group(vec![
+            bx(0.12, 0.5, 0.13, v(0.0, -0.25, 0.0), DARK),
+            bx(0.13, 0.07, 0.16, v(0.0, -0.485, 0.02), LIGHT), // paw
+        ])
+    };
+    let mut parts = legs(0.52, 0.16, 0.34, -0.34, &leg);
     parts.push(PartDef { kind: PartKind::Head, pivot: v(0.0, 0.8, 0.56), mesh: head });
     parts.push(PartDef { kind: PartKind::Tail, pivot: v(0.0, 0.62, -0.5), mesh: tail });
     CreatureSpec { torso, parts }
@@ -173,9 +193,16 @@ fn deer() -> CreatureSpec {
     let torso = group(vec![
         bx(0.34, 0.36, 0.85, v(0.0, 0.95, 0.0), COAT),
         bx(0.3, 0.1, 0.78, v(0.0, 0.8, 0.0), BELLY),
+        bx(0.3, 0.24, 0.05, v(0.0, 0.93, -0.41), BELLY), // pale rump patch
+        // fawn spots dappled along the back
+        bx(0.04, 0.012, 0.04, v(-0.09, 1.131, 0.18), BELLY),
+        bx(0.04, 0.012, 0.04, v(0.08, 1.131, 0.02), BELLY),
+        bx(0.04, 0.012, 0.04, v(-0.07, 1.131, -0.16), BELLY),
+        bx(0.04, 0.012, 0.04, v(0.1, 1.131, -0.3), BELLY),
     ]);
     let head = group(vec![
         bxr(0.15, 0.45, 0.15, v(0.0, 0.18, 0.04), rx(-0.5), COAT),
+        bxr(0.1, 0.34, 0.06, v(0.0, 0.17, 0.115), rx(-0.5), BELLY), // pale throat
         bx(0.18, 0.2, 0.34, v(0.0, 0.42, 0.2), COAT),
         bx(0.12, 0.12, 0.14, v(0.0, 0.38, 0.4), DARK),
         bx(0.07, 0.06, 0.04, v(0.0, 0.38, 0.48), NOSE),
@@ -183,11 +210,22 @@ fn deer() -> CreatureSpec {
         bx(0.03, 0.03, 0.01, v(0.07, 0.5, 0.28), NOSE),
         cone(0.05, 0.16, v(-0.13, 0.52, 0.16), rz(-0.5), DARK),
         cone(0.05, 0.16, v(0.13, 0.52, 0.16), rz(0.5), DARK),
-        cone(0.022, 0.22, v(-0.08, 0.62, 0.12), xyz(0.2, 0.0, -0.3), ANTLER),
-        cone(0.022, 0.22, v(0.08, 0.62, 0.12), xyz(0.2, 0.0, 0.3), ANTLER),
+        // antlers: a main beam each side with two forward tines (was a single spike)
+        bxr(0.035, 0.3, 0.035, v(-0.09, 0.65, 0.1), xyz(0.15, 0.0, 0.3), ANTLER),
+        bxr(0.028, 0.18, 0.028, v(-0.14, 0.76, 0.16), xyz(-0.6, 0.0, 0.25), ANTLER),
+        bxr(0.025, 0.15, 0.025, v(-0.18, 0.85, 0.1), xyz(0.2, 0.0, 0.5), ANTLER),
+        bxr(0.035, 0.3, 0.035, v(0.09, 0.65, 0.1), xyz(0.15, 0.0, -0.3), ANTLER),
+        bxr(0.028, 0.18, 0.028, v(0.14, 0.76, 0.16), xyz(-0.6, 0.0, -0.25), ANTLER),
+        bxr(0.025, 0.15, 0.025, v(0.18, 0.85, 0.1), xyz(0.2, 0.0, -0.5), ANTLER),
     ]);
     let tail = group(vec![bx(0.08, 0.16, 0.08, v(0.0, -0.04, -0.04), COAT)]);
-    let mut parts = legs(0.78, 0.13, 0.32, -0.32, &|| bx(0.08, 0.74, 0.08, v(0.0, -0.37, 0.0), DARK));
+    let leg = || {
+        group(vec![
+            bx(0.08, 0.7, 0.08, v(0.0, -0.35, 0.0), DARK),
+            bx(0.07, 0.05, 0.09, v(0.0, -0.715, 0.005), NOSE), // hoof
+        ])
+    };
+    let mut parts = legs(0.78, 0.13, 0.32, -0.32, &leg);
     parts.push(PartDef { kind: PartKind::Head, pivot: v(0.0, 1.05, 0.4), mesh: head });
     parts.push(PartDef { kind: PartKind::Tail, pivot: v(0.0, 1.0, -0.42), mesh: tail });
     CreatureSpec { torso, parts }
@@ -212,16 +250,28 @@ fn boar() -> CreatureSpec {
     let head = group(vec![
         bx(0.38, 0.34, 0.36, v(0.0, 0.0, 0.0), HIDE),
         bx(0.2, 0.18, 0.22, v(0.0, -0.08, 0.24), SNOUT),
+        bx(0.16, 0.07, 0.16, v(0.0, -0.185, 0.22), DARK), // lower jaw
         bx(0.12, 0.1, 0.05, v(0.0, -0.06, 0.36), NOSE),
+        bx(0.025, 0.035, 0.012, v(-0.03, -0.06, 0.385), BRISTLE), // nostrils on the disc
+        bx(0.025, 0.035, 0.012, v(0.03, -0.06, 0.385), BRISTLE),
         cone(0.028, 0.16, v(-0.1, -0.12, 0.3), xyz(-0.5, 0.0, -0.2), TUSK),
         cone(0.028, 0.16, v(0.1, -0.12, 0.3), xyz(-0.5, 0.0, 0.2), TUSK),
         cone(0.06, 0.14, v(-0.16, 0.18, -0.02), rz(-0.4), DARK),
         cone(0.06, 0.14, v(0.16, 0.18, -0.02), rz(0.4), DARK),
-        bx(0.04, 0.04, 0.01, v(-0.1, 0.04, 0.17), NOSE),
-        bx(0.04, 0.04, 0.01, v(0.1, 0.04, 0.17), NOSE),
+        cone(0.04, 0.1, v(0.0, 0.20, 0.06), rx(-0.3), BRISTLE), // forelock bristle
+        bx(0.04, 0.04, 0.01, v(-0.1, 0.04, 0.185), NOSE),
+        bx(0.04, 0.04, 0.01, v(0.1, 0.04, 0.185), NOSE),
     ]);
-    let mut parts = legs(0.36, 0.18, 0.3, -0.3, &|| bx(0.13, 0.34, 0.14, v(0.0, -0.17, 0.0), DARK));
+    let tail = group(vec![bxr(0.05, 0.2, 0.05, v(0.0, -0.07, -0.02), rx(0.45), DARK)]);
+    let leg = || {
+        group(vec![
+            bx(0.13, 0.3, 0.14, v(0.0, -0.15, 0.0), DARK),
+            bx(0.12, 0.05, 0.15, v(0.0, -0.315, 0.01), BRISTLE), // trotter
+        ])
+    };
+    let mut parts = legs(0.36, 0.18, 0.3, -0.3, &leg);
     parts.push(PartDef { kind: PartKind::Head, pivot: v(0.0, 0.6, 0.55), mesh: head });
+    parts.push(PartDef { kind: PartKind::Tail, pivot: v(0.0, 0.64, -0.44), mesh: tail });
     CreatureSpec { torso, parts }
 }
 
@@ -268,18 +318,33 @@ fn polar_bear() -> CreatureSpec {
     let torso = group(vec![
         bx(0.62, 0.58, 1.3, v(0.0, 0.68, 0.0), BODY),
         bx(0.58, 0.46, 0.56, v(0.0, 0.82, 0.38), BODY),
+        bx(0.5, 0.16, 0.5, v(0.0, 1.02, 0.1), BODY), // shoulder hump
+        bx(0.56, 0.1, 1.1, v(0.0, 0.42, 0.0), SHADOW), // shaded underbelly
+        bx(0.2, 0.36, 0.4, v(-0.26, 0.66, -0.4), BODY), // haunches
+        bx(0.2, 0.36, 0.4, v(0.26, 0.66, -0.4), BODY),
     ]);
     let head = group(vec![
         bx(0.42, 0.4, 0.42, v(0.0, 0.0, 0.0), BODY),
         bx(0.22, 0.18, 0.24, v(0.0, -0.07, 0.26), SNOUT),
+        bx(0.18, 0.06, 0.18, v(0.0, -0.17, 0.24), SHADOW), // lower jaw
         bx(0.1, 0.07, 0.05, v(0.0, -0.05, 0.39), NOSE),
+        bx(0.36, 0.05, 0.06, v(0.0, 0.12, 0.19), SHADOW), // brow shading
         cone(0.09, 0.14, v(-0.16, 0.24, -0.06), rz(-0.08), SHADOW),
         cone(0.09, 0.14, v(0.16, 0.24, -0.06), rz(0.08), SHADOW),
-        bx(0.05, 0.05, 0.01, v(-0.12, 0.04, 0.21), EYE),
-        bx(0.05, 0.05, 0.01, v(0.12, 0.04, 0.21), EYE),
+        bx(0.05, 0.05, 0.01, v(-0.12, 0.04, 0.215), EYE),
+        bx(0.05, 0.05, 0.01, v(0.12, 0.04, 0.215), EYE),
     ]);
     let tail = group(vec![bx(0.12, 0.12, 0.18, v(0.0, 0.0, -0.08), SHADOW)]);
-    let mut parts = legs(0.55, 0.22, 0.38, -0.38, &|| bx(0.18, 0.55, 0.2, v(0.0, -0.275, 0.0), SHADOW));
+    let leg = || {
+        group(vec![
+            bx(0.18, 0.5, 0.2, v(0.0, -0.25, 0.0), SHADOW),
+            bx(0.2, 0.1, 0.24, v(0.0, -0.5, 0.02), BODY), // broad paw
+            cone(0.02, 0.06, v(-0.06, -0.53, 0.15), rx(1.2), NOSE), // claws
+            cone(0.02, 0.06, v(0.0, -0.53, 0.15), rx(1.2), NOSE),
+            cone(0.02, 0.06, v(0.06, -0.53, 0.15), rx(1.2), NOSE),
+        ])
+    };
+    let mut parts = legs(0.55, 0.22, 0.38, -0.38, &leg);
     parts.push(PartDef { kind: PartKind::Head, pivot: v(0.0, 0.92, 0.72), mesh: head });
     parts.push(PartDef { kind: PartKind::Tail, pivot: v(0.0, 0.68, -0.66), mesh: tail });
     CreatureSpec { torso, parts }
@@ -473,23 +538,41 @@ fn golem() -> CreatureSpec {
     const CORE: u32 = 0x7ad2ff; // bright cyan reads as a glowing heart-stone
     let torso = group(vec![
         bx(0.74, 0.72, 0.56, v(0.0, 0.95, 0.0), STONE),
+        bxr(0.34, 0.26, 0.3, v(-0.28, 1.26, -0.06), xyz(0.25, 0.4, 0.2), STONE), // shoulder crags
+        bxr(0.3, 0.22, 0.28, v(0.3, 1.24, -0.04), xyz(-0.2, 0.3, -0.25), STONE),
+        bxr(0.52, 0.5, 0.18, v(0.0, 1.0, -0.3), xyz(0.15, 0.0, 0.1), DARK), // back slab
         bx(0.16, 0.12, 0.2, v(-0.34, 1.18, 0.0), MOSS), // shoulder moss
         bx(0.16, 0.12, 0.2, v(0.34, 1.18, 0.0), MOSS),
+        bx(0.2, 0.1, 0.14, v(0.1, 1.14, -0.34), MOSS), // back-slab moss
         bx(0.2, 0.22, 0.06, v(0.0, 0.96, 0.3), CORE), // chest core
+        bx(0.04, 0.2, 0.03, v(-0.2, 0.85, 0.275), CORE), // glowing seams radiating from the core
+        bx(0.18, 0.04, 0.03, v(0.18, 1.1, 0.275), CORE),
     ]);
     let head = group(vec![
         bx(0.42, 0.36, 0.36, v(0.0, 0.0, 0.0), STONE),
         bx(0.4, 0.08, 0.06, v(0.0, 0.12, 0.18), DARK), // brow ridge
+        cone(0.07, 0.16, v(-0.13, 0.22, -0.04), rz(0.3), STONE), // crown crags
+        cone(0.06, 0.13, v(0.1, 0.23, 0.02), rz(-0.25), STONE),
+        bx(0.14, 0.05, 0.12, v(0.04, 0.205, -0.1), MOSS), // mossy scalp
         bx(0.08, 0.08, 0.03, v(-0.12, 0.02, 0.18), CORE), // glowing eyes
         bx(0.08, 0.08, 0.03, v(0.12, 0.02, 0.18), CORE),
+        bx(0.3, 0.05, 0.04, v(0.0, -0.13, 0.18), DARK), // grim mouth slit
     ]);
     let arm = || {
         group(vec![
             bx(0.26, 0.6, 0.26, v(0.0, -0.3, 0.0), DARK),
+            bx(0.02, 0.34, 0.03, v(-0.13, -0.28, 0.06), CORE), // cracked glow seam
             bx(0.3, 0.26, 0.3, v(0.0, -0.66, 0.02), STONE), // fist
+            bx(0.1, 0.08, 0.06, v(-0.07, -0.56, 0.15), DARK), // knuckle stones
+            bx(0.1, 0.08, 0.06, v(0.07, -0.56, 0.15), DARK),
         ])
     };
-    let leg = || bx(0.24, 0.5, 0.26, v(0.0, -0.25, 0.0), DARK);
+    let leg = || {
+        group(vec![
+            bx(0.24, 0.5, 0.26, v(0.0, -0.25, 0.0), DARK),
+            bx(0.27, 0.12, 0.3, v(0.0, -0.44, 0.02), STONE), // boulder foot
+        ])
+    };
     let parts = vec![
         PartDef { kind: PartKind::Leg(1.0), pivot: v(-0.2, 0.5, 0.0), mesh: leg() },
         PartDef { kind: PartKind::Leg(-1.0), pivot: v(0.2, 0.5, 0.0), mesh: leg() },
@@ -555,15 +638,33 @@ fn bog_croc() -> CreatureSpec {
         bx(0.28, 0.1, 0.3, v(0.0, -0.02, 0.26), HIDE), // snout
         bx(0.24, 0.06, 0.26, v(0.0, -0.1, 0.22), DARK), // lower jaw
         bx(0.22, 0.04, 0.04, v(0.0, -0.04, 0.38), TOOTH), // teeth
+        bx(0.2, 0.03, 0.03, v(0.0, -0.09, 0.36), TOOTH), // lower tooth row
+        bx(0.06, 0.025, 0.025, v(-0.12, -0.045, 0.30), TOOTH), // side fangs proud of the lip
+        bx(0.06, 0.025, 0.025, v(0.12, -0.045, 0.30), TOOTH),
+        bx(0.07, 0.04, 0.09, v(-0.1, 0.135, 0.0), DARK), // raised eye ridges
+        bx(0.07, 0.04, 0.09, v(0.1, 0.135, 0.0), DARK),
         bx(0.05, 0.05, 0.05, v(-0.1, 0.1, 0.0), EYE),
         bx(0.05, 0.05, 0.05, v(0.1, 0.1, 0.0), EYE),
+        bx(0.025, 0.025, 0.012, v(-0.05, 0.035, 0.41), DARK), // nostril bumps on the snout tip
+        bx(0.025, 0.025, 0.012, v(0.05, 0.035, 0.41), DARK),
     ]);
-    let tail = group(vec![
+    let mut tail_parts = vec![
         bx(0.3, 0.22, 0.44, v(0.0, 0.0, 0.0), HIDE),
         bx(0.22, 0.16, 0.44, v(0.0, 0.0, -0.4), DARK),
         bx(0.12, 0.1, 0.38, v(0.0, 0.0, -0.78), DARK),
-    ]);
-    let leg = || group(vec![bx(0.16, 0.2, 0.16, v(0.0, -0.1, 0.0), DARK), bx(0.14, 0.08, 0.18, v(0.0, -0.2, 0.03), DARK)]);
+    ];
+    for (i, z) in [0.05f32, -0.25, -0.5].into_iter().enumerate() {
+        // the back's spine ridge continues down the tail, shrinking toward the tip
+        tail_parts.push(cone(0.05 - i as f32 * 0.01, 0.12 - i as f32 * 0.02, v(0.0, 0.11 - i as f32 * 0.03, z), Quat::IDENTITY, DARK));
+    }
+    let tail = group(tail_parts);
+    let leg = || {
+        group(vec![
+            bx(0.16, 0.2, 0.16, v(0.0, -0.1, 0.0), DARK),
+            bx(0.14, 0.08, 0.18, v(0.0, -0.2, 0.03), DARK),
+            bx(0.13, 0.035, 0.05, v(0.0, -0.22, 0.13), TOOTH), // claws
+        ])
+    };
     let mut parts = legs(0.2, 0.3, 0.5, -0.5, &leg);
     parts.push(PartDef { kind: PartKind::Head, pivot: v(0.0, 0.22, 0.9), mesh: head });
     parts.push(PartDef { kind: PartKind::Tail, pivot: v(0.0, 0.2, -0.78), mesh: tail });

--- a/src/orks.rs
+++ b/src/orks.rs
@@ -722,6 +722,9 @@ struct OrkSpec {
 fn v(x: f32, y: f32, z: f32) -> Vec3 {
     Vec3::new(x, y, z)
 }
+fn rx(a: f32) -> Quat {
+    Quat::from_rotation_x(a)
+}
 fn rz(a: f32) -> Quat {
     Quat::from_rotation_z(a)
 }
@@ -768,6 +771,7 @@ fn spec(variant: OrkVariant, faction: Faction) -> OrkSpec {
     let st = stats(variant);
     let skin = lin(st.skin);
     let dark = lin_scaled(st.skin, 0.62); // SKIN_DARK_ACCENT
+    let belly = lin_scaled(st.skin, 1.18); // lighter underbelly plate
     let fac = lin(faction.hex());
     const BELT: u32 = 0x3a2616;
     const TUSK: u32 = 0xece1c2;
@@ -776,63 +780,146 @@ fn spec(variant: OrkVariant, faction: Faction) -> OrkSpec {
     const CLUB_BAND: u32 = 0x1a1008;
     const STAFF_WOOD: u32 = 0x6a4a2a;
     const ORB: u32 = 0xc89cff;
+    const BONE: u32 = 0xd8cfae;
+    const WRAP: u32 = 0x2e1f12; // leather wrist/ankle wraps
+    const RING: u32 = 0xc9a24a; // crude gold earring
+    let hair = lin(CLUB_BAND);
     let body_rot = Quat::from_rotation_x(0.2);
     let body_off = v(0.0, 0.74, 0.05);
+    const PI: f32 = std::f32::consts::PI;
+    const HPI: f32 = std::f32::consts::FRAC_PI_2;
 
-    // Static torso: loincloth (faction) + belt + the pitched body group (torso + war-paint).
-    let torso = group(vec![
+    // Static torso: loincloth (faction) + belt + the pitched body group (torso + underbelly +
+    // war-paint + a leather shoulder strap + a trophy tooth-necklace) — the TS silhouette with
+    // Bevy-side savage dressing on top.
+    let mut torso_parts = vec![
         bx(0.55, 0.2, 0.3, v(0.0, 0.4, 0.0), fac), // loincloth
+        bx(0.15, 0.08, 0.29, v(-0.14, 0.27, 0.0), fac), // ragged hem tatters
+        bx(0.12, 0.06, 0.29, v(0.05, 0.28, 0.0), fac),
+        bx(0.10, 0.07, 0.29, v(0.19, 0.275, 0.0), fac),
         bx(0.56, 0.06, 0.31, v(0.0, 0.49, 0.0), lin(BELT)),
+        bx(0.07, 0.06, 0.02, v(0.0, 0.49, 0.155), lin(BONE)), // belt skull trophy
         baked(bx(0.55, 0.42, 0.34, Vec3::ZERO, skin), body_rot, body_off), // torso
-        baked(bx(0.12, 0.32, 0.006, v(0.0, 0.0, 0.175), fac), body_rot, body_off), // war-paint vert
-        baked(bx(0.4, 0.06, 0.004, v(0.0, 0.0, 0.176), dark), body_rot, body_off), // war-paint horiz
-    ]);
+        baked(bx(0.40, 0.28, 0.014, v(0.0, -0.06, 0.168), belly), body_rot, body_off), // underbelly
+        baked(bx(0.12, 0.32, 0.022, v(0.0, 0.0, 0.175), fac), body_rot, body_off), // war-paint vert
+        baked(bx(0.4, 0.06, 0.016, v(0.0, 0.0, 0.176), dark), body_rot, body_off), // war-paint horiz
+        baked(bxr(0.07, 0.50, 0.018, v(0.0, 0.0, 0.18), rz(0.65), lin(BELT)), body_rot, body_off), // shoulder strap
+        baked(bx(0.34, 0.018, 0.012, v(0.0, 0.185, 0.183), lin(BELT)), body_rot, body_off), // necklace cord
+    ];
+    for i in -2i32..=2 {
+        // trophy teeth strung on the cord, drooping toward the centre
+        let x = i as f32 * 0.07;
+        let y = 0.15 - (2 - i.abs()) as f32 * 0.012;
+        torso_parts.push(baked(cone(0.018, 0.07, v(x, y, 0.185), rx(PI), lin(TUSK)), body_rot, body_off));
+    }
+    let torso = group(torso_parts);
 
-    // Head: skull + brow + eyes + tusks + ears.
-    let head = group(vec![
+    // Head: skull + jutting underbite jaw (the tusks rise from it) + brow + eyes + nostrils +
+    // ears (one with a crude gold ring), topped by per-variant headgear: grunt topknot, scout
+    // faction headband + bone feather, berserker faction-dyed mohawk + cheek war-paint, shaman
+    // bone half-skull headdress with horns.
+    let mut head_parts = vec![
         bx(0.36, 0.34, 0.34, Vec3::ZERO, skin),
+        bx(0.30, 0.11, 0.30, v(0.0, -0.16, 0.05), skin), // underbite jaw
+        bx(0.26, 0.04, 0.02, v(0.0, -0.125, 0.195), dark), // mouth shadow above the jaw lip
         bx(0.32, 0.06, 0.01, v(0.0, 0.06, 0.175), dark),
         bx(0.05, 0.04, 0.008, v(-0.08, 0.02, 0.175), lin(EYE)),
         bx(0.05, 0.04, 0.008, v(0.08, 0.02, 0.175), lin(EYE)),
-        cone(0.026, 0.13, v(-0.08, -0.1, 0.17), rz(-0.15), lin(TUSK)),
-        cone(0.026, 0.13, v(0.08, -0.1, 0.17), rz(0.15), lin(TUSK)),
+        bx(0.02, 0.025, 0.008, v(-0.035, -0.055, 0.176), dark), // nostrils
+        bx(0.02, 0.025, 0.008, v(0.035, -0.055, 0.176), dark),
+        cone(0.028, 0.15, v(-0.09, -0.10, 0.19), rz(-0.15), lin(TUSK)), // tusks (from the jaw)
+        cone(0.028, 0.15, v(0.09, -0.10, 0.19), rz(0.15), lin(TUSK)),
         bx(0.06, 0.12, 0.14, v(-0.2, 0.0, 0.0), skin),
         bx(0.06, 0.12, 0.14, v(0.2, 0.0, 0.0), skin),
-    ]);
+        bx(0.03, 0.05, 0.012, v(-0.2, -0.085, 0.0), lin(RING)), // earring, left ear
+    ];
+    match variant {
+        OrkVariant::Grunt => {
+            head_parts.push(cyl(0.045, 0.10, v(0.0, 0.21, -0.02), Quat::IDENTITY, hair)); // topknot
+            head_parts.push(orb(0.06, v(0.0, 0.28, -0.02), hair));
+        }
+        OrkVariant::Scout => {
+            head_parts.push(bx(0.37, 0.05, 0.35, v(0.0, 0.10, 0.0), fac)); // faction headband
+            head_parts.push(cone(0.02, 0.16, v(0.17, 0.21, -0.05), rz(-0.3), lin(BONE))); // bone feather
+        }
+        OrkVariant::Berserker => {
+            for i in 0..4 {
+                // faction-dyed mohawk, raked back
+                head_parts.push(cone(0.035, 0.15, v(0.0, 0.21, 0.10 - i as f32 * 0.08), rx(-0.15), fac));
+            }
+            head_parts.push(bx(0.04, 0.13, 0.012, v(-0.13, -0.03, 0.174), fac)); // cheek war-paint
+            head_parts.push(bx(0.04, 0.13, 0.012, v(0.13, -0.03, 0.174), fac));
+        }
+        OrkVariant::Shaman => {
+            head_parts.push(bx(0.30, 0.10, 0.30, v(0.0, 0.19, 0.02), lin(BONE))); // half-skull headdress
+            head_parts.push(cone(0.035, 0.18, v(-0.13, 0.26, 0.0), rz(0.5), lin(TUSK))); // horns
+            head_parts.push(cone(0.035, 0.18, v(0.13, 0.26, 0.0), rz(-0.5), lin(TUSK)));
+        }
+    }
+    let head = group(head_parts);
 
-    // Right arm + baked weapon (club for melee, staff + orb for shaman).
+    // Right arm + baked weapon (club for melee, staff + orb for shaman): fur-trimmed spiked
+    // shoulder pad, wrist wrap, then the weapon.
     let mut arm_r = vec![
         bx(0.2, 0.1, 0.3, v(0.0, -0.02, 0.0), dark), // shoulder
+        bx(0.22, 0.05, 0.32, v(0.0, 0.045, 0.0), hair), // fur trim
         bxr(0.17, 0.5, 0.24, v(0.02, -0.25, 0.04), xyz(0.2, 0.0, 0.05), skin), // upper
+        bxr(0.17, 0.06, 0.24, v(0.035, -0.44, 0.065), xyz(0.2, 0.0, 0.05), lin(WRAP)), // wrist wrap
         bxr(0.16, 0.1, 0.22, v(0.04, -0.52, 0.08), xyz(0.2, 0.0, 0.05), dark), // forearm
     ];
+    if !st.shaman {
+        arm_r.push(cone(0.04, 0.13, v(0.0, 0.09, 0.0), xyz(0.0, 0.0, 0.25), lin(CLUB_BAND))); // shoulder spike
+    }
     if st.shaman {
         let wr = xyz(0.1, 0.0, 0.08);
         let wo = v(0.05, -0.5, 0.1);
         arm_r.push(baked(cyl(0.033, 1.1, v(0.0, -0.1, 0.0), Quat::IDENTITY, lin(STAFF_WOOD)), wr, wo));
+        arm_r.push(baked(cyl(0.04, 0.06, v(0.0, -0.45, 0.0), Quat::IDENTITY, lin(WRAP)), wr, wo)); // grip wrap
         arm_r.push(baked(orb(0.1, v(0.0, 0.5, 0.0), lin(ORB)), wr, wo));
+        // bone claw cradling the orb + a faction tassel under it
+        arm_r.push(baked(cone(0.02, 0.13, v(-0.06, 0.42, 0.0), rz(0.35), lin(TUSK)), wr, wo));
+        arm_r.push(baked(cone(0.02, 0.13, v(0.06, 0.42, 0.0), rz(-0.35), lin(TUSK)), wr, wo));
+        arm_r.push(baked(cone(0.02, 0.13, v(0.0, 0.42, 0.06), rx(-0.35), lin(TUSK)), wr, wo));
+        arm_r.push(baked(bx(0.03, 0.10, 0.03, v(0.07, 0.32, 0.0), fac), wr, wo));
     } else {
         let wr = xyz(0.4, 0.0, 0.1);
         let wo = v(0.05, -0.65, 0.1);
         arm_r.push(baked(cyl(0.04, 0.26, v(0.0, -0.1, 0.0), Quat::IDENTITY, lin(CLUB_WOOD)), wr, wo));
+        arm_r.push(baked(cyl(0.05, 0.07, v(0.0, -0.16, 0.0), Quat::IDENTITY, lin(WRAP)), wr, wo)); // grip wrap
         arm_r.push(baked(cyl(0.09, 0.34, v(0.0, -0.36, 0.0), Quat::IDENTITY, lin(CLUB_WOOD)), wr, wo));
         for i in 0..4 {
-            let a = i as f32 * std::f32::consts::FRAC_PI_2;
-            let spike = cone(0.03, 0.09, v(a.cos() * 0.1, -0.36, a.sin() * 0.1), xyz(0.0, a, std::f32::consts::FRAC_PI_2), lin(CLUB_BAND));
+            let a = i as f32 * HPI;
+            let spike = cone(0.03, 0.09, v(a.cos() * 0.1, -0.36, a.sin() * 0.1), xyz(0.0, a, HPI), lin(CLUB_BAND));
             arm_r.push(baked(spike, wr, wo));
+            // second offset spike ring higher on the head
+            let b = a + std::f32::consts::FRAC_PI_4;
+            let spike2 = cone(0.025, 0.08, v(b.cos() * 0.1, -0.26, b.sin() * 0.1), xyz(0.0, b, HPI), lin(CLUB_BAND));
+            arm_r.push(baked(spike2, wr, wo));
         }
+        arm_r.push(baked(cone(0.04, 0.10, v(0.0, -0.57, 0.0), rx(PI), lin(CLUB_BAND)), wr, wo)); // crown spike
     }
     let arm_r = group(arm_r);
 
-    // Left arm.
+    // Left arm: matching fur shoulder + a spiked leather bracer on the forearm.
     let arm_l = group(vec![
         bx(0.2, 0.1, 0.3, v(0.0, -0.02, 0.0), dark),
+        bx(0.22, 0.05, 0.32, v(0.0, 0.045, 0.0), hair), // fur trim
         bxr(0.17, 0.5, 0.24, v(-0.02, -0.25, 0.04), xyz(0.2, 0.0, -0.05), skin),
         bxr(0.18, 0.13, 0.26, v(-0.04, -0.52, 0.08), xyz(0.2, 0.0, -0.05), dark),
+        bxr(0.19, 0.06, 0.27, v(-0.045, -0.475, 0.075), xyz(0.2, 0.0, -0.05), lin(WRAP)), // bracer strap
+        cone(0.025, 0.09, v(-0.14, -0.52, 0.0), rz(HPI), lin(CLUB_BAND)), // bracer spikes
+        cone(0.025, 0.09, v(-0.14, -0.52, 0.14), rz(HPI), lin(CLUB_BAND)),
     ]);
 
-    // Legs (built top-at-origin so the hip pivot sits at the top; feet rest at root y≈0).
-    let leg = || group(vec![bx(0.2, 0.36, 0.22, v(0.0, -0.18, 0.0), skin)]);
+    // Legs (built top-at-origin so the hip pivot sits at the top; feet rest at root y≈0):
+    // shin + leather ankle wrap + a toed foot jutting forward.
+    let leg = || {
+        group(vec![
+            bx(0.2, 0.36, 0.22, v(0.0, -0.18, 0.0), skin),
+            bx(0.21, 0.07, 0.23, v(0.0, -0.28, 0.0), lin(WRAP)), // ankle wrap
+            bx(0.18, 0.08, 0.12, v(0.0, -0.32, 0.15), skin), // foot / toes
+        ])
+    };
 
     let parts = vec![
         PartDef { kind: PartKind::Leg(1.0), pivot: v(-0.13, 0.36, 0.0), mesh: leg() },

--- a/src/player/model.rs
+++ b/src/player/model.rs
@@ -30,6 +30,8 @@ const GOLD: u32 = 0xe8b84b; // Golden Blade gilding
 const AXE_STEEL: u32 = 0xaab0bc; // Battle Axe head
 const STONE: u32 = 0x8a8d92; // Stone Maul head
 const FROST: u32 = 0xaad2f0; // Frostfang greatsword (Bevy rim item, no TS mesh)
+const PLUME: u32 = 0xa03028; // crimson helm plume
+const CHAIN: u32 = 0x55585f; // chainmail skirt under the belt
 
 /// Shield rest pose (own pivot, decoupled from the left arm): slung on the left flank,
 /// decorated face out (−X). Block (M3) swings it across the front.
@@ -67,6 +69,9 @@ fn rx(a: f32) -> Quat {
 fn rz(a: f32) -> Quat {
     Quat::from_rotation_z(a)
 }
+fn xyz(x: f32, y: f32, z: f32) -> Quat {
+    Quat::from_euler(EulerRot::XYZ, x, y, z)
+}
 fn tinted(mut m: Mesh, c: u32) -> Mesh {
     let n = m.count_vertices();
     m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![lin(c); n]);
@@ -85,6 +90,9 @@ fn group(parts: Vec<Mesh>) -> Mesh {
 }
 fn bx(w: f32, h: f32, d: f32, off: Vec3, c: u32) -> Mesh {
     tinted(Cuboid::new(w, h, d).mesh().build().translated_by(off), c)
+}
+fn bxr(w: f32, h: f32, d: f32, off: Vec3, rot: Quat, c: u32) -> Mesh {
+    tinted(Cuboid::new(w, h, d).mesh().build().rotated_by(rot).translated_by(off), c)
 }
 fn cyl(r: f32, h: f32, off: Vec3, c: u32) -> Mesh {
     tinted(Cylinder::new(r, h).mesh().resolution(8).build().translated_by(off), c)
@@ -127,14 +135,19 @@ fn armor_palette(armor: Option<&str>) -> (u32, u32, u32) {
     (tint, lerp_hex(tint, 0xffffff, 0.28), lerp_hex(tint, 0x000000, 0.3))
 }
 
-/// Sword-shaped weapon parts (pommel/grip/guard/blade/tip) with the blade tinted `c`; shared
-/// by the iron sword (default), the golden blade, and the frost greatsword.
+/// Sword-shaped weapon parts (pommel/grip/guard/blade/fuller/tip) with the blade tinted `c`;
+/// shared by the iron sword (default), the golden blade, and the frost greatsword. The fuller
+/// (the darker groove down the blade's spine) is derived from the blade colour.
 fn sword_parts(blade: u32, pommel: u32) -> Vec<Mesh> {
+    let fuller = lerp_hex(blade, 0x000000, 0.35);
     vec![
         sphere(0.05, v(0.0, 0.14, 0.0), pommel),
         cyl(0.03, 0.14, v(0.0, 0.06, 0.0), GRIP),
         bx(0.30, 0.06, 0.08, v(0.0, -0.04, 0.0), pommel),
+        sphere(0.035, v(-0.15, -0.04, 0.0), pommel), // guard finials
+        sphere(0.035, v(0.15, -0.04, 0.0), pommel),
         bx(0.09, 0.80, 0.03, v(0.0, -0.47, 0.0), blade),
+        bx(0.03, 0.64, 0.034, v(0.0, -0.42, 0.0), fuller), // fuller groove
         cone(0.05, 0.12, v(0.0, -0.90, 0.0), rx(std::f32::consts::PI), blade),
     ]
 }
@@ -146,15 +159,22 @@ fn weapon_parts(weapon: Option<&str>) -> Vec<Mesh> {
     match weapon {
         Some("axe") => vec![
             cyl(0.028, 0.8, v(0.0, -0.12, 0.0), GRIP), // haft
+            cyl(0.034, 0.05, v(0.0, -0.27, 0.0), HILT), // haft binding rings
+            cyl(0.034, 0.05, v(0.0, 0.12, 0.0), HILT),
             sphere(0.04, v(0.0, 0.3, 0.0), HILT),      // pommel cap
             bx(0.26, 0.22, 0.05, v(0.13, -0.42, 0.0), AXE_STEEL), // head
             cone(0.11, 0.14, v(0.28, -0.42, 0.0), rz(-std::f32::consts::FRAC_PI_2), AXE_STEEL), // edge
+            cone(0.05, 0.10, v(-0.04, -0.42, 0.0), rz(std::f32::consts::FRAC_PI_2), AXE_STEEL), // back spike
         ],
         Some("sword_gold") => sword_parts(GOLD, GOLD),
         Some("blade_frost") => sword_parts(FROST, FROST),
         Some("stone_maul") => vec![
             cyl(0.035, 0.95, v(0.0, -0.1, 0.0), GRIP), // haft
+            cyl(0.042, 0.06, v(0.0, -0.32, 0.0), HILT), // haft binding ring
+            sphere(0.045, v(0.0, 0.36, 0.0), HILT),    // pommel cap
             bx(0.34, 0.26, 0.26, v(0.0, -0.6, 0.0), STONE), // head
+            bx(0.36, 0.04, 0.27, v(0.0, -0.52, 0.0), HILT), // iron bands
+            bx(0.36, 0.04, 0.27, v(0.0, -0.68, 0.0), HILT),
             bx(0.06, 0.2, 0.2, v(0.19, -0.6, 0.0), STONE), // striking cap +x
             bx(0.06, 0.2, 0.2, v(-0.19, -0.6, 0.0), STONE), // striking cap -x
         ],
@@ -170,56 +190,96 @@ pub fn build_knight(weapon: Option<&str>, armor: Option<&str>) -> KnightSpec {
     // Plate colour triple for the worn armor (bare = default steel).
     let (a, al, ad) = armor_palette(armor);
 
-    // Static torso: legs are articulated; belt + body + breastplate are baked in here.
+    // Static torso: legs are articulated; belt + body + plate layers are baked in here. The
+    // silhouette (belt/body/breastplate) is the TS one; the gorget, backplate, tassets, mail
+    // skirt and gold trim are Bevy-side dressing that recolours with the worn tier.
     let torso = group(vec![
+        bx(0.40, 0.10, 0.24, v(0.0, 0.33, 0.0), CHAIN), // mail skirt under the belt
         bx(0.42, 0.08, 0.22, v(0.0, 0.4, 0.0), BELT), // belt
+        bx(0.10, 0.06, 0.012, v(0.0, 0.4, 0.115), GOLD), // buckle
+        bxr(0.15, 0.14, 0.02, v(-0.17, 0.31, 0.11), xyz(0.15, 0.0, 0.12), ad), // tassets (hip plates)
+        bxr(0.15, 0.14, 0.02, v(0.17, 0.31, 0.11), xyz(0.15, 0.0, -0.12), ad),
         bx(0.42, 0.46, 0.26, v(0.0, 0.66, 0.0), a), // body
         bx(0.32, 0.32, 0.02, v(0.0, 0.70, 0.135), al), // breastplate
+        bx(0.05, 0.30, 0.016, v(0.0, 0.70, 0.142), a), // breastplate centre ridge
+        bx(0.32, 0.035, 0.018, v(0.0, 0.875, 0.14), GOLD), // gilded collar trim
+        bx(0.30, 0.34, 0.02, v(0.0, 0.68, -0.135), ad), // backplate
+        bx(0.26, 0.10, 0.30, v(0.0, 0.92, 0.0), ad), // gorget (neck ring)
     ]);
 
-    // Head: helm + visor slit + crest.
+    // Head: helm + stepped crown + visor slit, breath holes, gilded brow band, cheek guards,
+    // the dark crest brim and a crimson plume sweeping back over the crown.
     let head = group(vec![
         bx(0.32, 0.3, 0.32, v(0.0, 0.0, 0.0), al),
+        bx(0.28, 0.10, 0.28, v(0.0, 0.18, 0.0), al), // stepped crown
         bx(0.24, 0.06, 0.01, v(0.0, -0.01, 0.165), VISOR),
-        bx(0.34, 0.06, 0.34, v(0.0, 0.18, 0.0), ad),
+        bx(0.02, 0.025, 0.01, v(-0.045, -0.085, 0.165), VISOR), // breath holes
+        bx(0.02, 0.025, 0.01, v(0.045, -0.085, 0.165), VISOR),
+        bx(0.30, 0.025, 0.014, v(0.0, 0.045, 0.166), GOLD), // gilded brow band
+        bx(0.02, 0.13, 0.18, v(-0.17, -0.075, 0.05), ad), // cheek guards
+        bx(0.02, 0.13, 0.18, v(0.17, -0.075, 0.05), ad),
+        bx(0.34, 0.06, 0.34, v(0.0, 0.135, 0.0), ad), // crest brim
+        bxr(0.05, 0.10, 0.26, v(0.0, 0.27, -0.02), rx(0.22), PLUME), // plume crest
+        bxr(0.04, 0.08, 0.20, v(0.0, 0.24, -0.20), rx(0.75), PLUME), // plume tail
     ]);
 
-    // Right arm (sword hand): shoulder + upper + cuff, with the equipped weapon's parts baked
+    // Right arm (sword hand): plate arm with the equipped weapon's parts baked
     // individually at the hand so the blade swings with the arm. Sword sits at arm-local
     // (0,-0.5,0.06) rotated x=-π/2 so it extends FORWARD (+Z). CRITICAL: every part is an
     // indexed primitive merged by the SINGLE outer group() — do NOT pre-`group()` a sub-part
     // and re-merge it (flat-shading makes it non-indexed → merge corrupts the geometry, which
     // is what hid the sword). Matches the ork-club build in `orks.rs`.
+    // Plate-arm dressing shared by both arms (`s` mirrors the pauldron tilt): a two-lame
+    // pauldron, the upper arm, an elbow couter, the wrist cuff and a gauntleted fist.
+    let plate_arm = |s: f32| {
+        vec![
+            bxr(0.20, 0.10, 0.30, v(0.0, -0.02, 0.0), rz(s * 0.10), al), // pauldron cap
+            bxr(0.17, 0.07, 0.26, v(s * 0.02, -0.105, 0.0), rz(s * 0.20), a), // pauldron lame
+            bx(0.12, 0.42, 0.22, v(0.0, -0.21, 0.0), a), // upper
+            sphere(0.075, v(0.0, -0.30, 0.03), ad), // elbow couter
+            bx(0.13, 0.08, 0.23, v(0.0, -0.45, 0.0), ad), // cuff
+            bx(0.11, 0.09, 0.13, v(0.0, -0.51, 0.03), ad), // gauntlet fist
+            bx(0.115, 0.025, 0.10, v(0.0, -0.485, 0.06), al), // knuckle plate
+        ]
+    };
+
     let sw_rot = rx(-std::f32::consts::FRAC_PI_2);
     let sw_off = v(0.0, -0.5, 0.06);
-    let mut arm_r_parts = vec![
-        bx(0.18, 0.1, 0.28, v(0.0, -0.02, 0.0), al), // shoulder
-        bx(0.12, 0.42, 0.22, v(0.0, -0.21, 0.0), a), // upper
-        bx(0.13, 0.08, 0.23, v(0.0, -0.45, 0.0), ad), // cuff
-    ];
+    let mut arm_r_parts = plate_arm(1.0);
     for part in weapon_parts(weapon) {
         arm_r_parts.push(baked(part, sw_rot, sw_off));
     }
     let arm_r = group(arm_r_parts);
 
-    // Left arm (shield hand): shoulder + upper + cuff (shield is a separate part).
-    let arm_l = group(vec![
-        bx(0.18, 0.1, 0.28, v(0.0, -0.02, 0.0), al),
-        bx(0.12, 0.42, 0.22, v(0.0, -0.21, 0.0), a),
-        bx(0.13, 0.08, 0.23, v(0.0, -0.45, 0.0), ad),
-    ]);
+    // Left arm (shield hand): same plate dressing, mirrored (shield is a separate part).
+    let arm_l = group(plate_arm(-1.0));
 
-    // Shield (own pivot): heater plate + raised rim + recessed field + gold cross emblem.
+    // Shield (own pivot): heater plate + raised rim + recessed field + gold cross emblem,
+    // with a rotated-square lower point (reads as the heater taper) and corner rivets.
     let shield = group(vec![
         bx(0.42, 0.58, 0.05, v(0.0, 0.0, 0.0), SHIELD_FACE), // plate
+        bxr(0.30, 0.30, 0.05, v(0.0, -0.29, 0.0), rz(std::f32::consts::FRAC_PI_4), SHIELD_FACE), // lower point
+        bxr(0.33, 0.33, 0.014, v(0.0, -0.29, 0.028), rz(std::f32::consts::FRAC_PI_4), SHIELD_RIM), // point rim
         bx(0.46, 0.62, 0.014, v(0.0, 0.0, 0.028), SHIELD_RIM), // rim
         bx(0.34, 0.5, 0.014, v(0.0, 0.0, 0.034), SHIELD_FACE), // inset field
         bx(0.07, 0.4, 0.014, v(0.0, 0.03, 0.04), SHIELD_EMBLEM), // cross vertical
         bx(0.3, 0.07, 0.014, v(0.0, 0.1, 0.04), SHIELD_EMBLEM), // cross horizontal
+        bx(0.035, 0.035, 0.02, v(-0.17, 0.24, 0.03), SHIELD_EMBLEM), // corner rivets
+        bx(0.035, 0.035, 0.02, v(0.17, 0.24, 0.03), SHIELD_EMBLEM),
+        bx(0.035, 0.035, 0.02, v(-0.17, -0.18, 0.03), SHIELD_EMBLEM),
+        bx(0.035, 0.035, 0.02, v(0.17, -0.18, 0.03), SHIELD_EMBLEM),
     ]);
 
-    // Legs (built top-at-hip so the pivot sits at the hip; foot rests at root y≈0).
-    let leg = || group(vec![bx(0.16, 0.36, 0.18, v(0.0, -0.18, 0.0), ad)]);
+    // Legs (built top-at-hip so the pivot sits at the hip; foot rests at root y≈0):
+    // cuisse → poleyn (knee) → greave → sabaton, replacing the old single box.
+    let leg = || {
+        group(vec![
+            bx(0.17, 0.17, 0.19, v(0.0, -0.085, 0.0), a), // cuisse (thigh plate)
+            bx(0.10, 0.06, 0.06, v(0.0, -0.175, 0.08), al), // poleyn (knee cap)
+            bx(0.15, 0.17, 0.17, v(0.0, -0.255, 0.0), ad), // greave
+            bx(0.15, 0.05, 0.24, v(0.0, -0.335, 0.04), al), // sabaton (foot)
+        ])
+    };
 
     let parts = vec![
         HeroPartDef { limb: HeroLimb::LegR, pivot: v(0.1, 0.36, 0.0), rest: Quat::IDENTITY, mesh: leg() },


### PR DESCRIPTION
## Summary

This change adds substantial visual detail to all creature models (wolf, deer, boar, polar bear, golem, bog croc) and the player knight, plus introduces a new skill document for headless screenshot testing in cloud containers. The additions focus on anatomical accuracy, material differentiation, and silhouette refinement without changing gameplay or core geometry.

## Key Changes

**Creature Models (`src/critters.rs`)**
- **Wolf**: Added chest ruff collar, spine saddle stripe, pale belly, haunches, lower jaw, brow ridges, cheek fur tufts, and pale tail brush tip. Refactored legs into a closure to support paw details.
- **Deer**: Added pale rump patch, fawn spots dappled along the back, pale throat, and hooves. Replaced simple cone antlers with multi-part main beams and forward tines (more anatomically accurate).
- **Boar**: Added lower jaw, nostril details, forelock bristle, and trotters. Introduced a tail with bristle details.
- **Polar Bear**: Added shoulder hump, shaded underbelly, haunches, lower jaw shading, brow shading, and broad paws with claws.
- **Golem**: Added shoulder crags, back slab, mossy details, glowing seams radiating from the core, crown crags, mossy scalp, grim mouth slit, knuckle stones, and boulder feet.
- **Bog Croc**: Added lower tooth row, side fangs, raised eye ridges, nostril bumps, spine ridge continuing down the tail, and claws on feet.

**Ork Models (`src/orks.rs`)**
- Added `rx()` rotation helper function (was missing, only `rz()` existed).
- **Torso**: Added loincloth tatters, belt skull trophy, underbelly plate, shoulder strap, and a trophy tooth-necklace with drooping teeth.
- **Head**: Added underbite jaw (tusks now rise from it), mouth shadow, nostrils, and per-variant headgear (grunt topknot, scout faction headband with bone feather, berserker mohawk with cheek war-paint, shaman bone half-skull headdress with horns). Added earring on left ear.
- **Arms**: Added fur-trimmed shoulder pads, wrist wraps, shoulder spikes, and spiked leather bracers. Shaman staff now has grip wrap, bone claws cradling the orb, and faction tassels. Melee club now has grip wrap and a second offset spike ring.
- **Legs**: Added ankle wraps and toed feet.

**Player Knight (`src/player/model.rs`)**
- Added `xyz()` rotation helper and `bxr()` rotated box function.
- **Torso**: Added mail skirt under belt, belt buckle, tassets (hip plates), breastplate centre ridge, gilded collar trim, backplate, and gorget (neck ring).
- **Head**: Added stepped crown, breath holes, gilded brow band, cheek guards, crest brim, and crimson plume sweeping back.
- **Arms**: Refactored into a `plate_arm()` closure supporting both arms with two-lame pauldrons, elbow couters, wrist cuffs, gauntleted fists, and knuckle plates.
- **Weapons**: Sword now has guard finials and a fuller groove down the blade. Axe has haft binding rings and a back spike. Stone maul has haft binding ring, pommel cap, and iron bands.
- **Shield**: Added rotated-square lower point (heater taper) with rim and corner rivets.
- **Legs**: Replaced single box with cuisse (thigh plate), poleyn (knee cap), greave, and sabaton (foot).

**Testing Infrastructure (`src/camps.rs`, `.claude/skills/visual-debug-cloud/SKILL.md`)**
- Added `FOREST_ORKLINE` env hook to park one ork of each variant in a line for close-up model shots.
- New skill document documenting headless screenshot capture workflow for cloud containers (Xvfb + Mesa llvmpipe/

https://claude.ai/code/session_01GFPvi3LMeftXZccjxCtmrK