### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+`CLAUDE.md` is the primary, detailed guide for this repo (architecture, conventions, the
+`FOREST_*` capture harness, git rules). Read it first. The `.claude/skills/` directory holds
+task-specific SOPs (`visual-debug-cloud`, `model-viewer`, `trailer-maker`, `studio-port`,
+`release`). This file only adds the durable, non-obvious notes for running in a Cursor Cloud VM.
+
+## Cursor Cloud specific instructions
+
+**What this is:** "Warbell" — a single Bevy 0.19 / Rust game crate (`tileworld_bevy_forest`, root
+`src/`) plus a pure-logic workspace member `crates/core` (`tileworld_core`). One product, no
+backend/services.
+
+**Standard commands** (see `README.md` / `CLAUDE.md`):
+- `cargo build` — build the game (first build recompiles Bevy at `opt-level=3`, ~10 min; later
+  `src/` rebuilds are fast).
+- `cargo test -p tileworld_core` — the parity unit tests (~306 + integration tests). This is the
+  test suite; `src/` has no tests.
+- `cargo check` — the lint/type-check (no clippy/rustfmt gate in CI; CI only builds on tag).
+
+**Toolchain gotcha:** the crate is `edition = "2024"`, which needs Rust ≥ 1.85. The base VM's
+`rustup` default was an older pin (1.83), which fails with `feature 'edition2024' is required`.
+The environment is set to `rustup default stable` (currently 1.96); the update script re-asserts
+this each session.
+
+**Running / visual testing is headless (no GPU, no display).** The Bevy window can't be captured
+externally, so use the built-in render-and-exit harness, NOT a normal `cargo run`:
+- Required system libs (Bevy build deps + software-render stack) are baked into the VM snapshot:
+  `libwayland-dev libxkbcommon-dev libudev-dev libasound2-dev xvfb mesa-vulkan-drivers
+  libgl1-mesa-dri libegl1 libxkbcommon-x11-0`. If a fresh image ever lacks them, the build fails
+  with `wayland-client not found` / winit panics with `libxkbcommon-x11.so.0`.
+- Take a shot through Xvfb + lavapipe (software Vulkan):
+  ```bash
+  BEVY_ASSET_ROOT=$PWD FOREST_SHOT=/tmp/shot.png FOREST_TIME=0.28 \
+    timeout 570 xvfb-run -a -s "-screen 0 1280x720x24" \
+    ./target/debug/tileworld_bevy_forest
+  ```
+- **Always set `BEVY_ASSET_ROOT=$PWD`** or custom-material meshes (ground + hero) silently fail to
+  render. Verify a clean run: `grep -c "Path not found" <log>` must be `0`, and confirm the
+  `Screenshot saved` log line before trusting the PNG. Each shot takes ~1 min on llvmpipe; run
+  shots sequentially. The `software rendering ... very slow` warning is expected.
+- Stage scenes with the `FOREST_*` env vars (full table in `CLAUDE.md`), e.g.
+  `FOREST_WAVE=1 FOREST_DEFEND=1 FOREST_NIGHT=1` stages a fortified night siege,
+  `FOREST_CAM="x,y,z,tx,ty,tz"` frames it. See the `visual-debug-cloud` skill for the full
+  workflow and `FOREST_CLIP` for stitched video.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Warbell (Bevy 0.19 / Rust game) in Cursor Cloud and documents the non-obvious cloud caveats.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section: toolchain requirement (edition 2024 needs Rust ≥ 1.85; base image was pinned to 1.83), the baked-in system libs, and the headless `FOREST_SHOT` render/test workflow.
- No source/code changes — the repo builds, tests, and runs as-is once the toolchain + system libs are in place.

## Environment

- **Toolchain:** switched `rustup default` from 1.83 → `stable` (1.96) so `edition = "2024"` compiles.
- **System libs (snapshot):** `libwayland-dev libxkbcommon-dev libudev-dev libasound2-dev xvfb mesa-vulkan-drivers libgl1-mesa-dri libegl1 libxkbcommon-x11-0`.
- **Update script:** `rustup default stable` + `cargo fetch`.

## Verification

- ✅ `cargo build` (10m first build)
- ✅ `cargo test -p tileworld_core` — 306 + 1 integration tests passed
- ✅ `cargo check` — passes (pre-existing warnings only)
- ✅ Headless run via `FOREST_SHOT` (Xvfb + lavapipe), 0 asset errors

Daytime boot:

[Warbell boot](https://cursor.com/agents/bc-985b9c07-1c69-4a36-9bc5-a0dcf11f62a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwarbell_boot_day.png)

Night ork siege with fortified, armed walls (core defense loop):

[Warbell night siege](https://cursor.com/agents/bc-985b9c07-1c69-4a36-9bc5-a0dcf11f62a9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwarbell_night_siege.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-985b9c07-1c69-4a36-9bc5-a0dcf11f62a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-985b9c07-1c69-4a36-9bc5-a0dcf11f62a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

