### PR TITLE
Fix daytime shaman bolts, persistent raid alert, killable rival workers, later dusk

### DIFF
--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -457,9 +457,17 @@ pub fn player_attack(
             Option<&mut Animal>,
             Option<&mut crate::combat_fx::HitSquash>,
             Option<&crate::rival::RivalSoldier>,
+            Option<&crate::rival::RivalWorker>,
         ),
         (
-            Or<(With<Ork>, With<Animal>, With<crate::boss::Boss>, With<crate::warlord::Warlord>, With<crate::rival::RivalSoldier>)>,
+            Or<(
+                With<Ork>,
+                With<Animal>,
+                With<crate::boss::Boss>,
+                With<crate::warlord::Warlord>,
+                With<crate::rival::RivalSoldier>,
+                With<crate::rival::RivalWorker>,
+            )>,
             Without<crate::dying::Dying>,
         ),
     >,
@@ -584,7 +592,7 @@ pub fn player_attack(
     // Direct-hit bookkeeping for the cleave pass (positions to splash from + who's already hit).
     let mut struck: Vec<Vec2> = Vec::new();
     let mut hit_ents: Vec<Entity> = Vec::new();
-    for (e, gt, mut hp, mut ork, animal, mut squash, rival) in &mut targets {
+    for (e, gt, mut hp, mut ork, animal, mut squash, rival, worker) in &mut targets {
         let p = gt.translation();
         let to = Vec2::new(p.x - origin.x, p.z - origin.y);
         let dist = to.length();
@@ -639,6 +647,9 @@ pub fn player_attack(
             } else if rival.is_some() {
                 // A felled rival soldier pays a tough-ork-tier bounty (gold scales with the boon).
                 ((crate::rival::SOLDIER_BOUNTY_GOLD as f64 * bounty_mult).round() as i64, crate::rival::SOLDIER_BOUNTY_XP)
+            } else if worker.is_some() {
+                // A cut-down rival labourer pays only a token peasant bounty.
+                ((crate::rival::WORKER_BOUNTY_GOLD as f64 * bounty_mult).round() as i64, crate::rival::WORKER_BOUNTY_XP)
             } else {
                 (0, 0)
             };
@@ -717,7 +728,7 @@ pub fn player_attack(
     if player.0.cleave > 0.0 && !struck.is_empty() {
         let splash = cleave_damage(dmg as f64, player.0.cleave) as f32;
         if splash > 0.0 {
-            for (e, gt, mut hp, ork, _animal, mut squash, _rival) in &mut targets {
+            for (e, gt, mut hp, ork, _animal, mut squash, _rival, _worker) in &mut targets {
                 if ork.is_none() || hit_ents.contains(&e) {
                     continue; // cleave only hits orks, and never the directly-struck ones twice
                 }
@@ -801,7 +812,7 @@ pub fn player_attack(
         // collateral mid-battle. If any ork is near the hero we're in a fight, so stay quiet; an
         // accidental bonk between sword-strokes shouldn't make the peasant quip over the screaming.
         const BATTLE_QUIET_R2: f32 = 14.0 * 14.0;
-        let in_battle = targets.iter().any(|(_, gt, _, ork, _, _, _)| {
+        let in_battle = targets.iter().any(|(_, gt, _, ork, _, _, _, _)| {
             ork.is_some() && {
                 let p = gt.translation();
                 Vec2::new(p.x - origin.x, p.z - origin.y).length_squared() < BATTLE_QUIET_R2

--- a/src/projectile.rs
+++ b/src/projectile.rs
@@ -128,15 +128,22 @@ fn step_bolts(
     mut marks: MessageWriter<crate::aftermath::BattleMark>,
     mut commands: Commands,
     mut q: Query<(Entity, &mut Bolt, &mut Transform)>,
+    mut prev_phase: Local<Option<crate::siege::GamePhase>>,
 ) {
     let dt = time.delta_secs().min(0.05);
     let target = Vec3::new(hero.pos.x, hero.y + 1.0, hero.pos.y);
-    // A bolt still in flight when the night clears must not deal damage into the won daytime —
-    // fizzle any live bolt once the wave is over (the keep/invaders are cleared on the same edge).
-    let wave_active = siege.phase == crate::siege::GamePhase::Wave;
+    // A bolt still in flight when a night wave CLEARS must not deal damage into the won daytime —
+    // sweep every live bolt on that Wave→day edge only (the keep/invaders clear on the same edge).
+    // This must NOT fire every daytime frame: wilderness camp shamans cast during the day too, and
+    // despawning their bolts the instant they spawned made those bolts invisible ("szamani strzelają
+    // niewidzialnymi kulami"). Daytime bolts now fly normally and expire on their own TTL/range.
+    let cur_phase = siege.phase;
+    let was = prev_phase.replace(cur_phase);
+    let wave_cleared =
+        was == Some(crate::siege::GamePhase::Wave) && cur_phase != crate::siege::GamePhase::Wave;
     for (e, mut b, mut tf) in &mut q {
         b.ttl -= dt;
-        if !hero.alive || b.ttl <= 0.0 || !wave_active {
+        if !hero.alive || b.ttl <= 0.0 || wave_cleared {
             commands.entity(e).try_despawn();
             continue;
         }

--- a/src/rival.rs
+++ b/src/rival.rs
@@ -469,7 +469,12 @@ fn spawn_building(
         let site = home + out * reach;
         let wseed = 0x9a17_0000u32.wrapping_add((idx as u32).wrapping_mul(2654435761)) | 1;
         let e = crate::villagers::spawn_rival_worker(commands, meshes, creature_mats, trade, home, home, wseed);
-        commands.entity(e).insert(RivalWorker { home, site, patrol: site, patrol_t: 0.0, work_cd: 0.0, rng: wseed });
+        commands.entity(e).insert((
+            RivalWorker { home, site, patrol: site, patrol_t: 0.0, work_cd: 0.0, rng: wseed },
+            // A soft body so the hero can cut the rival's labourers down too (a raiding tactic —
+            // starve the enemy economy). Far frailer than a soldier; pays a peasant-tier bounty.
+            crate::player::Health { hp: WORKER_HP, max: WORKER_HP },
+        ));
     }
 }
 
@@ -850,6 +855,11 @@ const SOLDIER_DMG: f32 = 16.0;
 pub const SOLDIER_BOUNTY_GOLD: i64 = 12;
 pub const SOLDIER_BOUNTY_XP: i64 = 25;
 const SOLDIER_ATK_CD: f32 = 1.1;
+/// A rival labourer (farmer/woodcutter/miner) — an unarmed non-combatant, so it dies in a hit or two
+/// and pays only a token peasant bounty. Read in `player::combat`.
+const WORKER_HP: f32 = 40.0;
+pub const WORKER_BOUNTY_GOLD: i64 = 3;
+pub const WORKER_BOUNTY_XP: i64 = 8;
 const SOLDIER_MELEE: f32 = 1.7;
 /// How near a foe must come before a soldier engages…
 const SOLDIER_SIGHT: f32 = 13.0;
@@ -1088,6 +1098,8 @@ fn step_toward(v: &mut crate::villagers::Villager, target: Vec2, step: f32, cur_
 // keep-0 defeat stays night-gated in `siege.rs`).
 
 const RAIDER_HP: f32 = 70.0;
+/// Sticky-notice id for the "Rival raiders are attacking!" banner (persists while any raider lives).
+const RAID_ALERT_KEY: u32 = 0x5a1d_a1e7;
 const RAIDER_HERO_DMG: f32 = 8.0;
 const RAIDER_NPC_DMG: f32 = 9.0;
 /// Per-strike keep chip. Modest: a full party (~5) just out-paces the prep-time repair, so an
@@ -1219,7 +1231,6 @@ fn rival_raid_brain(
     mut npc_dmg: ResMut<crate::villagers::NpcDamage>,
     mut keep: ResMut<crate::siege::KeepHp>,
     mut notice: ResMut<crate::ui::notice::Notice>,
-    mut next_alert: Local<f64>,
     mut raiders: Query<(&mut RivalRaider, &mut crate::villagers::Villager, &mut Transform), Without<crate::dying::Dying>>,
     townsfolk: Query<(Entity, &Transform), (With<crate::villagers::Townsfolk>, Without<crate::dying::Dying>, Without<RivalSoldier>, Without<RivalRaider>)>,
 ) {
@@ -1292,12 +1303,15 @@ fn rival_raid_brain(
         tf.translation = Vec3::new(v.pos.x, gy + bob, v.pos.y);
         tf.rotation = Quat::from_rotation_y(v.facing);
     }
-    // Re-warn at most every 8s while the raid keeps landing blows (mirrors siege::keep_attack_alert,
-    // which is night-only — raids hit during the day, so they need their own cue).
-    let now64 = time.elapsed_secs_f64();
-    if struck && now64 >= *next_alert {
-        notice.push("Rival raiders are attacking!", now64);
-        *next_alert = now64 + 8.0;
+    // Keep a persistent "under attack" banner up for the WHOLE life of the raid — it must not lapse
+    // while any raider is still alive (the night-only siege keep-alert doesn't cover daytime raids).
+    // Raise it once the raid lands its first blow, and drop it the moment the last raider falls
+    // (the query already excludes `Dying`, so a downed raider stops counting immediately).
+    let alive = raiders.iter().count();
+    if alive == 0 {
+        notice.clear_sticky(RAID_ALERT_KEY);
+    } else if struck {
+        notice.set_sticky(RAID_ALERT_KEY, "Rival raiders are attacking!");
     }
 }
 

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -199,10 +199,11 @@ const NIGHT_DRIFT_RATE: f32 = 0.003; // slow clock creep through the wave (~100s
 // countdown so it isn't already dark with a third of prep left. It climbs dawn→noon over the first
 // ~two-thirds, then descends noon→dusk→dark over the final stretch — one steady sun arc you can
 // time the wave by. At `1.5` the sky hit full dark (`night`→1, ≈t 0.55) at prog≈0.79 — ~40s of
-// dark before the war-bell, which read as "sun set too early"; `3.0` pushes full dark to prog≈0.89
-// (~20s), then the last stretch is the moon climbing to true midnight (T_NIGHTFALL 0.75). Still a
-// visible, moving sky (no "dark, then wait" pop), just night arriving nearer the wave.
-const PREP_SUN_EASE: f32 = 3.0;
+// dark before the war-bell, which read as "sun set too early"; `3.0` pushed full dark to prog≈0.89
+// (~20s), still too early. `6.5` keeps the sun up until the final stretch — full dark (`night`→1)
+// lands at prog≈0.95 (~10s before the war-bell), then the last seconds are the moon climbing to
+// true midnight (T_NIGHTFALL 0.75). Dusk is quick, but it's daylight until night is genuinely near.
+const PREP_SUN_EASE: f32 = 6.5;
 
 fn smoothstep(e0: f32, e1: f32, x: f32) -> f32 {
     let t = ((x - e0) / (e1 - e0)).clamp(0.0, 1.0);

--- a/src/ui/notice.rs
+++ b/src/ui/notice.rs
@@ -11,14 +11,36 @@ use super::widgets::border;
 
 const LIFETIME: f64 = 3.5;
 
-/// Pending/active notices: `(text, born_secs)`.
+/// Top-centre system messages. `queue` holds transient `(text, born_secs)` pills that fade after
+/// [`LIFETIME`]; `sticky` holds state-driven banners kept up (no fade) until explicitly cleared.
 #[derive(Resource, Default)]
-pub struct Notice(VecDeque<(String, f64)>);
+pub struct Notice {
+    queue: VecDeque<(String, f64)>,
+    /// Persistent banners, keyed by a caller-chosen id so a system can update/clear its own.
+    sticky: Vec<(u32, String)>,
+}
 
 impl Notice {
-    /// Queue a message (it appears next frame). `now` is `time.elapsed_secs_f64()`.
+    /// Queue a transient message (it appears next frame, fades after ~3.5s). `now` is
+    /// `time.elapsed_secs_f64()`.
     pub fn push(&mut self, text: impl Into<String>, now: f64) {
-        self.0.push_front((text.into(), now));
+        self.queue.push_front((text.into(), now));
+    }
+
+    /// Show `text` as a persistent banner tagged `key`, replacing any prior banner with the same
+    /// key. It stays up (no fade) until [`Notice::clear_sticky`] — for state-driven warnings like an
+    /// active raid that must last exactly as long as the condition holds.
+    pub fn set_sticky(&mut self, key: u32, text: impl Into<String>) {
+        let text = text.into();
+        match self.sticky.iter_mut().find(|(k, _)| *k == key) {
+            Some(slot) => slot.1 = text,
+            None => self.sticky.push((key, text)),
+        }
+    }
+
+    /// Remove the sticky banner tagged `key` (no-op if none is set).
+    pub fn clear_sticky(&mut self, key: u32) {
+        self.sticky.retain(|(k, _)| *k != key);
     }
 }
 
@@ -64,13 +86,20 @@ fn update_notice(
     rows_q: Query<Entity, With<NoticeRow>>,
 ) {
     let now = time.elapsed_secs_f64();
-    notice.0.retain(|(_, born)| now - *born < LIFETIME);
+    notice.queue.retain(|(_, born)| now - *born < LIFETIME);
     for e in &rows_q {
         commands.entity(e).try_despawn();
     }
     let Ok(root) = root_q.single() else { return };
+    // Sticky banners sit on top (persistent state warnings), transient pills below (newest first).
+    let rows: Vec<&str> = notice
+        .sticky
+        .iter()
+        .map(|(_, t)| t.as_str())
+        .chain(notice.queue.iter().map(|(t, _)| t.as_str()))
+        .collect();
     commands.entity(root).with_children(|col| {
-        for (text, _) in notice.0.iter() {
+        for text in rows {
             col.spawn((
                 NoticeRow,
                 Node {
@@ -84,7 +113,7 @@ fn update_notice(
                 shadow_card(),
             ))
             .with_children(|p| {
-                p.spawn(label(&fonts.bold, text.clone(), 13.0, rgb(243, 230, 200)));
+                p.spawn(label(&fonts.bold, text.to_string(), 13.0, rgb(243, 230, 200)));
             });
         }
     });


### PR DESCRIPTION
## Summary

- **Daytime shaman bolts were invisible** — `step_bolts` despawned every live bolt on *every* non-Wave frame (`!wave_active`), so wilderness camp-shaman bolts (cast during the day) died the frame they spawned. Now bolts are only swept on the Wave→day edge; daytime bolts fly and expire normally on TTL/range.
- **Rival raid alert now persists** — added keyed sticky (no-fade) banners to the notice system. "Rival raiders are attacking!" is raised on the first blow and dropped only when the last raider falls, instead of a 3.5s toast throttled every 8s.
- **Rival labourers are killable** — farmers/woodcutters/miners get a soft `Health` body and join the hero's hit query, paying a token peasant bounty. Previously they had no `Health` and were untouchable.
- **Dusk arrives later** — `PREP_SUN_EASE` 3.0 → 6.5 so full dark lands ~10s before the war-bell (was ~20s), keeping daylight up until night is genuinely near.

## Testing

- `cargo check` clean (only pre-existing warnings)
- `cargo test` core + projectile unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011RKGcTGMRzYxJSeMSxgPEv)_