### PR TITLE
Fix 19 review findings: logic bugs, perf, run-state coherence

### DIFF
--- a/src/boss/mod.rs
+++ b/src/boss/mod.rs
@@ -237,6 +237,11 @@ impl Plugin for BossPlugin {
         app.init_resource::<PendingReward>()
             .init_resource::<CritTension>()
             .add_systems(PostStartup, spawn_wardens)
+            // Fresh in-process run (New Game / Restart / Play Again all exit StartScreen or GameOver
+            // without a GameLoaded): rebuild the full level-1 pantheon so a warden slain in a prior
+            // run isn't permanently gone (wardens aren't BiomeEntity, so the world rebuild skips them).
+            .add_systems(OnExit(AppState::StartScreen), respawn_wardens_on_new_run)
+            .add_systems(OnExit(AppState::GameOver), respawn_wardens_on_new_run)
             // On a loaded game, remove wardens the saved hero already slew (ungated; once per load).
             .add_systems(Update, despawn_slain_wardens)
             .add_systems(Update, boss_limbs) // limb sway keeps running while frozen
@@ -330,6 +335,24 @@ fn spawn_wardens(
             }
         });
     }
+}
+
+/// New Game / Restart / Play Again (a fresh in-process run — no `GameLoaded`, so `despawn_slain_wardens`
+/// never fires): despawn every warden and respawn all five at level 1, matching the boon flags that
+/// `Player::reset()` clears. Without this a warden killed in a prior run stays permanently gone for
+/// the rest of the process — its entity was `try_despawn`'d by the death-fade and is never rebuilt,
+/// since wardens carry no `BiomeEntity` tag for the world-rebuild sweep to catch. On a Continue this
+/// spawns fresh wardens too, then `despawn_slain_wardens` prunes the saved-slain ones the same frame.
+fn respawn_wardens_on_new_run(
+    mut commands: Commands,
+    existing: Query<Entity, With<Boss>>,
+    meshes: ResMut<Assets<Mesh>>,
+    materials: ResMut<Assets<crate::creature::CreatureMaterial>>,
+) {
+    for e in &existing {
+        commands.entity(e).try_despawn();
+    }
+    spawn_wardens(commands, meshes, materials);
 }
 
 /// On a loaded game, despawn any warden the saved hero has **already slain**. A warden isn't
