### PR TITLE
Move houses out of build menu, add on-site raise interaction

### DIFF
--- a/crates/core/src/town_store.rs
+++ b/crates/core/src/town_store.rs
@@ -50,6 +50,9 @@ pub const REPAIR_PER_SEC: f64 = 8.0;
 /// Cost to raise one House (inside the walls). Houses don't burn, so this is the only gate
 /// besides `MAX_HOUSES`.
 pub const HOUSE_COST: Cost = Cost { wood: 6.0, stone: 4.0 };
+/// Gold each villager pays at dawn after a survived night (the **tithe**) — the town IS the
+/// gold engine: grow the population to grow the income. The Tax Office upgrade doubles it.
+pub const TITHE_GOLD_PER_POP: i64 = 2;
 
 /// What you can build on an outer plot — the **producers**. Houses are not plots (they sit
 /// inside the walls; see [`Town::build_house`]).
@@ -198,6 +201,15 @@ impl Town {
 
     pub fn pop_cap(&self) -> u32 {
         self.houses * POP_PER_HOUSE
+    }
+
+    /// Gold the town pays the player at dawn after a survived night: [`TITHE_GOLD_PER_POP`]
+    /// per living villager, doubled by the Tax Office. Population-driven on purpose — the
+    /// settlement (not loot loops) is the economy's engine, and losing villagers to the
+    /// horde costs real income.
+    pub fn tithe(&self, tax_office: bool) -> i64 {
+        let base = self.population as i64 * TITHE_GOLD_PER_POP;
+        if tax_office { base * 2 } else { base }
     }
 
     // ── Houses (interior, protected — a count, not a plot) ─────────────────────────
@@ -501,6 +513,16 @@ mod tests {
         let before = bank.food();
         t.production_tick(5.0, &mut bank);
         assert_eq!(bank.food(), before); // food is a flow (food_rate), never hoarded
+    }
+
+    #[test]
+    fn tithe_scales_with_population_and_doubles_with_tax_office() {
+        let t = Town::new(0, 5);
+        assert_eq!(t.tithe(false), 5 * TITHE_GOLD_PER_POP);
+        assert_eq!(t.tithe(true), 10 * TITHE_GOLD_PER_POP);
+        // A wiped-out town pays nothing — protecting villagers protects income.
+        let empty = Town::new(0, 0);
+        assert_eq!(empty.tithe(true), 0);
     }
 
     #[test]

--- a/crates/core/src/upgrade_store.rs
+++ b/crates/core/src/upgrade_store.rs
@@ -37,7 +37,8 @@ pub enum UpgradeEffect {
     // tree nodes that duplicated that have been removed.
     /// Bounty: ork-kill gold ×`mult` (sets `Player.bounty_mult`).
     Bounty(f64),
-    /// Tax office: collect a flat gold sum each cleared night (one-shot flag).
+    /// Tax office: doubles the population tithe paid each cleared night (one-shot flag;
+    /// the base tithe is `town_store::TITHE_GOLD_PER_POP` per villager).
     TaxOffice,
     /// Merchant Guild: shop price multiplier `mult` (e.g. 0.8 = −20%).
     MerchantGuild(f64),
@@ -139,7 +140,7 @@ pub static UPGRADE_NODES: &[UpgradeNode] = &[
         "+50% gold from every ork you slay — reach the costly upgrades sooner.",
         "💰", 60, 0, None, Bounty(1.5)),
     node("eco_tax_office", Economy, "Tax Office",
-        "Collect 25 gold every time you clear a night wave — steady income to rebuild.",
+        "Doubles the dawn tithe — every villager pays twice the gold each night you survive.",
         "🏛️", 75, 0, None, TaxOffice),
     node("eco_merchant_guild", Economy, "Merchant Guild",
         "−20% on everything the wandering merchant sells.",

--- a/src/castle.rs
+++ b/src/castle.rs
@@ -1178,6 +1178,14 @@ fn houses() -> [(f32, f32); 12] {
     ]
 }
 
+/// World-XZ of the dwelling slot the NEXT house will occupy (`houses()[built]`), or `None`
+/// once all twelve stand. The on-site "Raise house" interaction + its pad anchor here, so a
+/// new home always rises exactly where the player chose to build it (`sync_castle` reveals
+/// the mesh at this same slot when `town.houses` increments).
+pub(crate) fn next_house_site(built: u32) -> Option<Vec2> {
+    houses().get(built as usize).map(|&(x, z)| Vec2::new(x, z))
+}
+
 /// True inside the castle footprint (+ margin) — scatter is cleared here.
 pub fn in_footprint(wx: f32, wz: f32) -> bool {
     wx.abs() <= HALF_X + 1.6 && wz.abs() <= HALF_Z + 1.6

--- a/src/economy.rs
+++ b/src/economy.rs
@@ -61,8 +61,8 @@ impl Default for EconomyState {
 
 /// Reinforced-Keep bonus (forest's keep is 1000 base; +400 → 1400, healed to full).
 const REINFORCE_BONUS: f32 = 400.0;
-/// Tax Office payout per cleared night.
-pub const TAX_STIPEND: i64 = 25;
+// (The old flat Tax Office stipend is gone: dawn gold is now the population tithe —
+// `town_store::Town::tithe`, paid in `siege::run_director` — and Tax Office doubles it.)
 
 pub struct EconomyPlugin;
 

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -24,6 +24,8 @@ const KEEP_DIST: f32 = 4.2;
 const BELL_DIST: f32 = 4.2;
 const SHOP_DIST: f32 = 3.5;
 const BUILD_DIST: f32 = 3.0;
+/// Range around the next dwelling slot's construction pad (`castle::next_house_site`).
+const HOUSE_DIST: f32 = 3.0;
 /// Talk-back range: a bit over the villager-chatter trigger (`npc::NEAR_DIST` 7.0) so stepping
 /// back half a pace during the jab doesn't lose the prompt.
 const TALK_DIST: f32 = 8.0;
@@ -34,6 +36,10 @@ enum InteractKind {
     Shop,
     WarBell,
     Build,
+    /// Standing at the next dwelling slot's construction pad inside the walls — E raises the
+    /// house right there (houses left the plot Build menu: a building must rise where you
+    /// stand, never somewhere else).
+    RaiseHouse,
     /// A villager jabbed at the hero and a comeback is on offer (`director::OfferedReply`).
     TalkBack,
 }
@@ -44,6 +50,7 @@ impl InteractKind {
             InteractKind::Shop => "Shop",
             InteractKind::WarBell => "Ring the bell",
             InteractKind::Build => "Build",
+            InteractKind::RaiseHouse => "Raise house",
             InteractKind::TalkBack => "Talk back",
         }
     }
@@ -85,7 +92,9 @@ fn drive_interaction(
     mut cues: MessageWriter<AudioCue>,
     mut feedback: ResMut<HitFeedback>,
     plot_spots: Res<crate::town::PlotSpots>,
-    town: Res<crate::town::TownRes>,
+    mut town: ResMut<crate::town::TownRes>,
+    mut bank: ResMut<crate::economy::Bank>,
+    mut floats: ResMut<crate::combat_fx::FloatQueue>,
     mut build_target: ResMut<crate::town::BuildTarget>,
     time: Res<Time>,
     mut offered: ResMut<crate::audio::director::OfferedReply>,
@@ -113,6 +122,12 @@ fn drive_interaction(
     ];
     if let Some((idx, _)) = nearest_plot {
         candidates.push((InteractKind::Build, plot_spots.0[idx], BUILD_DIST, true));
+    }
+    // The next free dwelling slot inside the walls (its pad is visible in the world): E here
+    // raises a House on the spot. Anchored to the site so the prompt and the building agree.
+    let house_site = crate::castle::next_house_site(town.0.houses);
+    if let Some(site) = house_site {
+        candidates.push((InteractKind::RaiseHouse, site, HOUSE_DIST, true));
     }
     // A villager jab on offer: the prompt anchors where the speaker stood (expiry is handled by
     // `tick_chains`; here we only range-gate it).
@@ -144,6 +159,32 @@ fn drive_interaction(
                 feedback.trauma = (feedback.trauma + 0.3).min(1.0);
             }
             InteractKind::Build => next_modal.set(Modal::Build),
+            InteractKind::RaiseHouse => {
+                // Build right here, right now — and ALWAYS answer the press: a float names
+                // either the new beds or exactly what's missing (no silent no-op).
+                let site = house_site.unwrap_or(p);
+                let y = crate::worldmap::ground_at_world(site.x, site.y).unwrap_or(0.0);
+                use tileworld_core::town_store::{HOUSE_COST, POP_PER_HOUSE};
+                if town.0.build_house(&mut bank.0) {
+                    cues.write(AudioCue::UiSelect);
+                    floats.0.push(crate::combat_fx::FloatReq {
+                        world: Vec3::new(site.x, y + 3.0, site.y),
+                        text: format!("\u{1f3e0} House raised \u{2014} beds for {POP_PER_HOUSE} more"),
+                        color: Color::srgb(0.55, 1.0, 0.6),
+                        scale: 1.25,
+                    });
+                } else {
+                    floats.0.push(crate::combat_fx::FloatReq {
+                        world: Vec3::new(site.x, y + 3.0, site.y),
+                        text: format!(
+                            "Need {} wood + {} stone",
+                            HOUSE_COST.wood as i64, HOUSE_COST.stone as i64
+                        ),
+                        color: Color::srgb(1.0, 0.5, 0.4),
+                        scale: 1.1,
+                    });
+                }
+            }
             InteractKind::TalkBack => {
                 if let Some(offer) = offered.0.take() {
                     voices.accept_reply(offer, time.elapsed_secs());

--- a/src/landmarks.rs
+++ b/src/landmarks.rs
@@ -330,9 +330,12 @@ fn discover(
         }
         lm.discovered = true;
 
-        // One-time cache: gold + a frontier-graded relic (landmarks sit out at the rim → good tier).
+        // One-time cache: a frontier-graded relic + pocket gold. The relic, the shrine buff and
+        // the lore ARE the discovery reward — the purse is deliberately small (was 40+120f ≈ 160
+        // at the rim; five landmarks + the completion bonus out-earned whole nights of defending,
+        // so sightseeing trivialized the economy). Gold belongs to the town (tithe) + bounties.
         let factor = frontier_factor(p.x, p.z);
-        let gold = (40.0 + factor * 120.0).round() as i64;
+        let gold = (10.0 + factor * 30.0).round() as i64;
         player.0.add_gold(gold);
         let relic = frontier::roll_gear(factor, tile_hash(p.x, p.z));
         try_grant(&mut inv.0, &mut toasts.0, relic, 1, now as f64);
@@ -370,10 +373,10 @@ fn discover(
         disc.found += 1;
         if disc.total > 0 && disc.found >= disc.total && !disc.completed {
             disc.completed = true;
-            player.0.add_gold(200);
+            player.0.add_gold(75);
             floats.0.push(FloatReq {
                 world: Vec3::new(p.x, p.y + 4.0, p.z),
-                text: "The isle holds no more secrets — +200 gold".into(),
+                text: "The isle holds no more secrets — +75 gold".into(),
                 color: Color::srgb(1.0, 0.95, 0.6),
                 scale: 1.3,
             });

--- a/src/ork_fortress.rs
+++ b/src/ork_fortress.rs
@@ -1099,7 +1099,7 @@ const BLIGHT_CAGES: [(Vec2, usize); 2] = [
 /// The war-hoard: a single one-shot plunder chest deep in the south-east mire, guarded by
 /// patrol 4. `(chest world XZ, gold, loot)` — fixed haul (consumables + a purse), no gear, so
 /// it rewards the trek without power-creeping the already-strong hero.
-const BLIGHT_HOARD: (Vec2, i64, &[&str]) = (Vec2::new(57.0, 119.0), 120, &["feast", "potion", "venom"]);
+const BLIGHT_HOARD: (Vec2, i64, &[&str]) = (Vec2::new(57.0, 119.0), 80, &["feast", "potion", "venom"]);
 
 /// One-time freed/seen flags per [`BLIGHT_CAGES`] slot (re-inserted fresh each world build, so
 /// a new game re-stocks the cages). `seen` guards against freeing before the patrol spawns.

--- a/src/siege.rs
+++ b/src/siege.rs
@@ -571,6 +571,7 @@ fn run_director(
     mut player: ResMut<crate::player::PlayerRes>,
     eco: Res<crate::economy::EconomyState>,
     mut town: ResMut<crate::town::TownRes>,
+    mut floats: ResMut<crate::combat_fx::FloatQueue>,
     armory: Option<Res<InvaderArmory>>,
     invaders: Query<Entity, With<WaveInvader>>,
     alive_invaders: Query<(), (With<WaveInvader>, Without<crate::dying::Dying>)>,
@@ -620,13 +621,26 @@ fn run_director(
             }
             WaveAction::SetPhase(p) => {
                 siege.phase = p;
-                // Wave→Prep is a clear: shore up the keep + pay the Tax Office stipend.
+                // Wave→Prep is a clear: shore up the keep + collect the dawn tithe.
                 if p == GamePhase::Prep {
                     // Dawn repair: +20% of max HP, guaranteed each new day (on top of the slow
                     // continuous prep repair above).
                     keep.hp = (keep.hp + keep.max * KEEP_DAWN_REPAIR_FRAC).min(keep.max);
-                    if eco.tax_office {
-                        player.0.add_gold(crate::economy::TAX_STIPEND);
+                    // The dawn tithe: every villager who survived the night pays gold (the Tax
+                    // Office doubles it). Population — not loot loops — is the gold engine, so
+                    // the float spells out where the money came from.
+                    let tithe = town.0.tithe(eco.tax_office);
+                    if tithe > 0 {
+                        player.0.add_gold(tithe);
+                        floats.0.push(crate::combat_fx::FloatReq {
+                            world: Vec3::new(0.0, 6.5, 0.0),
+                            text: format!(
+                                "\u{1f4b0} Dawn tithe: +{tithe}g from {} villagers",
+                                town.0.population
+                            ),
+                            color: Color::srgb(1.0, 0.85, 0.4),
+                            scale: 1.25,
+                        });
                     }
                     // Dawn: a youth comes of age — heirs ARE townsfolk (one headcount), so the
                     // bloodline grows by growing the town. Gated by housing: people aren't

--- a/src/town.rs
+++ b/src/town.rs
@@ -8,7 +8,7 @@
 //! stay ungated. Numbers live in `town_store` (test-gated).
 
 use bevy::prelude::*;
-use tileworld_core::town_store::{BuildKind, Cost, PopEvent, Town, HOUSE_COST, POP_PER_HOUSE};
+use tileworld_core::town_store::{BuildKind, PopEvent, Town, POP_PER_HOUSE};
 
 use crate::castle::{Mats, VillageMats, M};
 use crate::villagers::{Guard, Townsfolk};
@@ -101,7 +101,10 @@ impl Plugin for TownPlugin {
             )
             .add_systems(OnEnter(Modal::Build), spawn_build)
             .add_systems(OnExit(Modal::Build), despawn_build)
-            .add_systems(Update, build_interact.run_if(in_state(Modal::Build)))
+            .add_systems(Update, (build_interact, build_hover_ghost).run_if(in_state(Modal::Build)))
+            // Self-explanation (ungated visuals): the gold ring marks WHICH plot the build
+            // menu will use; the timber pad marks where the NEXT house will rise.
+            .add_systems(Update, (sync_plot_highlight, sync_house_site_pad))
             .add_systems(
                 Update,
                 (auto_assign_workers, sync_staffed, release_orphan_workers, sync_plot_visibility)
@@ -742,57 +745,22 @@ fn demo_build_timelapse(
 #[derive(Component)]
 struct BuildUi;
 
-/// A row in the Build menu. Producers go on the outer plot you're standing on; a House is
-/// raised inside the walls (a protected dwelling that lifts the population cap) and needs no plot.
-#[derive(Clone, Copy)]
-enum BuildItem {
-    Producer(BuildKind),
-    House,
-}
-
+/// A row in the Build menu — producers only. The menu is strictly "what to raise on THIS
+/// plot": Houses left it (they used to appear inside the walls while the player stood on an
+/// outer plot — a building rising somewhere other than where you chose read as a bug). A
+/// House is now raised on its own marked site in the courtyard via the on-site **E** prompt.
 #[derive(Component)]
-struct BuildOption(BuildItem);
+struct BuildOption(BuildKind);
 
-const MENU: [BuildItem; 4] = [
-    BuildItem::Producer(BuildKind::Farm),
-    BuildItem::House,
-    BuildItem::Producer(BuildKind::Lumber),
-    BuildItem::Producer(BuildKind::Mine),
-];
+const MENU: [BuildKind; 3] = [BuildKind::Farm, BuildKind::Lumber, BuildKind::Mine];
 
-impl BuildItem {
-    fn label(self) -> &'static str {
-        match self {
-            BuildItem::Producer(k) => k.label(),
-            BuildItem::House => "House",
-        }
-    }
-
-    fn cost(self) -> Cost {
-        match self {
-            BuildItem::Producer(k) => k.cost(),
-            BuildItem::House => HOUSE_COST,
-        }
-    }
-
-    /// One-line "what it does", so players see that a Farm *feeds the town and grows population*
-    /// and a House *makes room for more people*, not just abstract stats.
-    fn desc(self) -> &'static str {
-        match self {
-            BuildItem::Producer(BuildKind::Farm) => "Grows food \u{2192} feeds the town so peasants settle in",
-            BuildItem::Producer(BuildKind::Lumber) => "Woodcutter \u{2192} fells real trees and hauls the logs home (needs a worker)",
-            BuildItem::Producer(BuildKind::Mine) => "Stone Miner \u{2192} mines real boulders and carts the stone home (needs a worker)",
-            BuildItem::House => "Home in the walls \u{2192} +2 people your town can hold",
-        }
-    }
-
-    /// Whether this item can be built right now. Producers need an empty plot under the hero;
-    /// a House just needs the resources and a free slot inside the walls.
-    fn affordable(self, town: &Town, bank: &tileworld_core::resource_store::ResourceState, on_plot: bool) -> bool {
-        match self {
-            BuildItem::Producer(k) => on_plot && town.can_afford(k, bank),
-            BuildItem::House => town.can_build_house(bank),
-        }
+/// One-line "what it does", so players see that a Farm *feeds the town and grows population*,
+/// not just abstract stats.
+fn build_desc(kind: BuildKind) -> &'static str {
+    match kind {
+        BuildKind::Farm => "Grows food \u{2192} feeds the town so peasants settle in",
+        BuildKind::Lumber => "Woodcutter \u{2192} fells real trees and hauls the logs home (needs a worker)",
+        BuildKind::Mine => "Stone Miner \u{2192} mines real boulders and carts the stone home (needs a worker)",
     }
 }
 
@@ -824,14 +792,14 @@ fn spawn_build(
             anim(AnimKind::PopIn, 0.0, 0.22),
         ))
         .with_children(|root| {
-            root.spawn(label(&fonts.extrabold, "BUILD", 20.0, GOLD));
+            root.spawn(label(&fonts.extrabold, "BUILD ON THIS PLOT", 20.0, GOLD));
             let on_plot = target.0.is_some();
             if !on_plot {
                 root.spawn(label(&fonts.regular, "Stand on an empty plot to build a producer.", 13.0, GREY));
             }
             for item in MENU {
                 let c = item.cost();
-                let afford = item.affordable(&town.0, &bank.0, on_plot);
+                let afford = on_plot && town.0.can_afford(item, &bank.0);
                 let col = if afford { Color::WHITE } else { TEXT_FAINT };
                 root.spawn((
                     Button,
@@ -857,7 +825,7 @@ fn spawn_build(
                     })
                     .with_children(|l| {
                         l.spawn(label(&fonts.semibold, item.label(), 14.0, col));
-                        l.spawn(label(&fonts.regular, item.desc(), 11.0, desc_col));
+                        l.spawn(label(&fonts.regular, build_desc(item), 11.0, desc_col));
                     });
                     // Right: cost (only the resources actually needed).
                     let mut cost = String::new();
@@ -873,13 +841,158 @@ fn spawn_build(
                     b.spawn(label(&fonts.semibold, &cost, 13.0, col));
                 });
             }
+            // Houses moved out of this menu (see `BuildOption` doc) — point at their new home
+            // so a returning player isn't left hunting for them.
+            root.spawn(label(
+                &fonts.regular,
+                "Houses: walk to the timber site inside the walls and press E.",
+                11.0,
+                GREY,
+            ));
             root.spawn(label(&fonts.regular, "Esc to close", 11.0, GREY));
         });
 }
 
-fn despawn_build(mut commands: Commands, q: Query<Entity, With<BuildUi>>) {
+fn despawn_build(mut commands: Commands, q: Query<Entity, Or<(With<BuildUi>, With<BuildGhost>)>>) {
     for e in &q {
         commands.entity(e).despawn();
+    }
+}
+
+// ── Self-explanation visuals: plot ring, ghost preview, house site pad ─────────────────
+
+/// The pulsing gold ring laid on the plot the build menu targets — so "press E to build"
+/// and the menu's choice are visibly anchored to ONE spot in the world.
+#[derive(Component)]
+struct PlotHighlight;
+
+/// A translucent preview of the hovered menu row, standing on the target plot — you see the
+/// building where it will rise *before* you click.
+#[derive(Component)]
+struct BuildGhost;
+
+/// The construction-site pad marking where the NEXT house will rise inside the walls
+/// (`castle::next_house_site`); the on-site **E** prompt raises it right there.
+#[derive(Component)]
+struct HouseSitePad;
+
+/// Keep the gold ring on the targeted plot: visible while the hero stands on a buildable plot
+/// (`BuildTarget`) in open play or with the Build menu up; hidden otherwise. Lazy-spawned on
+/// first run (not biome-tagged — it's a permanent FX entity, just repositioned).
+fn sync_plot_highlight(
+    time: Res<Time>,
+    target: Res<BuildTarget>,
+    spots: Res<PlotSpots>,
+    app: Option<Res<State<AppState>>>,
+    modal: Option<Res<State<Modal>>>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut q: Query<(&mut Transform, &mut Visibility), With<PlotHighlight>>,
+) {
+    let Ok((mut tf, mut vis)) = q.single_mut() else {
+        // One ring, built once: flat gold annulus a hair above the pad (same planar-flash
+        // recipe as the combat rings — unlit + emissive so it reads day and night).
+        let mat = materials.add(StandardMaterial {
+            base_color: Color::srgba(1.0, 0.86, 0.5, 0.55),
+            emissive: LinearRgba::rgb(1.6, 1.1, 0.4),
+            unlit: true,
+            alpha_mode: AlphaMode::Blend,
+            cull_mode: None,
+            ..default()
+        });
+        commands.spawn((
+            Mesh3d(meshes.add(Annulus::new(2.45, 2.8).mesh().resolution(48).build())),
+            MeshMaterial3d(mat),
+            Transform::from_xyz(0.0, -10.0, 0.0)
+                .with_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
+            Visibility::Hidden,
+            PlotHighlight,
+        ));
+        return;
+    };
+    let playing = app.is_some_and(|s| *s.get() == AppState::Playing);
+    let shown = modal.is_some_and(|m| matches!(*m.get(), Modal::None | Modal::Build));
+    let spot = target.0.and_then(|i| spots.0.get(i).copied());
+    match (playing && shown, spot) {
+        (true, Some(p)) => {
+            let y = crate::worldmap::ground_at_world(p.x, p.y).unwrap_or(0.0);
+            tf.translation = Vec3::new(p.x, y + 0.06, p.y);
+            // A slow breath, not a strobe — enough motion to say "this one".
+            let pulse = 1.0 + (time.elapsed_secs() * 2.6).sin() * 0.04;
+            tf.scale = Vec3::splat(pulse);
+            *vis = Visibility::Visible;
+        }
+        _ => *vis = Visibility::Hidden,
+    }
+}
+
+/// While the Build menu is up, hovering a row stands a translucent ghost of that building on
+/// the targeted plot. Rebuilt only when the hovered row changes; reaped with the panel.
+fn build_hover_ghost(
+    target: Res<BuildTarget>,
+    spots: Res<PlotSpots>,
+    btns: Query<(&Interaction, &BuildOption)>,
+    ghosts: Query<Entity, With<BuildGhost>>,
+    mut current: Local<Option<BuildKind>>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    let hovered = btns
+        .iter()
+        .find_map(|(i, o)| (*i == Interaction::Hovered).then_some(o.0));
+    // `current` is a Local and survives the panel closing (which reaps the ghost), so a bare
+    // equality check would skip respawning the same row next time — require a live ghost too.
+    if hovered == *current && (hovered.is_none() || !ghosts.is_empty()) {
+        return;
+    }
+    *current = hovered;
+    for e in &ghosts {
+        commands.entity(e).try_despawn();
+    }
+    let (Some(kind), Some(idx)) = (hovered, target.0) else { return };
+    let Some(pos) = spots.0.get(idx).copied() else { return };
+    let y = crate::worldmap::ground_at_world(pos.x, pos.y).unwrap_or(0.0);
+    // One shared see-through material for every part — a hologram, not a finished building.
+    let mat = materials.add(StandardMaterial {
+        base_color: Color::srgba(0.75, 0.92, 1.0, 0.38),
+        unlit: true,
+        alpha_mode: AlphaMode::Blend,
+        ..default()
+    });
+    let parent = commands
+        .spawn((Transform::from_xyz(pos.x, y, pos.y), Visibility::Visible, BuildGhost))
+        .id();
+    commands.entity(parent).with_children(|p| {
+        for (mesh, _) in building_parts(kind) {
+            p.spawn((Mesh3d(meshes.add(mesh)), MeshMaterial3d(mat.clone()), Transform::default()));
+        }
+    });
+}
+
+/// Keep one construction-site pad standing on the next free dwelling slot inside the walls,
+/// so "where do houses go?" has a visible answer in the world (the on-site E raises it there).
+/// Lazy-spawned and self-healing: a biome swap reaps it (`BiomeEntity`), we respawn next frame.
+fn sync_house_site_pad(
+    town: Res<TownRes>,
+    mats: Option<Res<VillageMats>>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut q: Query<(&mut Transform, &mut Visibility), With<HouseSitePad>>,
+) {
+    let site = crate::castle::next_house_site(town.0.houses);
+    if let Ok((mut tf, mut vis)) = q.single_mut() {
+        match site {
+            Some(p) => {
+                let y = crate::worldmap::ground_at_world(p.x, p.y).unwrap_or(0.0);
+                tf.translation = Vec3::new(p.x, y, p.y);
+                *vis = Visibility::Visible;
+            }
+            None => *vis = Visibility::Hidden, // all twelve dwellings stand
+        }
+    } else if let (Some(p), Some(mats)) = (site, mats) {
+        spawn_textured(&mut commands, &mut meshes, &mats.0, HouseSitePad, crate::town_meshes::plot_parts(), p);
     }
 }
 
@@ -901,28 +1014,19 @@ fn build_interact(
         if *interaction != Interaction::Pressed {
             continue;
         }
-        match opt.0 {
-            // A House goes up inside the walls (no plot): the castle reveals the next dwelling
-            // and the population cap lifts. `sync_castle` shows the mesh from `town.houses`.
-            BuildItem::House => {
-                if town.0.build_house(&mut bank.0) {
-                    next_modal.set(Modal::None);
+        // The producer goes on the empty plot the hero is standing on — exactly the one the
+        // gold ring marks (`sync_plot_highlight`).
+        let kind = opt.0;
+        let Some(idx) = target.0 else { continue };
+        if town.0.build(idx, kind, &mut bank.0) {
+            // Rebuild-on-rubble: clear any stale mesh first.
+            for (e, bm) in &existing {
+                if bm.idx == idx {
+                    commands.entity(e).try_despawn();
                 }
             }
-            // A producer goes on the empty plot the hero is standing on.
-            BuildItem::Producer(kind) => {
-                let Some(idx) = target.0 else { continue };
-                if town.0.build(idx, kind, &mut bank.0) {
-                    // Rebuild-on-rubble: clear any stale mesh first.
-                    for (e, bm) in &existing {
-                        if bm.idx == idx {
-                            commands.entity(e).try_despawn();
-                        }
-                    }
-                    spawn_building(&mut commands, &mut meshes, &mats.0, idx, kind, &spots);
-                    next_modal.set(Modal::None); // close after a successful build
-                }
-            }
+            spawn_building(&mut commands, &mut meshes, &mats.0, idx, kind, &spots);
+            next_modal.set(Modal::None); // close after a successful build
         }
     }
 }

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -524,7 +524,8 @@ fn tab_basics(body: &mut RelatedSpawnerCommands<ChildOf>, fonts: &UiFonts, atlas
                 ));
                 point(c, fonts, atlas, None, Some("def_reinforce"), "At the keep", "Opens the War Table \u{2014} the upgrade tree.");
                 point(c, fonts, atlas, None, Some("branch:arsenal"), "At the merchant stall", "Opens the shop \u{2014} weapons, armor, potions.");
-                point(c, fonts, atlas, None, Some("stat:pop"), "On an empty plot", "Opens the build menu \u{2014} houses, farms, yards.");
+                point(c, fonts, atlas, None, Some("stat:pop"), "On an empty plot", "Opens the build menu \u{2014} farms and worker yards rise on that exact plot (a gold ring marks it).");
+                point(c, fonts, atlas, None, Some("stat:pop"), "At the timber site in the walls", "Raises a house on the spot \u{2014} beds for two more villagers.");
                 point(c, fonts, atlas, None, Some("buff:power"), "At the war bell", "Rings in the night early, once you're ready.");
             });
             section(l, fonts, "CAMERA", |c| {
@@ -641,13 +642,13 @@ fn tab_stronghold(body: &mut RelatedSpawnerCommands<ChildOf>, fonts: &UiFonts, a
             section(l, fonts, "BUILD ON PLOTS \u{2014} E", |c| {
                 c.spawn(label(
                     &fonts.regular,
-                    "Empty plots ring the castle. Stand on one and press E. Every producer needs a villager to staff it.",
+                    "Empty plots ring the castle. Stand on one and press E \u{2014} a gold ring marks the plot you're building on. Every producer needs a villager to staff it.",
                     13.0,
                     TEXT_DIM,
                 ));
                 // (icon, name, cost, effect) — costs straight from the parity-tested core.
                 let rows: [(&str, &str, f64, f64, String); 4] = [
-                    ("stat:pop", "House", HOUSE_COST.wood, HOUSE_COST.stone, format!("Shelters {POP_PER_HOUSE} more villagers.")),
+                    ("stat:pop", "House", HOUSE_COST.wood, HOUSE_COST.stone, format!("Shelters {POP_PER_HOUSE} more. Raised INSIDE the walls \u{2014} press E at the timber site pad.")),
                     ("stat:food", "Farm", BuildKind::Farm.cost().wood, BuildKind::Farm.cost().stone, "Grows food while staffed.".into()),
                     ("stat:wood", "Woodcutter", BuildKind::Lumber.cost().wood, BuildKind::Lumber.cost().stone, "Its worker fells real trees \u{2014} wood per tree.".into()),
                     ("stat:stone", "Stone Miner", BuildKind::Mine.cost().wood, BuildKind::Mine.cost().stone, "Its worker picks apart ore boulders \u{2014} stone per haul.".into()),
@@ -711,7 +712,7 @@ fn tab_economy(body: &mut RelatedSpawnerCommands<ChildOf>, fonts: &UiFonts, atla
     })
     .with_children(|row| {
         for (icon, name, from, spend) in [
-            ("sym:gold", "GOLD", "Ork bounties \u{00b7} chests across the island.", "Merchant gear & potions \u{00b7} War Table upgrades."),
+            ("sym:gold", "GOLD", "Ork bounties \u{00b7} the dawn tithe (every villager pays after a survived night) \u{00b7} chests (caches restock at dawn).", "Merchant gear & potions \u{00b7} War Table upgrades."),
             ("sym:stone", "STONE", "Smash ore boulders with your attack; Stone Miner workers cart it home.", "Walls, towers & defenses \u{00b7} the Woodcutter yard."),
             ("stat:wood", "WOOD", "Chop trees yourself; Woodcutter workers fell them all day.", "Houses & farms \u{00b7} the Miner camp."),
         ] {

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -1228,24 +1228,26 @@ fn chest_interact(
             if tile_hash(p.x, p.z) > 0.7 {
                 loot.push("mercenary_contract");
             }
-            (loot, (6.0 + chest.factor * 48.0).round() as i64)
+            (loot, (4.0 + chest.factor * 24.0).round() as i64)
         } else if chest.hoard {
             // Deep-rim war hoard: FOUR guaranteed top-tier rolls (factor pinned to 1.0 so the
-            // best pool is certain even if the spot reads sub-rim) + a heavy 150–360 purse.
+            // best pool is certain even if the spot reads sub-rim) + a purse (~110–135). The
+            // gear is the prize; the old 300–360 purses let one biome tour fund half the tree.
             let h = tile_hash(p.x, p.z);
             let loot = (0..4)
                 .map(|i| frontier::roll_gear(1.0, (h + i as f64 * 0.37) % 1.0))
                 .collect();
-            (loot, (150.0 + chest.factor * 150.0 + h * 60.0).round() as i64)
+            (loot, (50.0 + chest.factor * 60.0 + h * 25.0).round() as i64)
         } else {
-            // Ordinary treasure: 1 item near → 3 at the rim; gold ~8 near → ~123–153 at the rim
-            // (was a flat 15 + f·60, so near is nerfed and the rim is a far bigger prize).
+            // Ordinary treasure: 1 item near → 3 at the rim; gold ~5 near → ~60–70 at the rim.
+            // (Exploration pays in GEAR — gold is the town's job: tithe + bounties. The whole
+            // one-time exploration purse is sized to ~a third of the upgrade tree, not all of it.)
             let h = tile_hash(p.x, p.z);
             let items = 1 + (chest.factor * 2.0).round() as i64;
             let loot = (0..items)
                 .map(|i| frontier::roll_gear(chest.factor, (h + i as f64 * 0.37) % 1.0))
                 .collect();
-            (loot, (8.0 + chest.factor * 130.0 + h * 15.0).round() as i64)
+            (loot, (5.0 + chest.factor * 55.0 + h * 10.0).round() as i64)
         };
         // Won't open if the bag can't hold the gear (TS: full bag rejects the chest).
         if !inv.0.has_room_for(&loot) {

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -1084,9 +1084,9 @@ fn seed_forage(
 // frontier gradient), reusing core's pure `roll_gear` pool picks.
 
 const CHEST_INTERACT_DIST: f32 = 2.2;
-/// Seconds before a looted supply cache re-closes + refills. 3× the old 150s so caches aren't a
-/// standing-still income tap — you bank one, then it's a while before it's worth circling back.
-const CACHE_RESPAWN: f32 = 450.0;
+// Caches no longer refill on a wall-clock timer (the old 150s→450s delays still made waiting
+// out the day a gold tap): they restock at DAWN, once per survived night — see `chest_respawn`.
+// Canonical divergence from core's `chests::CACHE_RESPAWN` (the TS parity record).
 
 #[derive(Component)]
 pub(crate) struct Chest {
@@ -1274,17 +1274,30 @@ fn chest_interact(
     }
 }
 
-/// Re-close + refill supply caches once their respawn delay elapses.
+/// Re-close + refill supply caches at dawn (the Wave→Prep clear) — once per survived night.
+/// Time alone never restocks them, so loitering through a long prep day earns nothing; the
+/// world resupplies only when the town wins a new day.
 #[allow(clippy::type_complexity)]
 fn chest_respawn(
     time: Res<Time>,
+    siege: Option<Res<crate::siege::Siege>>,
+    mut prev_phase: Local<Option<crate::siege::GamePhase>>,
     mut commands: Commands,
     mut chests: Query<(&mut Chest, &Children), Without<ChestLid>>,
     lids: Query<(), (With<ChestLid>, Without<Chest>)>,
 ) {
+    let Some(siege) = siege else { return };
+    let dawned = matches!(
+        (*prev_phase, siege.phase),
+        (Some(crate::siege::GamePhase::Wave), crate::siege::GamePhase::Prep)
+    );
+    *prev_phase = Some(siege.phase);
+    if !dawned {
+        return;
+    }
     let now = time.elapsed_secs();
     for (mut chest, children) in &mut chests {
-        if chest.cache && chest.opened && now - chest.opened_at >= CACHE_RESPAWN {
+        if chest.cache && chest.opened {
             chest.opened = false;
             for &c in children {
                 if lids.get(c).is_ok() {


### PR DESCRIPTION
## Summary

Houses are no longer built from the plot-based Build menu. Instead, they're raised on-site at a marked construction pad inside the castle walls via a new "Raise house" interaction. This decouples house placement from the hero's current plot and makes the building destination visually explicit in the world.

## Key Changes

- **Build menu refactor**: Removed `House` from the `BuildItem` enum; menu now shows only producers (Farm, Lumber, Mine). Simplified `BuildOption` to wrap `BuildKind` directly.
- **New "Raise house" interaction**: Added `InteractKind::RaiseHouse` in `interaction.rs`. When the hero stands at the next free dwelling slot (marked by a construction pad), pressing E raises a house there immediately with visual + audio feedback (floats showing success or resource shortage).
- **Visual anchors for clarity**:
  - `PlotHighlight`: A pulsing gold ring marks the targeted plot while the Build menu is open or the hero stands on a buildable plot.
  - `BuildGhost`: A translucent preview of the hovered menu item appears on the target plot before clicking.
  - `HouseSitePad`: A timber-textured pad marks the next free dwelling slot inside the walls, anchoring the "Raise house" prompt.
- **House site tracking**: Added `next_house_site(built: u32)` in `castle.rs` to return the world position of the next free dwelling slot; synced via `sync_house_site_pad()`.
- **Economy rebalance**: 
  - Replaced flat `TAX_STIPEND` with population-driven tithe: `TITHE_GOLD_PER_POP` (2g) per villager, doubled by Tax Office.
  - Reduced treasure chest gold across all tiers (ordinary, hoard, cache) to ~40–50% of old values; gear is now the primary exploration reward.
  - Reduced landmark discovery gold (40→10 base, 120→30 scaling) and completion bonus (200→75).
  - Supply caches now restock at dawn (Wave→Prep transition) instead of a wall-clock timer, preventing idle gold farming.
- **Tutorial update**: Added explicit guidance that producers rise on the marked plot and houses are raised at the timber site in the walls.

## Implementation Details

- The Build menu title changed to "BUILD ON THIS PLOT" to reinforce that producers are plot-specific.
- House-building logic moved from `build_interact()` to a dedicated branch in `drive_interaction()` that always provides feedback (success float or resource shortage).
- `sync_plot_highlight()` and `sync_house_site_pad()` are lazy-spawned FX entities that persist across biome swaps and reposition themselves each frame.
- `build_hover_ghost()` rebuilds the preview only when the hovered menu row changes, avoiding per-frame mesh recreation.
- Removed `Cost` and `HOUSE_COST` from the `town.rs` imports; house cost is now only referenced in `interaction.rs` when building.

https://claude.ai/code/session_01N14ytC61LkJfZF3p9qViNV