### PR TITLE
Filter stale GPU pass measurements from debug stats table

### DIFF
--- a/src/debug_stats.rs
+++ b/src/debug_stats.rs
@@ -218,12 +218,20 @@ fn stats_ui(
 /// heaviest pass so the bottleneck pass is obvious at a glance. Total of the listed passes is
 /// shown at the bottom.
 fn gpu_passes(ui: &mut egui::Ui, diags: &DiagnosticsStore) {
+    // A pass that stopped running (e.g. volumetric_lighting once the God Rays preset is off)
+    // keeps its last `smoothed()` value forever — the EMA only updates on a new measurement.
+    // Skip any pass whose most-recent measurement is stale, so a node that ran only during
+    // startup warmup doesn't sit at the top of the table for the rest of the session.
+    let stale = std::time::Duration::from_millis(500);
     let collect = |field: &str| -> Vec<(String, f64)> {
         let mut v: Vec<(String, f64)> = diags
             .iter()
             .filter_map(|d| {
                 let p = d.path().as_str();
                 let name = p.strip_prefix("render/")?.strip_suffix(field)?;
+                if d.measurement().is_none_or(|m| m.time.elapsed() > stale) {
+                    return None;
+                }
                 let ms = d.smoothed().filter(|m| *m > 0.0)?;
                 Some((name.trim_end_matches('/').replace('/', " › "), ms))
             })

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -10,7 +10,7 @@ use bevy::core_pipeline::prepass::{DepthPrepass, NormalPrepass};
 use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::light::{
     CascadeShadowConfigBuilder, DirectionalLightShadowMap, FogVolume, ShadowFilteringMethod,
-    SunDisk, VolumetricFog, VolumetricLight,
+    SunDisk, VolumetricFog,
 };
 use bevy::pbr::{
     Atmosphere, DistanceFog, FogFalloff, ScatteringMedium, ScreenSpaceAmbientOcclusion,
@@ -452,9 +452,12 @@ fn setup_sun(mut commands: Commands) {
             shadows_enabled: true,
             ..default()
         },
-        // Cast volumetric light shafts through the `FogVolume` below — the sun's half of the
-        // god-rays effect (the camera's `VolumetricFog` is the other half).
-        VolumetricLight,
+        // NB: no `VolumetricLight` here. The sun's half of the god-rays effect (the camera's
+        // `VolumetricFog` is the other half) is the *only* runtime switch for the volumetric pass
+        // — Bevy tears the pass down when no `VolumetricLight` exists. The God Rays graphics preset
+        // (`quality.rs`) inserts it on demand; spawning it here would run the pass for the first
+        // frame or two before `apply_quality` removes it, seeding a stale ~20 ms reading that the
+        // F2 GPU-passes table then shows forever. Default presets (High/Low) never pay for it.
         // Visible solar disk in the Atmosphere sky. Default is `SunDisk::EARTH` —
         // physically-accurate 0.0093 rad (≈0.5°), a barely-visible dot. The stylized look
         // wants a big warm ball: ~6× earth size, overexposed so Bloom halos it into a glow.


### PR DESCRIPTION
## Summary

Fixes a visual artifact in the GPU-passes debug table where passes that stop running (e.g., volumetric lighting when the God Rays preset is disabled) retain their last smoothed measurement value indefinitely, making them appear at the top of the table even though they're no longer active.

## Changes

- **`src/debug_stats.rs`**: Added staleness filtering to the `gpu_passes()` diagnostic collector. Passes whose most recent measurement is older than 500ms are now excluded from the table, preventing stale EMA values from cluttering the display.

- **`src/scene.rs`**: Removed `VolumetricLight` component from the sun entity spawn. Added detailed comment explaining that the volumetric pass is runtime-gated on the presence of `VolumetricLight` — spawning it unconditionally would cause the pass to run during startup warmup before the God Rays quality preset removes it, seeding a stale ~20ms measurement that persists in the stats table for the entire session.

## Implementation Details

The root cause: Bevy's diagnostic EMA (exponential moving average) only updates when a new measurement arrives. Once a pass stops running, its last smoothed value freezes. The fix checks `measurement().time.elapsed()` against a 500ms threshold — any pass without a recent measurement is filtered out, keeping the table focused on currently-active passes.

This pairs with the scene setup change: by not spawning `VolumetricLight` on the sun initially, the volumetric pass doesn't run during the first frame or two before quality presets apply, avoiding the stale reading that would otherwise dominate the stats display.

https://claude.ai/code/session_01K15AjUeuAGQgg18kqSpRMh