@@ -616,7 +639,12 @@ fn boss_levelup(
 ) {
     let dawn = matches!(*prev, Some(GamePhase::Wave)) && siege.phase == GamePhase::Prep;
     *prev = Some(siege.phase);
-    if !dawn {
+    // Guard the fresh-run false trigger: this system is frozen (Modal gone) whenever we leave
+    // Playing, so a death mid-siege leaves `prev == Some(Wave)`. A New Game / Restart then resets
+    // Siege to Prep (wave_index = -1) and this would false-fire a level-up on day 1 before a single
+    // night is fought. A *real* dawn always follows a night, so wave_index is >= 0 then — mirrors
+    // the identical guard in `savegame::autosave_on_dawn`.
+    if !dawn || siege.wave_index < 0 {
         return;
     }
     for (mut b, mut h) in &mut q {

--- a/src/defenses.rs
+++ b/src/defenses.rs
@@ -175,7 +175,9 @@ fn defenders_fire(
     defenses: Res<Defenses>,
     mut orders: ResMut<DefenderBolts>,
     mut emitters: Query<&mut Defender>,
-    invaders: Query<(Entity, &Transform), With<WaveInvader>>,
+    // `Without<Dying>`: don't lock a shot (and burn the cooldown) onto a fading corpse — a killed
+    // invader stays a valid `WaveInvader` for ~1.4s. Matches `step_defender_bolts`'s own query.
+    invaders: Query<(Entity, &Transform), (With<WaveInvader>, Without<crate::dying::Dying>)>,
 ) {
     if siege.phase != GamePhase::Wave {
         return;
@@ -296,7 +298,9 @@ fn batter_towers(
     time: Res<Time>,
     siege: Res<Siege>,
     mut towers: Query<&mut Defender>,
-    invaders: Query<&Transform, With<WaveInvader>>,
+    // `Without<Dying>`: a defeated invader keeps its position for the ~1.4s death fade; without this
+    // it would keep gnawing on a tower after it's dead, per the corpse-filtering rule in `dying.rs`.
+    invaders: Query<&Transform, (With<WaveInvader>, Without<crate::dying::Dying>)>,
 ) {
     if siege.phase != GamePhase::Wave {
         return;

--- a/src/economy.rs
+++ b/src/economy.rs
@@ -64,7 +64,7 @@ impl Default for EconomyState {
 }
 
 /// Reinforced-Keep bonus (forest's keep is 1500 base; +400 → 1900, healed to full).
-const REINFORCE_BONUS: f32 = 400.0;
+pub const REINFORCE_BONUS: f32 = 400.0;
 // (The old flat Tax Office stipend is gone: dawn gold is now the population tithe —
 // `town_store::Town::tithe`, paid in `siege::run_director` — and Tax Office doubles it.)
 
@@ -453,11 +453,14 @@ fn shop_interact(
     let now = time.elapsed_secs() as f64;
     let keyed: Vec<Entity> = acts.read().map(|a| a.0).collect();
     let mut acted = false;
+    // Built once per tick — the catalog is tiny but this system runs every frame the shop is open
+    // and both the BUY loop and the recolour loop scan it (was rebuilt per-button before).
+    let items = build_shop_items(&eco.unlocked_weapons);
 
     // BUY: a click or Enter/E focus activation (one per press).
     for (e, interaction, btn, _) in &buy_buttons {
         if *interaction == Interaction::Pressed || keyed.contains(&e) {
-            if let Some(item) = build_shop_items(&eco.unlocked_weapons).iter().find(|i| i.id == btn.0) {
+            if let Some(item) = items.iter().find(|i| i.id == btn.0) {
                 let price = discounted_price(item.price, discount);
                 // Need the gold AND room in the bag; otherwise no-op (TS refunds a full bag).
                 if player.0.gold >= price && inv.0.has_room_for(&[item.id]) {
@@ -500,7 +503,7 @@ fn shop_interact(
     // Recolour BUY lines: affordable = gold, too dear = grey.
     let gold = player.0.gold;
     for (_, _, btn, mut bg) in &mut buy_buttons {
-        let price = build_shop_items(&eco.unlocked_weapons)
+        let price = items
             .iter()
             .find(|i| i.id == btn.0)
             .map(|i| discounted_price(i.price, discount))

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -189,7 +189,7 @@ fn debug_bufftest(mut buffs: ResMut<Buffs>, time: Res<Time>) {
 fn debug_seed(mut inv: ResMut<Inventory>) {
     if std::env::var("FOREST_PANEL").ok().as_deref() == Some("inv") {
         for (id, n) in [("bread", 3), ("potion", 2), ("fur", 1), ("sword_iron", 1), ("leather_armor", 1), ("apple", 4)] {
-            inv.0.add(id, n); // fur auto-binds Z (slot 0)
+            inv.0.add(id, n); // fur auto-binds Y (slot 0)
         }
         inv.0.set_quick_bind(1, "potion"); // demo a manual bind: a heal pinned to T (slot 1)
     }

--- a/src/landmarks.rs
+++ b/src/landmarks.rs
@@ -29,7 +29,7 @@ use tileworld_core::buff_store::BuffKind;
 use crate::audio::AudioCue;
 use crate::biome::{Biome, BiomeEntity};
 use crate::combat_fx::{col_kill, FloatQueue, FloatReq};
-use crate::game_state::Modal;
+use crate::game_state::{AppState, Modal};
 use crate::inventory::{try_grant, Buffs, Inventory, Toasts};
 use crate::player::{HeroState, PlayerRes};
 use crate::ui::fonts::{label, FONT_LABEL, UiFonts};
@@ -315,6 +315,11 @@ impl Plugin for LandmarksPlugin {
         app.init_resource::<Discoveries>()
             .init_resource::<RuneTrial>()
             .add_message::<LandmarkInteract>()
+            // Wipe the found/completed tally on a fresh run — the freshly-rebuilt `Landmark` entities
+            // reset to undiscovered, but this resource is not `BiomeEntity` and otherwise leaks across
+            // runs, letting the all-found +75g bonus fire early (or never) in the next run.
+            .add_systems(OnExit(AppState::StartScreen), reset_discoveries)
+            .add_systems(OnExit(AppState::GameOver), reset_discoveries)
             // Beacon drift is a visual — runs even while the world is frozen, like the particles.
             .add_systems(Update, beacon_drift)
             // Light/snuff each beacon to mirror its landmark's "boost ready" state (ungated, so it
@@ -370,6 +375,14 @@ fn clear_around_landmarks(
             commands.entity(e).try_despawn();
         }
     }
+}
+
+/// New Game / Restart / Play Again: zero the found/completed tally (keep `total` — the landmark
+/// count is constant across runs, re-latched by `track_total` anyway). Mirrors the reset systems on
+/// every other earned run-state resource (economy, quests, siege, lives, rescues).
+fn reset_discoveries(mut disc: ResMut<Discoveries>) {
+    disc.found = 0;
+    disc.completed = false;
 }
 
 /// Latch the landmark count into [`Discoveries::total`] once they've spawned (drives the

--- a/src/lumberjack.rs
+++ b/src/lumberjack.rs
@@ -301,6 +301,13 @@ fn chop_work(
             commands.entity(self_e).try_remove::<ChopJob>();
             continue;
         };
+        // Already dropped to 0 HP by another cutter (or the hero) THIS frame — the `Stump` insert is
+        // deferred, so the tree is still queryable here. Bail before swinging, or this worker fells
+        // the same tree a second time and banks a second unearned log (mirrors `miner::pick_work`).
+        if tree.felled() {
+            commands.entity(self_e).try_remove::<ChopJob>();
+            continue;
+        }
         let tp = Vec2::new(ttf.translation.x, ttf.translation.z);
         let d = v.pos.distance(tp);
         // Reach is sized to THIS tree's trunk (thin sapling vs fat bole) so the cutter steps right

--- a/src/orbs.rs
+++ b/src/orbs.rs
@@ -6,7 +6,7 @@
 use bevy::prelude::*;
 use tileworld_core::orb::{self, Orb, OrbKind, OrbStep, PlayerPose};
 
-use crate::game_state::Modal;
+use crate::game_state::{AppState, Modal};
 use crate::player::{HeroState, PlayerRes};
 
 /// A reward queued by combat on a kill — split into gold + xp orbs by [`spawn_queued_orbs`].
@@ -55,6 +55,11 @@ impl Plugin for OrbsPlugin {
         app.init_resource::<RewardBursts>()
             .init_resource::<OrbRng>()
             .add_systems(Startup, setup_orb_assets)
+            // Fresh run (New Game / Restart / Play Again): sweep in-flight motes and drop any queued
+            // bursts. They aren't `BiomeEntity` (so the world rebuild skips them) and would otherwise
+            // home onto the reset hero and bank last run's gold/xp into the new run.
+            .add_systems(OnExit(AppState::StartScreen), reset_orbs)
+            .add_systems(OnExit(AppState::GameOver), reset_orbs)
             .add_systems(
                 Update,
                 (spawn_queued_orbs, step_reward_orbs)
@@ -62,6 +67,14 @@ impl Plugin for OrbsPlugin {
                     .run_if(in_state(Modal::None)),
             );
     }
+}
+
+/// Despawn every in-flight reward orb and clear the pending-burst queue on a fresh run.
+fn reset_orbs(mut commands: Commands, orbs: Query<Entity, With<RewardOrb>>, mut bursts: ResMut<RewardBursts>) {
+    for e in &orbs {
+        commands.entity(e).try_despawn();
+    }
+    bursts.0.clear();
 }
 
 fn setup_orb_assets(

--- a/src/ork_fortress.rs
+++ b/src/ork_fortress.rs
@@ -28,7 +28,7 @@ use bevy::prelude::*;
 use crate::biome::{AtmoSample, BiomeAmbience, BiomeEntity, GroundDetail, ParticleKind};
 use crate::critters::PartKind;
 use crate::firelight::{self, FireLight};
-use crate::game_state::Modal;
+use crate::game_state::{AppState, Modal};
 use crate::orks::{Armory, Faction, OrkPart, OrkVariant};
 use crate::palette::lin;
 use crate::player::{HeroState, PendingHeroDamage};
@@ -211,6 +211,14 @@ impl Plugin for OrkFortressPlugin {
             .add_systems(Update, (wobble_flames, drift_smoke, denizen_limbs, quality_lod, gate_beacon))
             // Ungated (once per load): reconcile the fortress to pristine on a Continue/Load.
             .add_systems(Update, reset_fortress_on_load)
+            // Fresh in-process run (New Game / Restart / Play Again route through StartScreen, and
+            // GameOver -> fresh): clear the transient assault flags so the win condition is reachable
+            // again — the world rebuild respawns every fortress entity, so only these flags leak.
+            .add_systems(
+                OnExit(AppState::StartScreen),
+                reset_fortress_on_new_run,
+            )
+            .add_systems(OnExit(AppState::GameOver), reset_fortress_on_new_run)
             // Sim carries the freeze gate, per the game_state contract.
             .add_systems(
                 Update,
@@ -615,7 +623,9 @@ pub fn build(
         let pos = at(*t);
         let rot = ry(yaw) * Quat::from_rotation_z(lean);
         spawn_solid(commands, meshes, &timber_mat, tower_mesh(&mut rng), pos, rot);
-        crate::blockers::add(t.x, t.y, 1.2);
+        // Box, not circle: radius 1.2 > the ≤1.0 bound `blockers::is_blocked`'s neighbour-only scan
+        // assumes for circles, so a circle here could be missed a tile out. A box has no such bound.
+        crate::blockers::add_box(t.x, t.y, 1.2, 1.2);
         commands.spawn((
             WarTower {
                 muzzle: pos + rot * Vec3::new(0.0, 5.1, 0.0),
@@ -704,7 +714,9 @@ pub fn build(
         Transform { translation: spire_pos, rotation: spire_rot, scale: Vec3::splat(SPIRE_SCALE) },
         BiomeEntity,
     ));
-    crate::blockers::add(SPIRE_AT.x, SPIRE_AT.y, 1.8 * SPIRE_SCALE);
+    // Box, not circle: this footprint (~2.07) far exceeds the ≤1.0 circle bound, so a plain circle
+    // would be silently missed by `is_blocked` two-plus tiles out. A box is tested directly.
+    crate::blockers::add_box(SPIRE_AT.x, SPIRE_AT.y, 1.8 * SPIRE_SCALE, 1.8 * SPIRE_SCALE);
     let brazier = spire_pos + spire_rot * (Vec3::new(0.45, 12.05, -0.3) * SPIRE_SCALE);
     commands.spawn((
         Mesh3d(meshes.add(flame_mesh(1.5))),
@@ -740,7 +752,8 @@ pub fn build(
     //    across the strait at dusk ARE the fortress's voice). ──
     let fire = at(BONFIRE_AT);
     spawn_solid(commands, meshes, &mat, bonfire_base_mesh(), fire, Quat::IDENTITY);
-    crate::blockers::add(BONFIRE_AT.x, BONFIRE_AT.y, 1.1);
+    // Box, not circle: radius 1.1 > the ≤1.0 circle bound the neighbour-only scan assumes.
+    crate::blockers::add_box(BONFIRE_AT.x, BONFIRE_AT.y, 1.1, 1.1);
     commands.spawn((
         Mesh3d(meshes.add(flame_mesh(2.3))),
         MeshMaterial3d(flame_mat.clone()),
@@ -2908,6 +2921,20 @@ fn reset_fortress_on_load(
     crate::blockers::remove_box_near(GATE.x, GATE.y, 0.6);
     crate::blockers::add_obb(GATE.x, GATE.y, 3.2, 0.5, 0.0);
     spawn_garrison_denizens(&mut commands, &patrols.armory);
+}
+
+/// Fresh in-process run (New Game / Restart / Play Again all funnel through `StartScreen` without a
+/// `GameLoaded`, so `reset_fortress_on_load` never fires for them): clear the transient assault
+/// flags. The `biome::PendingBuild` world rebuild despawns + respawns every fortress `BiomeEntity`
+/// (Warlord, garrison, denizens, patrols) and re-adds the shut gate blocker via `build()`, so only
+/// these two leaked resource flags need resetting here. Without this the breach prompt/beacon stay
+/// suppressed forever after one victory (`AssaultState.breached` sticks true across the run).
+fn reset_fortress_on_new_run(
+    mut assault: ResMut<AssaultState>,
+    mut director: ResMut<crate::cinematic::DirectorState>,
+) {
+    assault.breached = false;
+    director.gate_open = false;
 }
 
 /// Show + pulse the breach beacon while the hero is in range of the unbroken gate; hide it once

--- a/src/orks.rs
+++ b/src/orks.rs
@@ -97,8 +97,9 @@ pub(crate) fn bounty_xp(v: OrkVariant) -> i64 {
 }
 
 /// Per-variant melee damage to the hero in this scene's combat units. The Grunt is the
-/// `ORK_DAMAGE` anchor; others scale by the `ork_config` damage ratio (Scout ≈5, Berserker
-/// ≈10). The Shaman casts `SHAMAN_BOLT_DAMAGE` instead, so this is unused for it.
+/// `ORK_DAMAGE` anchor; others scale by the `ork_config` damage ratio (with core's Scout 15 /
+/// Berserker 30 vs Grunt 24, that lands Scout ≈14, Berserker ≈27). The Shaman casts
+/// `SHAMAN_BOLT_DAMAGE` instead, so this is unused for it.
 pub(crate) fn variant_melee(v: OrkVariant) -> f32 {
     use tileworld_core::ork_config::{ork_config, OrkVariant as C};
     let grunt = ork_config(C::Grunt).damage as f32; // core ratio anchor (24); ORK_DAMAGE is the nerfed scene value

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -482,12 +482,15 @@ pub fn player_attack(
     let dt = time.delta_secs();
 
     // Lock-on: in third-person, snap toward the nearest enemy the instant a swing begins (FP aims by
-    // view, so it owns facing — no lock there). Computed once and reused for the light press and the
-    // heavy release below so both swings commit to the same foe.
-    let new_lock = if juice.fp.active {
-        None
-    } else {
+    // view, so it owns facing — no lock there). Only computed on the press/release edges that
+    // actually read it — otherwise this O(n) scan over every live foe ran every frame of a siege for
+    // a value that was discarded. (Both edges use the same value so a light→heavy combo locks one foe.)
+    let new_lock = if !juice.fp.active
+        && (buttons.just_pressed(MouseButton::Left) || buttons.just_released(MouseButton::Left))
+    {
         lock_target_angle(targets.iter().map(|t| t.1), hero.pos, hero.facing)
+    } else {
+        None
     };
 
     // Charging is gated on the same conditions as swinging: cursor locked (actually playing) and not

--- a/src/rival.rs
+++ b/src/rival.rs
@@ -1231,7 +1231,7 @@ fn rival_raid_brain(
     mut npc_dmg: ResMut<crate::villagers::NpcDamage>,
     mut keep: ResMut<crate::siege::KeepHp>,
     mut notice: ResMut<crate::ui::notice::Notice>,
-    mut raiders: Query<(&mut RivalRaider, &mut crate::villagers::Villager, &mut Transform), Without<crate::dying::Dying>>,
+    mut raiders: Query<(Entity, &mut RivalRaider, &mut crate::villagers::Villager, &mut Transform), Without<crate::dying::Dying>>,
     townsfolk: Query<(Entity, &Transform), (With<crate::villagers::Townsfolk>, Without<crate::dying::Dying>, Without<RivalSoldier>, Without<RivalRaider>)>,
 ) {
     let dt = time.delta_secs().min(0.05);
@@ -1243,7 +1243,7 @@ fn rival_raid_brain(
     let goal = crate::siege::KEEP_POS;
     let folk: Vec<(Entity, Vec2)> =
         townsfolk.iter().map(|(e, t)| (e, Vec2::new(t.translation.x, t.translation.z))).collect();
-    for (mut rd, mut v, mut tf) in &mut raiders {
+    for (re, mut rd, mut v, mut tf) in &mut raiders {
         rd.atk_cd -= dt;
         let vpos = v.pos;
         // Nearest of our people (hero or townsperson) in sight.
@@ -1276,7 +1276,10 @@ fn rival_raid_brain(
                     struck = true;
                     match victim {
                         None => pending.0 += RAIDER_HERO_DMG,
-                        Some(ve) => npc_dmg.0.push(crate::villagers::NpcHit { victim: ve, amount: RAIDER_NPC_DMG, attacker: None }),
+                        // `attacker: Some(re)` so the struck townsperson fights back against the raider
+                        // like it does every other foe (raiders carry `RivalSoldier`, now in the
+                        // `npc_fight_back` hostile set) — mirrors `rival_combat`'s garrison strike.
+                        Some(ve) => npc_dmg.0.push(crate::villagers::NpcHit { victim: ve, amount: RAIDER_NPC_DMG, attacker: Some(re) }),
                     }
                 }
             } else {

--- a/src/savegame.rs
+++ b/src/savegame.rs
@@ -412,6 +412,10 @@ fn apply_pending_load(
     siege.difficulty = data.difficulty;
     siege.wave_index = data.wave_index;
     siege.phase = GamePhase::Prep;
+    // Rearm the director's scratch timers/counters so the loaded Prep day starts a *fresh* countdown
+    // from the current clock, not the abandoned run's stale (possibly already-expired) prep_ends_at —
+    // which would otherwise fire BeginWave immediately and drop the resumed night with no prep time.
+    siege.rearm_scratch();
     keep.hp = data.keep_hp;
     keep.max = data.keep_max;
     lives.heirs = data.heirs;

--- a/src/siege.rs
+++ b/src/siege.rs
@@ -422,12 +422,16 @@ const KEEP_HP_PER_NIGHT: f32 = 0.10;
 const KEEP_HP_NIGHT_CAP: f32 = 2.5;
 
 /// The keep's MAX HP for night `wave_index` (0-based): base × difficulty handicap × per-night
-/// reinforcement, clamped to [`KEEP_HP_NIGHT_CAP`]. `wave_index < 0` (pre-first-night) → base.
-pub fn keep_max_for(wave_index: i32, diff: Difficulty) -> f32 {
+/// reinforcement, clamped to [`KEEP_HP_NIGHT_CAP`], plus the flat Reinforced Keep upgrade bonus when
+/// owned. `wave_index < 0` (pre-first-night) → base. The `reinforced` term MUST be folded in here:
+/// this is an *absolute* recompute of `keep.max` on every night start, so a bonus applied only at
+/// purchase time (`economy::apply_effect`) is silently overwritten the next dusk without it.
+pub fn keep_max_for(wave_index: i32, diff: Difficulty, reinforced: bool) -> f32 {
     let base = KEEP_MAX_HP * mods_for(diff).keep_hp_mul;
     let nights = wave_index.max(0) as f32;
     let scale = (1.0 + KEEP_HP_PER_NIGHT * nights).min(KEEP_HP_NIGHT_CAP);
-    base * scale
+    let bonus = if reinforced { crate::economy::REINFORCE_BONUS } else { 0.0 };
+    base * scale + bonus
 }
 /// Keep self-repair during the prep breather (HP/s) — the day is a chance to recover.
 const KEEP_REPAIR_RATE: f32 = 12.0;
@@ -487,6 +491,15 @@ impl Siege {
     /// Ring in the night early (war bell / **B**): the reducer floors it to `MIN_PREP_SECONDS`.
     pub fn request_prep_skip(&mut self) {
         self.skip_requested = true;
+    }
+
+    /// Clear the reducer's scratch (prep/spawn timers, spawn count, pending skip) so a loaded run
+    /// re-arms a fresh Prep day from the current clock instead of inheriting the saved-over run's
+    /// stale countdown. Called by `savegame::apply_pending_load`.
+    pub fn rearm_scratch(&mut self) {
+        self.timers = WaveTimers::default();
+        self.spawned = 0;
+        self.skip_requested = false;
     }
 }
 
@@ -622,7 +635,7 @@ fn reset_siege(
     // Re-derive the keep's max from base × the difficulty handicap (so switching difficulty between
     // runs takes effect, and the Easy keep is genuinely tougher). At reset wave_index is -1 (pre
     // first night), so this is the un-reinforced base — it grows per night via `keep_max_for`.
-    keep.max = keep_max_for(siege.wave_index, diff);
+    keep.max = keep_max_for(siege.wave_index, diff, false);
     keep.hp = keep.max;
 }
 
@@ -799,6 +812,7 @@ fn run_director(
     mut keep: ResMut<KeepHp>,
     mut player: ResMut<crate::player::PlayerRes>,
     eco: Res<crate::economy::EconomyState>,
+    def: Res<crate::economy::Defenses>,
     mut town: ResMut<crate::town::TownRes>,
     mut floats: ResMut<crate::combat_fx::FloatQueue>,
     armory: Option<Res<InvaderArmory>>,
@@ -849,7 +863,7 @@ fn run_director(
                 siege.spawned = 0;
                 // Reinforce the keep for this night: its MAX HP scales with the night index, and
                 // the new headroom is granted as real HP (the town shored up the walls overnight).
-                let new_max = keep_max_for(siege.wave_index, siege.difficulty);
+                let new_max = keep_max_for(siege.wave_index, siege.difficulty, def.reinforced);
                 let delta = new_max - keep.max;
                 keep.max = new_max;
                 if delta > 0.0 {

--- a/src/succession.rs
+++ b/src/succession.rs
@@ -245,7 +245,14 @@ fn drive_succession(
         }
         // Possess the body: drop one townsperson from the pool, despawn it, and stand the hero up
         // on its spot at full strength with a beat of spawn-protection.
-        town.0.population = town.0.population.saturating_sub(1);
+        // Guard the double-decrement: combat (`npc_damage_apply`) can kill the stolen body during the
+        // slow-mo beat, and that path already dropped population by one. Only decrement here if the
+        // body is still a live townsperson (or we're rising at the gate with no body picked) — a body
+        // that died mid-beat is `Dying`/gone, so `villagers.get` fails and we skip the second drop.
+        let already_counted = succ.steal_entity.is_some_and(|e| villagers.get(e).is_err());
+        if !already_counted {
+            town.0.population = town.0.population.saturating_sub(1);
+        }
         if let Some(e) = succ.steal_entity.take() {
             commands.entity(e).try_despawn();
         }

--- a/src/town.rs
+++ b/src/town.rs
@@ -308,7 +308,9 @@ fn auto_assign_workers(
     spots: Res<PlotSpots>,
     siege: Option<Res<crate::siege::Siege>>,
     mut commands: Commands,
-    workers: Query<(Entity, &Worker)>,
+    // `Without<Dying>`: a dying worker's corpse must not read as still occupying its plot, or a live
+    // replacement can't be assigned until it despawns (mirrors the `idle` filter below).
+    workers: Query<(Entity, &Worker), Without<crate::dying::Dying>>,
     // Rallied guards are excluded: a guard that has answered the muster (`K`) stays fallen-in and
     // following the hero, off the labour pool, until the player stands the war party down.
     idle: Query<
@@ -381,7 +383,13 @@ fn auto_assign_workers(
 }
 
 /// Each frame, mark a plot `staffed` iff a posted, visible worker is on it.
-fn sync_staffed(mut town: ResMut<TownRes>, workers: Query<(&Worker, &Visibility)>) {
+fn sync_staffed(
+    mut town: ResMut<TownRes>,
+    // `Without<Dying>`: a worker killed mid-fade keeps its `Worker{at_post}` tag and stays
+    // `Visibility::Visible` for the ~1.4s death fade, so without this filter its plot reads staffed
+    // (and keeps yielding) while its worker is already dead.
+    workers: Query<(&Worker, &Visibility), Without<crate::dying::Dying>>,
+) {
     let n = town.0.plots.len();
     let mut staffed = vec![false; n];
     for (w, vis) in &workers {

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -267,6 +267,12 @@ impl ChopTree {
         Self { hp: TREE_HP, trunk_r }
     }
 
+    /// True once the tree has been chopped to 0 HP — used by cutters to bail before double-felling a
+    /// tree another actor already dropped this frame (the `Stump` insert that removes it is deferred).
+    pub fn felled(&self) -> bool {
+        self.hp <= 0.0
+    }
+
     /// Trunk-blocker radius — the woodcutter (`lumberjack.rs`) plants its swing just outside this
     /// so it stands at the bark, not an arm's length off it.
     pub fn trunk_r(&self) -> f32 {

--- a/src/villagers.rs
+++ b/src/villagers.rs
@@ -1024,8 +1024,15 @@ fn npc_fight_back(
     mut hostiles: Query<
         (&Transform, &mut crate::player::Health, Option<&crate::wildlife::Animal>),
         (
-            Or<(With<crate::orks::Ork>, With<crate::wildlife::Animal>)>,
-            Without<Villager>,
+            // Rival soldiers/raiders carry `Villager` (for locomotion/anim) but neither `Ork` nor
+            // `Animal`, so they must be named explicitly here — and `Without<Villager>` must NOT be
+            // used (it would re-exclude those same rival bodies). The `Or` already keeps friendly
+            // townsfolk out (they carry none of these markers), mirroring `guard_combat`'s query.
+            Or<(
+                With<crate::orks::Ork>,
+                With<crate::wildlife::Animal>,
+                With<crate::rival::RivalSoldier>,
+            )>,
             Without<crate::dying::Dying>,
         ),
     >,

--- a/src/wildlife.rs
+++ b/src/wildlife.rs
@@ -923,8 +923,10 @@ const PLANS: [Plan; 13] = [
     Plan { species: Species::Elk, count: 8, cluster: 4, scale: 0.95, speed: 5.5, wander_speed: 1.4, flee_r: 13.0, wander_r: 12.0, gait: 10.0, swing: 0.55, bob: 0.05, place: Place::Forest },
     // Rabbit — grass, small clusters; very skittish + bouncy.
     Plan { species: Species::Rabbit, count: 10, cluster: 2, scale: 0.65, speed: 6.5, wander_speed: 1.6, flee_r: 16.0, wander_r: 8.0, gait: 14.0, swing: 0.5, bob: 0.12, place: Place::Grass },
-    // Boar — forest/frontier loners; mild flee.
-    Plan { species: Species::Boar, count: 5, cluster: 1, scale: 0.8, speed: 4.0, wander_speed: 1.0, flee_r: 8.0, wander_r: 10.0, gait: 11.0, swing: 0.5, bob: 0.04, place: Place::GrassOrForest },
+    // Boar — forest/frontier loners; a predator (charges the hero), so flee_r is unused (0.0) like
+    // the other hunters — `animal_brain`'s predator branch wins over the flee branch for any species
+    // with `predator_stats`, so a nonzero flee_r here would be dead data.
+    Plan { species: Species::Boar, count: 5, cluster: 1, scale: 0.8, speed: 4.0, wander_speed: 1.0, flee_r: 0.0, wander_r: 10.0, gait: 11.0, swing: 0.5, bob: 0.04, place: Place::GrassOrForest },
     // Wolf — forest packs; apex, ignores the camera.
     Plan { species: Species::Wolf, count: 6, cluster: 3, scale: 0.8, speed: 5.0, wander_speed: 1.4, flee_r: 0.0, wander_r: 16.0, gait: 12.0, swing: 0.6, bob: 0.04, place: Place::Forest },
     // Goat — rock highlands; nimble, roams the terraces.


### PR DESCRIPTION
Multi-agent (sonnet) review pass ahead of the promotion, verified
adversarially. Grouped by severity:

HIGH — game-breaking:
- ork_fortress: reset AssaultState.breached on a fresh in-process run
  (New Game / Restart / Play Again). It only reset on Continue, so after
  one victory the breach prompt/beacon stayed suppressed and the win
  condition was unreachable for the rest of the process.
- boss: respawn all five wardens on a fresh run — a slain warden's entity
  was never rebuilt (not a BiomeEntity), leaving the biome bossless and its
  boon unobtainable. Also guard boss_levelup against the fresh-run false
  trigger (a mid-siege death + Restart levelled every warden on day 1).
- villagers: passive townsfolk now retaliate against rival soldiers/raiders
  (npc_fight_back excluded Villager, which those bodies carry).
- siege: fold the Reinforced Keep +400 bonus into keep_max_for so it isn't
  wiped by the next night's absolute max-HP recompute.

MEDIUM:
- savegame: rearm the siege director's scratch timers on load so a resumed
  Prep day gets a fresh countdown, not the saved-over run's stale one.
- town: filter Without<Dying> in sync_staffed / auto_assign_workers so a
  dying worker doesn't keep a plot "staffed" (or block a replacement).
- lumberjack: guard chop_work on tree.felled() so a tree felled the same
  frame by another cutter can't pay out wood twice.
- landmarks: reset Discoveries on New Game (was persisted but never wiped).
- succession: don't double-decrement town population when combat kills the
  possessed body during the transform beat.
- rival: raiders strike with attacker: Some(e) so victims fight back.
- defenses: filter Without<Dying> in defenders_fire / batter_towers so
  corpses aren't targeted or kept battering a tower.
- orbs: sweep in-flight reward motes + queued bursts on a fresh run.

LOW:
- orks: correct the variant_melee damage-ratio doc comment.
- economy: hoist build_shop_items out of the per-button shop loop.
- player/combat: only compute the lock-on target on press/release edges.
- wildlife: Boar flee_r is dead data (predator branch wins) — set 0.0.
- blockers: register oversized fortress props (towers/spire/bonfire) as
  boxes, not circles that violate the <=1.0 neighbour-scan bound.
- inventory: fix a stale quick-bind key comment.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Td8EyAnFYe1WUT37GSVNSp