### PR TITLE
Attack aim-assist facing + camera terrain clamp

### DIFF
--- a/src/player/camera.rs
+++ b/src/player/camera.rs
@@ -37,6 +37,11 @@ const MAX_PITCH: f32 = 1.45;
 const MIN_DIST: f32 = 2.3;
 const MAX_DIST: f32 = 11.0;
 const ZOOM_SENS: f32 = 0.55;
+/// Minimum gap kept between the third-person eye and the terrain below it. When the orbit would sink
+/// the camera into a hill/slope between the hero and the lens, the eye is lifted to ground + this so
+/// it never punches under the world (the "camera dips below the hill" bug). Covers the 0.04 near
+/// plane plus a little body so geometry doesn't poke into frame.
+const CAM_GROUND_CLEAR: f32 = 0.5;
 /// Extra follow distance pulled back (smoothly) while a warden winds up its killing blow — a slow
 /// dolly-out that builds tension across the telegraph, then eases back in once the blow resolves.
 const CRIT_ZOOM_OUT: f32 = 4.5;
@@ -285,8 +290,15 @@ pub fn player_camera(
     // Speed feel: sprinting dollies the camera back a touch (eased by `run_amt`).
     let r_speed = hero.run_amt.clamp(0.0, 1.0) * SPRINT_DOLLY;
     let (a, p, r) = (orbit.azimuth, orbit.pitch, orbit.dist + r_tension + r_speed);
-    let follow_eye =
+    let mut follow_eye =
         follow_target + Vec3::new(a.sin() * p.cos() * r, p.sin() * r, a.cos() * p.cos() * r);
+    // Terrain clamp: never let the follow eye sink below the ground under it (a slope/ridge between
+    // hero and camera). `smooth_surface_y` is continuous so the lift glides instead of popping; only
+    // the third-person eye is clamped (FP rides at head height; build cam is far overhead). `None` —
+    // over water / off the island — leaves the eye free.
+    if let Some(g) = crate::worldmap::ground_at_world(follow_eye.x, follow_eye.z) {
+        follow_eye.y = follow_eye.y.max(g + CAM_GROUND_CLEAR);
+    }
 
     // ── First-person pose ──
     // The orbit's *view* heading (camera-forward yaw) is `azimuth + π` — the look-yaw FP must use so

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -15,12 +15,46 @@ use crate::orks::Ork;
 use crate::wildlife::Animal;
 
 use super::camera::OrbitCam;
-use super::{Hero, HeroHealth, PlayMode, PlayerRes};
+use super::{FirstPerson, Hero, HeroHealth, PlayMode, PlayerRes};
 
 pub const ATTACK_DURATION: f32 = 0.45;
 const ATTACK_RANGE: f32 = 1.8;
 const ATTACK_CONE_DOT: f32 = 0.5; // cos 60° — front cone half-angle
 const HIT_PHASE: f32 = 0.3; // fraction into the swing where damage lands
+
+// ── Attack lock-on ──
+// When a swing starts, the hero soft-snaps his facing toward the nearest enemy so a strafing attack
+// lands square on the target instead of sideways (the "turns his side to whoever he's hitting" bug).
+const LOCK_RANGE: f32 = 3.0; // a touch past ATTACK_RANGE so a circled foo is grabbed before you're on top
+const LOCK_DOT: f32 = -0.4; // ~226° front arc — catch a foe at your side, but never whip 180° to your back
+const LOCK_TURN_RATE: f32 = 24.0; // rad/s soft-turn — snappier than the move-steer so it lands by the hit frame
+
+/// Nearest live enemy within [`LOCK_RANGE`] and the front [`LOCK_DOT`] arc, as a facing angle.
+/// Picks the closest so a knight in a melee commits to the foe he's actually next to.
+fn lock_target_angle<'a>(
+    gts: impl Iterator<Item = &'a GlobalTransform>,
+    origin: Vec2,
+    facing: f32,
+) -> Option<f32> {
+    let fwd = Vec2::new(facing.sin(), facing.cos());
+    let mut best: Option<(f32, f32)> = None; // (dist², angle)
+    for gt in gts {
+        let p = gt.translation();
+        let to = Vec2::new(p.x - origin.x, p.z - origin.y);
+        let d2 = to.length_squared();
+        if d2 > LOCK_RANGE * LOCK_RANGE || d2 < 1e-6 {
+            continue;
+        }
+        let dir = to / d2.sqrt();
+        if dir.dot(fwd) < LOCK_DOT {
+            continue; // behind you — don't snap-spin onto it mid-swing
+        }
+        if best.map_or(true, |(bd, _)| d2 < bd) {
+            best = Some((d2, dir.x.atan2(dir.y)));
+        }
+    }
+    best.map(|(_, a)| a)
+}
 
 /// Deterministic crit-roll source — one roll per swing. mulberry32 ("feels-the-same", no
 /// byte-parity need). Init in `PlayerPlugin`.
