### PR TITLE
Give NPCs solid collision + harmless bonk reactions

### DIFF
--- a/src/audio/lines.rs
+++ b/src/audio/lines.rs
@@ -80,6 +80,8 @@ pub enum Concept {
     SiegeFalls,
     Dawn,
     Rescued,
+    /// The hero swung at (and harmlessly bonked) a townsperson — they answer with a barbed remark.
+    HitByHero,
     // ── Ork ──
     OrkSpot,
     OrkDeath,
@@ -255,6 +257,16 @@ pub const LINES: &[Line] = &[
     Line { interruptible: false, priority: 15, floor: 600.0, ..line("siege_dry",   Speaker::Villager, Concept::SiegeFalls, "Orks again. Right on schedule. Everyone act surprised.") },
     Line { interruptible: false, priority: 15, floor: 600.0, ..line("dawn_dry",    Speaker::Villager, Concept::Dawn,       "Still alive, then. The betting pool will be devastated.") },
     Line { interruptible: false, priority: 15, floor: 600.0, ..line("rescued_dry", Speaker::Villager, Concept::Rescued,    "My hero. Only took you, what, a fortnight? Bless.") },
+    // ── "You just HIT me?!" — harmless bonk reactions (the hero can clip a townsperson with a
+    // swing; it does no damage but earns a sarcastic earful). These REUSE existing villager clips
+    // whose lines best fit getting smacked by your own knight — no new audio, same affronted tone.
+    // priority 13 so a bonk barges over idle chatter (prio 10) but yields to event lines (15);
+    // floor 5 throttles machine-gun swinging without making a clip feel unresponsive.
+    Line { priority: 13, floor: 5.0, ..line("last_word_c", Speaker::Villager, Concept::HitByHero, "Touchy, touchy. And after everything we do for you.") },
+    Line { priority: 13, floor: 5.0, ..line("last_word_a", Speaker::Villager, Concept::HitByHero, "Ooh, sharp. Practice that one on the cows, did we?") },
+    Line { priority: 13, floor: 5.0, ..line("last_word_b", Speaker::Villager, Concept::HitByHero, "Noted, m'lord. I'll scream quieter tonight, just for you.") },
+    Line { priority: 13, floor: 5.0, ..line("grateful",    Speaker::Villager, Concept::HitByHero, "We're ever so grateful. Truly. Now could you grateful your boots off my step.") },
+    Line { priority: 13, floor: 5.0, ..line("screaming",   Speaker::Villager, Concept::HitByHero, "Bless you for the protection. The screaming at night is a lovely touch.") },
     // ── Ork battle barks (nearest ork in earshot; pitch-shifted per utterance) ──
     Line { ..line("spot",   Speaker::Ork, Concept::OrkSpot,  "Little knight. Little bones.") },
     Line { ..line("charge", Speaker::Ork, Concept::OrkSpot,  "Smash the stone. Burn the nest.") },

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -79,6 +79,20 @@ pub struct Juice<'w> {
     materials: ResMut<'w, Assets<StandardMaterial>>,
 }
 
+/// Townsfolk the hero can harmlessly bonk with a swing: the [`crate::villagers::Villager`] bodies
+/// (which are NOT in the damage-dealing `targets` query) plus the voice channel to make them yelp.
+/// Bundled into one [`SystemParam`] so [`player_attack`] stays under Bevy's 16-param ceiling.
+#[derive(bevy::ecs::system::SystemParam)]
+pub struct Bystanders<'w, 's> {
+    speak: MessageWriter<'w, crate::audio::Speak>,
+    folk: Query<
+        'w,
+        's,
+        &'static GlobalTransform,
+        (With<crate::villagers::Villager>, Without<crate::dying::Dying>),
+    >,
+}
+
 /// Vitals attached to a hittable (ork / animal) by [`ensure_combat_health`].
 #[derive(Component)]
 pub struct Health {
@@ -258,6 +272,7 @@ pub fn player_attack(
     mut mods: crate::inventory::CombatMods,
     mut rewards: ResMut<crate::orbs::RewardBursts>,
     mut juice: Juice,
+    mut bystanders: Bystanders,
     mut commands: Commands,
     mut cues: MessageWriter<AudioCue>,
     mut floats: ResMut<crate::combat_fx::FloatQueue>,
@@ -461,6 +476,30 @@ pub fn player_attack(
                 }
             }
         }
+    }
+
+    // ── Bonking a townsperson: the same front-cone, but villagers aren't in the damage query, so
+    // a swing that clips one does NO harm — it just lands a soft thud and earns a sarcastic earful.
+    // Nearest bonked villager wins, so the line comes from whoever you actually clipped. ──
+    let mut bonk: Option<(f32, Vec3)> = None;
+    for gt in &bystanders.folk {
+        let p = gt.translation();
+        let to = Vec2::new(p.x - origin.x, p.z - origin.y);
+        let dist = to.length();
+        if dist > ATTACK_RANGE || dist < 1e-3 {
+            continue;
+        }
+        if (to / dist).dot(fwd) < ATTACK_CONE_DOT {
+            continue;
+        }
+        if bonk.is_none_or(|(bd, _)| dist < bd) {
+            bonk = Some((dist, Vec3::new(p.x, p.y + 1.6, p.z)));
+        }
+    }
+    if let Some((_, head)) = bonk {
+        bystanders.speak.write(crate::audio::Speak::at(crate::audio::Concept::HitByHero, head));
+        // A connecting bonk plays the impact thud + a light shake below, not the empty-swing whoosh.
+        hit_any = true;
     }
 
     // Juice: a connecting blow shakes the screen, punches the FOV + briefly freezes the sim

