### PR TITLE
Add settings, load, and restart to the pause menu

### DIFF
--- a/src/economy.rs
+++ b/src/economy.rs
@@ -77,6 +77,11 @@ impl Plugin for EconomyPlugin {
             // Fresh run wipes the economy (gold resets with PlayerRes).
             .add_systems(OnExit(AppState::StartScreen), reset_economy)
             .add_systems(OnExit(AppState::GameOver), reset_economy)
+            // Pause-menu Restart / Load also begins a fresh run (gated; see game_state).
+            .add_systems(
+                OnExit(AppState::Paused),
+                reset_economy.run_if(crate::game_state::restart_requested),
+            )
             // Open the tree with U (only while actually playing, no other panel open).
             .add_systems(Update, open_tree.run_if(in_state(Modal::None)))
             .add_systems(OnEnter(Modal::UpgradeTree), spawn_tree)

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -14,10 +14,15 @@
 //! Panels are a sub-state **of** `Playing` (not sibling `AppState` variants) on purpose:
 //! opening one does NOT fire `OnExit(Playing)`/`OnEnter(Playing)`, so it never wipes the run.
 
+use bevy::ecs::relationship::RelatedSpawnerCommands;
 use bevy::prelude::*;
+use bevy::window::{PrimaryWindow, WindowMode};
 
+use crate::quality::GraphicsQuality;
 use crate::ui::anim::{anim, anim_btn, AnimKind};
 use crate::ui::fonts::{label, UiFonts};
+use crate::ui::notice::Notice;
+use crate::ui::settings::AudioSettings;
 use crate::ui::theme::*;
 use crate::ui::widgets;
 
@@ -46,6 +51,18 @@ pub enum Modal {
     Build,
 }
 
+/// Set true by the pause menu's **Restart** / **Load last save** before it hands back to
+/// `Playing`, so the per-plugin "fresh run" resets (normally keyed to leaving the start /
+/// game-over screens) also fire on the `Paused → Playing` edge. A plain resume leaves it `false`,
+/// so the world is untouched. Cleared again on `OnEnter(Playing)`.
+#[derive(Resource, Default)]
+pub struct RestartRequested(pub bool);
+
+/// Run condition for the gated `OnExit(AppState::Paused)` reset systems (see [`RestartRequested`]).
+pub fn restart_requested(flag: Res<RestartRequested>) -> bool {
+    flag.0
+}
+
 pub struct GameStatePlugin;
 
 impl Plugin for GameStatePlugin {
@@ -54,7 +71,16 @@ impl Plugin for GameStatePlugin {
         let boot = if skip_menu() { AppState::Playing } else { AppState::StartScreen };
         app.insert_state(boot)
             .add_sub_state::<Modal>()
+            .init_resource::<RestartRequested>()
             .add_systems(Update, (pause_toggle, watch_end))
+            // Clear the restart flag once we're back in Playing (after the gated OnExit(Paused)
+            // resets have run during the same transition).
+            .add_systems(OnEnter(AppState::Playing), clear_restart_flag)
+            // Pause-menu buttons + live settings labels (only while the pause screen is up).
+            .add_systems(
+                Update,
+                (pause_click, pause_settings_sync).run_if(in_state(AppState::Paused)),
+            )
             // Minimal overlays (fleshed out + difficulty chooser in P0.6).
             .add_systems(OnEnter(AppState::StartScreen), spawn_start_screen)
             .add_systems(OnExit(AppState::StartScreen), despawn_screen::<StartScreenUi>)
@@ -212,6 +238,25 @@ struct StartContinueButton;
 /// A difficulty segment (click to select).
 #[derive(Component)]
 struct SegButton(crate::siege::Difficulty);
+// ── Pause-menu buttons ──
+#[derive(Component)]
+struct PauseResumeBtn;
+#[derive(Component)]
+struct PauseLoadBtn;
+#[derive(Component)]
+struct PauseRestartBtn;
+#[derive(Component)]
+struct PauseAudioBtn;
+#[derive(Component)]
+struct PauseGfxBtn;
+#[derive(Component)]
+struct PauseFsBtn;
+#[derive(Component)]
+struct PauseAudioLabel;
+#[derive(Component)]
+struct PauseGfxLabel;
+#[derive(Component)]
+struct PauseFsLabel;
 /// The "Play again" / "New Game" button on the game-over screen (a fresh run).
 #[derive(Component)]
 struct AgainButton;
@@ -437,13 +482,62 @@ fn spawn_start_screen(
         });
 }
 
-fn spawn_pause_screen(mut commands: Commands, fonts: Res<UiFonts>) {
+fn audio_label(muted: bool) -> String {
+    format!("Audio: {}", if muted { "Off" } else { "On" })
+}
+fn fs_label(fullscreen: bool) -> String {
+    format!("Fullscreen: {}", if fullscreen { "On" } else { "Off" })
+}
+
+/// A full-width pause-menu button (primary-blue paint), with `text` and an optional extra bundle
+/// on its label (a `PauseXLabel` marker for the live-syncing settings rows; `()` otherwise).
+fn pause_btn<M: Component, L: Bundle>(
+    p: &mut RelatedSpawnerCommands<ChildOf>,
+    font: &Handle<Font>,
+    text: &str,
+    marker: M,
+    label_extra: L,
+    delay: f32,
+) {
+    p.spawn((
+        Node {
+            width: Val::Px(264.0),
+            padding: UiRect::axes(Val::Px(18.0), Val::Px(10.0)),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            border: widgets::border(1.0),
+            border_radius: radius(R_BTN),
+            ..default()
+        },
+        widgets::btn_primary_paint(),
+        marker,
+        anim_btn(AnimKind::PopIn, delay, 0.28),
+    ))
+    .with_children(|b| {
+        b.spawn((label(font, text, 16.0, Color::WHITE), label_extra));
+    });
+}
+
+fn spawn_pause_screen(
+    mut commands: Commands,
+    fonts: Res<UiFonts>,
+    save: Res<crate::savegame::SaveExists>,
+    audio: Res<AudioSettings>,
+    quality: Res<GraphicsQuality>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+) {
+    let has_save = save.0;
+    let audio_txt = audio_label(audio.muted);
+    let gfx_txt = format!("Graphics: {}", quality.label());
+    let fs_on = windows.single().map(|w| !matches!(w.mode, WindowMode::Windowed)).unwrap_or(false);
+    let fs_txt = fs_label(fs_on);
+
     commands.spawn((modal_root(50), PausedUi)).with_children(|root| {
         root.spawn((
             Node {
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
-                row_gap: Val::Px(10.0),
+                row_gap: Val::Px(9.0),
                 padding: UiRect::axes(Val::Px(40.0), Val::Px(28.0)),
                 border: widgets::border(1.0),
                 border_radius: radius(R_PANEL),
@@ -453,10 +547,128 @@ fn spawn_pause_screen(mut commands: Commands, fonts: Res<UiFonts>) {
             anim(AnimKind::PopIn, 0.0, 0.26),
         ))
         .with_children(|c| {
-            c.spawn(label(&fonts.extrabold, "PAUSED", 40.0, TEXT));
-            c.spawn(label(&fonts.regular, "Esc to resume", 16.0, GREY));
+            c.spawn((
+                label(&fonts.extrabold, "PAUSED", 38.0, TEXT),
+                Node { margin: UiRect::bottom(Val::Px(4.0)), ..default() },
+            ));
+
+            pause_btn(c, &fonts.extrabold, "RESUME", PauseResumeBtn, (), 0.04);
+
+            // ── Settings (toggle in place; labels live-sync via pause_settings_sync) ──
+            c.spawn((
+                label(&fonts.semibold, "SETTINGS", 11.0, KICKER),
+                Node { margin: UiRect::top(Val::Px(8.0)), ..default() },
+            ));
+            pause_btn(c, &fonts.bold, &audio_txt, PauseAudioBtn, PauseAudioLabel, 0.06);
+            pause_btn(c, &fonts.bold, &gfx_txt, PauseGfxBtn, PauseGfxLabel, 0.08);
+            pause_btn(c, &fonts.bold, &fs_txt, PauseFsBtn, PauseFsLabel, 0.10);
+
+            // ── Run controls ──
+            c.spawn((
+                Node {
+                    width: Val::Px(220.0),
+                    height: Val::Px(1.0),
+                    margin: UiRect::vertical(Val::Px(8.0)),
+                    ..default()
+                },
+                BackgroundColor(BORDER_SOFT),
+            ));
+            if has_save {
+                pause_btn(c, &fonts.extrabold, "LOAD LAST SAVE", PauseLoadBtn, (), 0.12);
+            }
+            pause_btn(c, &fonts.extrabold, "RESTART", PauseRestartBtn, (), 0.14);
+
+            c.spawn((
+                label(&fonts.regular, "Esc to resume", 13.0, GREY),
+                Node { margin: UiRect::top(Val::Px(6.0)), ..default() },
+            ));
         });
     });
+}
+
+/// Handle the pause-menu buttons: resume, the three in-place settings toggles, and the two
+/// run actions (Load last save / Restart) that both re-run the fresh-start resets via
+/// [`RestartRequested`] before handing control back to `Playing`.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn pause_click(
+    q: Query<
+        (
+            &Interaction,
+            Option<&PauseResumeBtn>,
+            Option<&PauseLoadBtn>,
+            Option<&PauseRestartBtn>,
+            Option<&PauseAudioBtn>,
+            Option<&PauseGfxBtn>,
+            Option<&PauseFsBtn>,
+        ),
+        Changed<Interaction>,
+    >,
+    mut next_app: ResMut<NextState<AppState>>,
+    mut pending: ResMut<crate::savegame::PendingLoad>,
+    mut restart: ResMut<RestartRequested>,
+    mut audio: ResMut<AudioSettings>,
+    mut quality: ResMut<GraphicsQuality>,
+    mut windows: Query<&mut Window, With<PrimaryWindow>>,
+    mut notice: ResMut<Notice>,
+    time: Res<Time>,
+) {
+    let now = time.elapsed_secs_f64();
+    for (interaction, resume, load, restart_b, audio_b, gfx_b, fs_b) in &q {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        if resume.is_some() {
+            next_app.set(AppState::Playing);
+        }
+        if load.is_some() {
+            // Clear the in-progress field/entities (restart resets), then the loaded snapshot
+            // overwrites the resources on the next Playing frame — identical to Continue.
+            pending.0 = crate::savegame::load_save();
+            restart.0 = true;
+            next_app.set(AppState::Playing);
+        }
+        if restart_b.is_some() {
+            pending.0 = None; // fresh run (keeps the chosen difficulty)
+            restart.0 = true;
+            next_app.set(AppState::Playing);
+        }
+        if audio_b.is_some() {
+            crate::ui::settings::toggle_mute(&mut audio, &mut notice, now);
+        }
+        if gfx_b.is_some() {
+            crate::ui::settings::toggle_quality(&mut quality, &mut notice, now);
+        }
+        if fs_b.is_some() {
+            crate::ui::settings::toggle_fullscreen(&mut windows, &mut notice, now);
+        }
+    }
+}
+
+/// Keep the three pause settings buttons' labels matching live state (they can also be flipped by
+/// the M / F10 / F11 keys while paused).
+#[allow(clippy::type_complexity)]
+fn pause_settings_sync(
+    audio: Res<AudioSettings>,
+    quality: Res<GraphicsQuality>,
+    windows: Query<&Window, With<PrimaryWindow>>,
+    mut audio_l: Query<&mut Text, (With<PauseAudioLabel>, Without<PauseGfxLabel>, Without<PauseFsLabel>)>,
+    mut gfx_l: Query<&mut Text, (With<PauseGfxLabel>, Without<PauseAudioLabel>, Without<PauseFsLabel>)>,
+    mut fs_l: Query<&mut Text, (With<PauseFsLabel>, Without<PauseAudioLabel>, Without<PauseGfxLabel>)>,
+) {
+    if let Ok(mut t) = audio_l.single_mut() {
+        **t = audio_label(audio.muted);
+    }
+    if let Ok(mut t) = gfx_l.single_mut() {
+        **t = format!("Graphics: {}", quality.label());
+    }
+    if let Ok(mut t) = fs_l.single_mut() {
+        let on = windows.single().map(|w| !matches!(w.mode, WindowMode::Windowed)).unwrap_or(false);
+        **t = fs_label(on);
+    }
+}
+
+fn clear_restart_flag(mut restart: ResMut<RestartRequested>) {
+    restart.0 = false;
 }
 
 fn spawn_gameover_screen(

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -104,6 +104,11 @@ impl Plugin for InventoryPlugin {
             // Fresh run wipes bag, buffs and toasts (with the rest of progression).
             .add_systems(OnExit(AppState::StartScreen), reset_inventory)
             .add_systems(OnExit(AppState::GameOver), reset_inventory)
+            // Pause-menu Restart / Load also begins a fresh run (gated; see game_state).
+            .add_systems(
+                OnExit(AppState::Paused),
+                reset_inventory.run_if(crate::game_state::restart_requested),
+            )
             // Quick-bar (Q/Z/X/C) + open the satchel (I): only while playing with no panel up.
             .add_systems(Update, (quickbar_input, open_inventory).run_if(in_state(Modal::None)))
             // The satchel modal (freezes the world like the tree).

--- a/src/siege.rs
+++ b/src/siege.rs
@@ -455,7 +455,12 @@ impl Plugin for SiegePlugin {
             // Fresh run: reset on leaving the start screen or game-over (NOT on un-pausing,
             // which is a Playing↔Paused transition and never touches these).
             .add_systems(OnExit(AppState::StartScreen), reset_siege)
-            .add_systems(OnExit(AppState::GameOver), reset_siege);
+            .add_systems(OnExit(AppState::GameOver), reset_siege)
+            // Pause-menu Restart / Load also begins a fresh run (gated so a plain resume is inert).
+            .add_systems(
+                OnExit(AppState::Paused),
+                reset_siege.run_if(crate::game_state::restart_requested),
+            );
     }
 }
 

--- a/src/succession.rs
+++ b/src/succession.rs
@@ -35,6 +35,10 @@ impl Plugin for SuccessionPlugin {
         app.init_resource::<Lives>()
             .add_systems(OnExit(AppState::StartScreen), reset_lives)
             .add_systems(OnExit(AppState::GameOver), reset_lives)
+            .add_systems(
+                OnExit(AppState::Paused),
+                reset_lives.run_if(crate::game_state::restart_requested),
+            )
             .add_systems(Update, watch_bloodline.run_if(in_state(AppState::Playing)));
     }
 }

--- a/src/succession_fx.rs
+++ b/src/succession_fx.rs
@@ -53,7 +53,11 @@ impl Plugin for SuccessionFxPlugin {
             .add_systems(Startup, setup_fx_assets)
             .add_systems(Update, (spawn_succession_fx, drive_souls))
             .add_systems(OnExit(AppState::StartScreen), clear_graves)
-            .add_systems(OnExit(AppState::GameOver), clear_graves);
+            .add_systems(OnExit(AppState::GameOver), clear_graves)
+            .add_systems(
+                OnExit(AppState::Paused),
+                clear_graves.run_if(crate::game_state::restart_requested),
+            );
     }
 }
 

--- a/src/town.rs
+++ b/src/town.rs
@@ -93,6 +93,13 @@ impl Plugin for TownPlugin {
                 OnExit(AppState::GameOver),
                 reset_town.after(crate::economy::reset_economy),
             )
+            // Pause-menu Restart / Load also begins a fresh run (gated; see game_state).
+            .add_systems(
+                OnExit(AppState::Paused),
+                reset_town
+                    .after(crate::economy::reset_economy)
+                    .run_if(crate::game_state::restart_requested),
+            )
             .add_systems(OnEnter(Modal::Build), spawn_build)
             .add_systems(OnExit(Modal::Build), despawn_build)
             .add_systems(Update, build_interact.run_if(in_state(Modal::Build)))

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -178,14 +178,14 @@ fn keys(
     }
 }
 
-fn toggle_mute(settings: &mut AudioSettings, notice: &mut Notice, now: f64) {
+pub(crate) fn toggle_mute(settings: &mut AudioSettings, notice: &mut Notice, now: f64) {
     settings.muted = !settings.muted;
     // The actual silencing happens in `sync_mute` (live `AudioSink`s) — GlobalVolume alone is
     // only sampled when a sink *starts*, so it never touches already-playing music/ambience.
     notice.push(if settings.muted { "Audio muted" } else { "Audio on" }, now);
 }
 
-fn toggle_quality(quality: &mut GraphicsQuality, notice: &mut Notice, now: f64) {
+pub(crate) fn toggle_quality(quality: &mut GraphicsQuality, notice: &mut Notice, now: f64) {
     *quality = quality.next();
     notice.push(format!("Graphics: {}", quality.label()), now);
 }
@@ -233,7 +233,7 @@ fn sync_quality_label(
     }
 }
 
-fn toggle_fullscreen(
+pub(crate) fn toggle_fullscreen(
     windows: &mut Query<&mut Window, With<PrimaryWindow>>,
     notice: &mut Notice,
     now: f64,


### PR DESCRIPTION
The pause screen was a static "PAUSED" card. Flesh it out with buttons: Resume, three in-place settings toggles (Audio / Graphics / Fullscreen), Load Last Save (only when a save exists), and Restart.

- Settings buttons reuse settings.rs's toggle_* helpers (now pub(crate)) and live-sync their labels, so M / F10 / F11 stay in agreement.
- Load and Restart both begin a fresh run from pause: a new RestartRequested flag gates the per-plugin "fresh run" resets onto the Paused -> Playing edge (normally keyed only to leaving the start / game-over screens), so a plain Resume stays inert. Load then overwrites the reset state with the snapshot via the existing PendingLoad path -- identical to Continue, but reachable mid-run and clearing the live night's invaders first.