@@ -125,6 +159,9 @@ pub struct Juice<'w> {
     materials: ResMut<'w, Assets<StandardMaterial>>,
     /// Active run's difficulty — drives the Easy hero-damage handicap.
     siege: Option<Res<'w, crate::siege::Siege>>,
+    /// First-person flag — folded in here (not a standalone `Res`) so `player_attack` stays under
+    /// Bevy's 16-param ceiling. In FP the view owns facing, so the lock-on facing-snap is skipped.
+    fp: Res<'w, FirstPerson>,
 }
 
 /// Townsfolk the hero can harmlessly bonk with a swing: the [`crate::villagers::Villager`] bodies
@@ -428,9 +465,19 @@ pub fn player_attack(
     if *mode != PlayMode::Play || !player.0.is_alive() {
         hero.attacking = false;
         hero.charge_t = -1.0;
+        hero.lock_face = None;
         return;
     }
     let dt = time.delta_secs();
+
+    // Lock-on: in third-person, snap toward the nearest enemy the instant a swing begins (FP aims by
+    // view, so it owns facing — no lock there). Computed once and reused for the light press and the
+    // heavy release below so both swings commit to the same foe.
+    let new_lock = if juice.fp.active {
+        None
+    } else {
+        lock_target_angle(targets.iter().map(|t| t.1), hero.pos, hero.facing)
+    };
 
     // Charging is gated on the same conditions as swinging: cursor locked (actually playing) and not
     // guarding (the shield takes priority).
@@ -447,6 +494,7 @@ pub fn player_attack(
             hero.attack_t = 0.0;
             hero.hit_dealt = false;
             hero.heavy = false;
+            hero.lock_face = new_lock; // commit the swing to the nearest foe (None = no target → hold facing)
             // Roll a random studio attack clip (0 overhead chop / 1 horizontal slash / 2 forward
             // thrust) so successive swings vary instead of replaying one canned slash.
             hero.attack_variant = (rng.unit() * 3.0).floor().clamp(0.0, 2.0) as u8;
@@ -473,6 +521,7 @@ pub fn player_attack(
                 hero.attack_t = 0.0;
                 hero.hit_dealt = false;
                 hero.heavy = true;
+                hero.lock_face = new_lock; // commit the heavy to the nearest foe too
                 hero.attack_variant = HEAVY_VARIANT;
                 cues.write(AudioCue::HeroGruntSwing);
                 cues.write(AudioCue::Slam); // a beefier release whoosh for the heavy wind-up
@@ -483,11 +532,17 @@ pub fn player_attack(
     if !hero.attacking {
         return;
     }
+    // Soft-snap toward the locked foe across the wind-up so the blow lands facing it. Movement's
+    // move-steer is suppressed while `attacking`, so this is the sole facing writer here (third-person).
+    if let Some(target) = hero.lock_face {
+        hero.facing = super::movement::lerp_angle(hero.facing, target, (dt * LOCK_TURN_RATE).min(1.0));
+    }
     hero.attack_t += dt;
     let phase = hero.attack_t / ATTACK_DURATION;
     if phase >= 1.0 {
         hero.attacking = false;
         hero.heavy = false; // swing done — the next light swing must not inherit the heavy tag
+        hero.lock_face = None; // release the facing lock so move-steer takes over again
         return;
     }
     if hero.hit_dealt || phase < HIT_PHASE {

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -22,12 +22,15 @@ const ATTACK_RANGE: f32 = 1.8;
 const ATTACK_CONE_DOT: f32 = 0.5; // cos 60° — front cone half-angle
 const HIT_PHASE: f32 = 0.3; // fraction into the swing where damage lands
 
-// ── Attack lock-on ──
-// When a swing starts, the hero soft-snaps his facing toward the nearest enemy so a strafing attack
-// lands square on the target instead of sideways (the "turns his side to whoever he's hitting" bug).
-const LOCK_RANGE: f32 = 3.0; // a touch past ATTACK_RANGE so a circled foo is grabbed before you're on top
-const LOCK_DOT: f32 = -0.4; // ~226° front arc — catch a foe at your side, but never whip 180° to your back
-const LOCK_TURN_RATE: f32 = 24.0; // rad/s soft-turn — snappier than the move-steer so it lands by the hit frame
+// ── Attack aim-assist ──
+// When a swing starts, the hero *gently* leans his facing toward the nearest enemy so a swing reads
+// as aimed at the foe instead of sideways (the "turns his side to whoever he's hitting" bug). It's a
+// soft assist, NOT a lock: the turn is slower than the move-steer, which stays live, so the player's
+// own input always overpowers it — standing still and swinging tidies your aim; actively strafing
+// keeps your heading. Never a hard snap, never freezes control.
+const LOCK_RANGE: f32 = 3.0; // a touch past ATTACK_RANGE so a circled foe is grabbed before you're on top
+const LOCK_DOT: f32 = -0.2; // ~200° front arc — leans toward a foe at your side, but never to your back
+const LOCK_TURN_RATE: f32 = 9.0; // rad/s — gentler than the 15 rad/s move-steer, so player input wins
 
 /// Nearest live enemy within [`LOCK_RANGE`] and the front [`LOCK_DOT`] arc, as a facing angle.
 /// Picks the closest so a knight in a melee commits to the foe he's actually next to.
@@ -532,8 +535,9 @@ pub fn player_attack(
     if !hero.attacking {
         return;
     }
-    // Soft-snap toward the locked foe across the wind-up so the blow lands facing it. Movement's
-    // move-steer is suppressed while `attacking`, so this is the sole facing writer here (third-person).
+    // Gently lean toward the locked foe across the swing (third-person). This is a soft assist, not a
+    // lock — the move-steer in `player_move` stays live and turns faster, so active input overrides
+    // this; with no input (standing to swing) it quietly tidies the aim onto the target.
     if let Some(target) = hero.lock_face {
         hero.facing = super::movement::lerp_angle(hero.facing, target, (dt * LOCK_TURN_RATE).min(1.0));
     }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -136,6 +136,12 @@ pub struct Hero {
     /// World-XZ endpoints of the active dash slide (only meaningful while `dash_t >= 0.0`).
     pub dash_from: Vec2,
     pub dash_to: Vec2,
+    // ── Attack lock-on ──
+    /// Facing angle the current swing is soft-snapping toward — the nearest enemy in lock range when
+    /// the swing started. `Some` only while a swing steers toward a target (third-person; FP aims by
+    /// view), cleared when the swing ends. Makes a blow face what you're hitting instead of your
+    /// strafe direction. Transient (derived, like `attacking`) — not saved.
+    pub lock_face: Option<f32>,
 }
 
 /// Hero **shield/stamina** state — only the block mechanic. HP, gold, XP/level and the combat
@@ -433,6 +439,7 @@ fn spawn_hero(
                 dash_t: -1.0,
                 dash_from: Vec2::ZERO,
                 dash_to: Vec2::ZERO,
+                lock_face: None,
             },
             HeroHealth::default(),
         ))
@@ -638,6 +645,7 @@ fn reset_player(
         dash_t: -1.0,
         dash_from: Vec2::ZERO,
         dash_to: Vec2::ZERO,
+        lock_face: None,
     };
     tf.translation = Vec3::new(pos.x, y, pos.y);
     tf.rotation = Quat::from_rotation_y(0.0);

--- a/src/player/movement.rs
+++ b/src/player/movement.rs
@@ -54,7 +54,7 @@ fn key_axis(keys: &ButtonInput<KeyCode>, pos: KeyCode, neg: KeyCode) -> f32 {
     (keys.pressed(pos) as i32 - keys.pressed(neg) as i32) as f32
 }
 
-fn lerp_angle(a: f32, b: f32, t: f32) -> f32 {
+pub(super) fn lerp_angle(a: f32, b: f32, t: f32) -> f32 {
     a + steer::wrap_pi(b - a) * t
 }
 
@@ -308,7 +308,10 @@ pub fn player_move(
         }
         // Steer toward the INPUT direction while pressing (hold the last facing through the slide). In
         // first person the *view* owns facing (set in `player_camera`) so attacks fire where you aim.
-        if moving && !fp.active {
+        // While a swing is in flight the *attack* owns facing (it soft-snaps toward the locked target
+        // in `player_attack`), so we skip the move-steer there — otherwise strafing yanks the body off
+        // the enemy and the blow lands sideways. This was the "hero turns his side to the target" bug.
+        if moving && !fp.active && !hero.attacking {
             let want = move_dir.x.atan2(move_dir.z);
             hero.facing = lerp_angle(hero.facing, want, (dt * TURN_RATE).min(1.0));
         }

--- a/src/player/movement.rs
+++ b/src/player/movement.rs
@@ -308,10 +308,10 @@ pub fn player_move(
         }
         // Steer toward the INPUT direction while pressing (hold the last facing through the slide). In
         // first person the *view* owns facing (set in `player_camera`) so attacks fire where you aim.
-        // While a swing is in flight the *attack* owns facing (it soft-snaps toward the locked target
-        // in `player_attack`), so we skip the move-steer there — otherwise strafing yanks the body off
-        // the enemy and the blow lands sideways. This was the "hero turns his side to the target" bug.
-        if moving && !fp.active && !hero.attacking {
+        // This stays live DURING a swing — `player_attack` only *gently* nudges facing toward the
+        // locked foe (a soft aim-assist), and the player's own steer here always overpowers it, so it
+        // never feels like the game wrenches the body off where you're pointing.
+        if moving && !fp.active {
             let want = move_dir.x.atan2(move_dir.z);
             hero.facing = lerp_angle(hero.facing, want, (dt * TURN_RATE).min(1.0));
         }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -267,6 +267,7 @@ fn setup(
                 dash_t: -1.0,
                 dash_from: Vec2::ZERO,
                 dash_to: Vec2::ZERO,
+                lock_face: None,
             },
             crate::player::HeroHealth::default(),
         ))


### PR DESCRIPTION
Two player-control fixes from playtest feedback.

## 1. Hero turned his side to the enemy he was attacking
In third-person `hero.facing` was steered only by movement input, so strafing around a foe and swinging landed the blow sideways. Added a **soft aim-assist**: a swing gently leans the hero toward the nearest enemy in range (front ~200° arc, 3u). It is intentionally *not* a hard lock — the move-steer stays live and turns faster (15 rad/s vs the assist's 9 rad/s), so the player's own input always overpowers it. Standing still and swinging tidies your aim onto a foe beside you; an active strafe keeps your heading. FP is unchanged (the view owns aim there). The camera is untouched — it stays fully mouse-driven.

## 2. The follow camera punched through hills
The third-person eye now clamps above the terrain sampled at its position (`worldmap::ground_at_world`), lifting just clear of the ground when a slope/ridge would put the lens underground. Only the third-person eye is clamped; FP and build cam are untouched. `smooth_surface_y` is continuous, so the lift glides instead of popping, and flat ground is unaffected.

Builds clean (`cargo check`); 306 core tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A14884p3zVSv9e9rcETJQV)_