--- a/src/player/movement.rs
+++ b/src/player/movement.rs
@@ -10,6 +10,7 @@ use bevy::prelude::*;
 use crate::audio::AudioCue;
 use crate::biome::Biome;
 use crate::orks::Ork;
+use crate::villagers::Villager;
 use crate::wildlife::Animal;
 use crate::{blockers, steer, worldmap};
 
@@ -111,6 +112,7 @@ pub fn player_move(
     cam_q: Query<&Transform, (With<Camera3d>, Without<Hero>)>,
     orks: Query<&Ork>,
     animals: Query<&Animal>,
+    villagers: Query<&Villager>,
     mut state: ResMut<HeroState>,
     mut pending: ResMut<PendingHeroDamage>,
     mut feedback: ResMut<crate::combat_fx::HitFeedback>,
@@ -208,6 +210,11 @@ pub fn player_move(
     }
     for a in &animals {
         shove_out_of(&mut hero, a.pos, a.body_r, cur_y);
+    }
+    // Townsfolk are solid too — you bump them, you don't walk through them.
+    for v in &villagers {
+        let (p, r) = v.body();
+        shove_out_of(&mut hero, p, r, cur_y);
     }
 
     // ── Vertical: jump + gravity + ground snap ──

--- a/src/villagers.rs
+++ b/src/villagers.rs
@@ -71,6 +71,14 @@ pub struct Villager {
     gathering: bool,
 }
 
+impl Villager {
+    /// Body centre (world XZ) + collision radius — read by the hero's body-collision pass so he
+    /// can't clip through townsfolk (the same one-way shove the orks/animals get).
+    pub fn body(&self) -> (Vec2, f32) {
+        (self.pos, self.body_r)
+    }
+}
+
 #[derive(Component)]
 struct VilPart {
     kind: PartKind,


### PR DESCRIPTION
Townsfolk were ghosts: the hero clipped straight through them and a swing that hit one whiffed on empty air. Now they're solid and they talk back.

- Collision: villagers (all NPC bodies carry Villager + body_r) join the hero's one-way creature-shove pass in player_move, alongside orks/animals, so you bump them instead of walking through them. New Villager::body() accessor exposes (pos, body_r) for the shove.
- Harmless bonk: player_attack now also front-cone scans villagers (who are NOT in the damage query, so zero HP loss). A connecting bonk plays the impact thud + light shake instead of the empty-swing whoosh, and emits a new Concept::HitByHero voice request from the nearest clipped townsperson.
- Voice: HitByHero reuses the best-fitting existing affronted villager clips (last_word_a/b/c, grateful, screaming) — no new audio. Priority 13 barges over idle chatter but yields to event lines; floor 5s throttles spam. Bystanders SystemParam bundles the query + writer to stay under the 16-param ceiling.