### PR TITLE
Add itch.io badge + auto-publish releases to itch.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,3 +116,60 @@ jobs:
             dist/Warbell-${{ github.ref_name }}-setup.msi
           fail_on_unmatched_files: false
           generate_release_notes: true
+
+      # Hand the packaged build to the itch.io publish job below. We ship the
+      # archive (not the raw dir) because workflow artifacts strip the Linux
+      # executable bit; the tar.gz preserves it.
+      - name: Upload artifact for itch.io
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: |
+            dist/${{ matrix.artifact }}.zip
+            dist/${{ matrix.artifact }}.tar.gz
+          if-no-files-found: error
+
+  # Push both platform builds to itch.io (https://miskibin.itch.io/warbell) via butler.
+  # Needs the BUTLER_API_KEY repo secret (itch.io → Settings → API keys); if it's absent
+  # (e.g. a fork) the job warns and skips instead of failing the release. Channels
+  # `windows` / `linux` are created by butler on first push; --userversion stamps the
+  # tag's version so the itch.io app can diff/auto-update between releases.
+  itch:
+    name: Publish to itch.io
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
+      ITCH_TARGET: miskibin/warbell
+    steps:
+      - name: Warn if BUTLER_API_KEY is not configured
+        if: env.BUTLER_API_KEY == ''
+        run: echo "::warning::BUTLER_API_KEY secret not set — skipping itch.io publish"
+
+      - name: Download build artifacts
+        if: env.BUTLER_API_KEY != ''
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Install butler
+        if: env.BUTLER_API_KEY != ''
+        run: |
+          curl -fsSL -o butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
+          unzip -q butler.zip -d butler
+          chmod +x butler/butler
+          ./butler/butler -V
+
+      - name: Push to itch.io
+        if: env.BUTLER_API_KEY != ''
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Re-extract so butler pushes plain directories (better patch diffing than
+          # pushing the archives themselves). The Windows zip has no wrapper dir
+          # (Compress-Archive of dir/*); the Linux tar wraps everything in the
+          # artifact-name dir, hence --strip-components.
+          mkdir -p push/windows push/linux
+          unzip -q dist/tileworld-windows-x86_64/tileworld-windows-x86_64.zip -d push/windows
+          tar -xzf dist/tileworld-linux-x86_64/tileworld-linux-x86_64.tar.gz -C push/linux --strip-components=1
+          ./butler/butler push push/windows "$ITCH_TARGET:windows" --userversion "$VERSION"
+          ./butler/butler push push/linux "$ITCH_TARGET:linux" --userversion "$VERSION"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Built in Rust on [**Bevy 0.18**](https://bevyengine.org).
 
 [**▶ Website**](https://miskibin.github.io/warbell/) · [**⬇ Download for Windows**](https://github.com/miskibin/warbell/releases/latest/download/Warbell-Setup.msi) · [**Changelog**](https://miskibin.github.io/warbell/changelog.html)
 
+<a href="https://miskibin.itch.io/warbell"><img src="https://static.itch.io/images/badge-color.svg" alt="Available on itch.io" height="40"></a>
+
 
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e54e45fd-5f4d-4230-bf76-b6040ae66cce" />
 
@@ -19,6 +21,7 @@ Built in Rust on [**Bevy 0.18**](https://bevyengine.org).
 ## Play
 
 - **Windows:** download [**`Warbell-Setup.msi`**](https://github.com/miskibin/warbell/releases/latest/download/Warbell-Setup.msi) and run it. The installer is self-signed, so Windows SmartScreen shows "Unknown Publisher" — click **More info → Run anyway**.
+- **itch.io:** [**miskibin.itch.io/warbell**](https://miskibin.itch.io/warbell) — Windows & Linux builds, pushed automatically on every release (works with the [itch.io app](https://itch.io/app) for auto-updates).
 - **From source** (any platform): see [Build from source](#build-from-source) below.
 
 |  |  |  |


### PR DESCRIPTION
## What

- **README:** adds the official itch.io badge linking to [miskibin.itch.io/warbell](https://miskibin.itch.io/warbell), plus an itch.io entry in the Play section.
- **Release workflow:** new `itch` job that runs on every `v*` tag after both platform builds. It downloads the packaged archives, re-extracts them (the tar.gz preserves the Linux exec bit), and butler-pushes plain directories to `miskibin/warbell:windows` and `miskibin/warbell:linux`, stamped with `--userversion` from the tag so the itch.io app can patch/auto-update between releases.

## Setup required

The job needs a `BUTLER_API_KEY` Actions secret (itch.io → Settings → API keys). If it's absent (e.g. on a fork), the job logs a warning and skips instead of failing the release. Channels are created by butler on the first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016soDPgNGY1tt8vP8sMoDR8

---
_Generated by [Claude Code](https://claude.ai/code/session_016soDPgNGY1tt8vP8sMoDR8)_