### PR TITLE
chore(release): v0.16.1 — first itch.io auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,15 @@ jobs:
           Write-Host "Timestamp        : $($sig.TimeStamperCertificate.Subject)"
           if (-not $sig.SignerCertificate) { throw "MSI is not signed" }
 
+      # The website's download button resolves releases/latest/download/Warbell-Setup.msi —
+      # a STABLE filename. scripts/release.ps1 attaches it when releasing from a dev machine,
+      # but a tag pushed without the script (e.g. from a cloud session) must not leave the
+      # latest release missing that asset, so CI attaches a stable-named copy too.
+      - name: Stable-name MSI copy (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Copy-Item "dist/Warbell-${{ github.ref_name }}-setup.msi" "dist/Warbell-Setup.msi"
+
       - name: Package (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -104,6 +113,15 @@ jobs:
           cp ${{ matrix.binary }} dist/${{ matrix.artifact }}/
           cp -r assets dist/${{ matrix.artifact }}/assets
           tar -C dist -czf dist/${{ matrix.artifact }}.tar.gz ${{ matrix.artifact }}
+
+      # Handwritten player-facing notes, when the release commit carries them
+      # (docs/release-notes/<tag>.md). Falls back to GitHub's auto-generated notes.
+      - name: Locate handwritten release notes
+        id: notes
+        shell: bash
+        run: |
+          f="docs/release-notes/${GITHUB_REF_NAME}.md"
+          if [ -f "$f" ]; then echo "path=$f" >> "$GITHUB_OUTPUT"; fi
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
@@ -114,8 +132,12 @@ jobs:
             dist/${{ matrix.artifact }}.zip
             dist/${{ matrix.artifact }}.tar.gz
             dist/Warbell-${{ github.ref_name }}-setup.msi
+            dist/Warbell-Setup.msi
           fail_on_unmatched_files: false
-          generate_release_notes: true
+          # body_path is ignored when empty (no notes file committed for this tag),
+          # in which case auto-generated notes fill the body instead.
+          body_path: ${{ steps.notes.outputs.path }}
+          generate_release_notes: ${{ steps.notes.outputs.path == '' }}
 
       # Hand the packaged build to the itch.io publish job below. We ship the
       # archive (not the raw dir) because workflow artifacts strip the Linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "tileworld_bevy_forest"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bevy",
  "bevy_egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/core"]
 
 [package]
 name = "tileworld_bevy_forest"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 
 [dependencies]

--- a/docs/release-notes/v0.16.1.md
+++ b/docs/release-notes/v0.16.1.md
@@ -1,0 +1,12 @@
+## New
+
+- **Warbell is now on itch.io** — [miskibin.itch.io/warbell](https://miskibin.itch.io/warbell), with both **Windows and Linux** builds. Install through the [itch.io app](https://itch.io/app) and it keeps the game updated automatically with small delta patches.
+
+## Under the hood
+
+- Every release is now pushed to itch.io automatically by CI, stamped with the release version — no manual uploads.
+- The stable-named `Warbell-Setup.msi` installer is now attached by CI on every release, so the website's download button always points at the newest installer.
+
+---
+
+*The Windows installer is self-signed, so SmartScreen shows "Unknown Publisher" — click **More info → Run anyway**.*

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -73,11 +73,36 @@
 
 <main class="log">
 
-  <!-- ── v0.16.0 ── -->
+  <!-- ── v0.16.1 ── -->
   <article class="rel latest rv">
     <div class="rel-head">
-      <span class="rel-ver">v0.16.0</span>
+      <span class="rel-ver">v0.16.1</span>
       <span class="rel-badge">Latest</span>
+      <span class="rel-date">July 2, 2026</span>
+    </div>
+    <p class="rel-sum">Warbell lands on itch.io — Windows &amp; Linux builds, published automatically with every release.</p>
+    <div class="rel-card">
+      <div class="grp">
+        <div class="grp-h"><span class="tag new">New</span></div>
+        <ul>
+          <li><strong>Warbell is on itch.io.</strong> Get it at <a href="https://miskibin.itch.io/warbell">miskibin.itch.io/warbell</a> — Windows and Linux builds. Install through the <a href="https://itch.io/app">itch.io app</a> and it keeps the game updated automatically with small delta patches.</li>
+        </ul>
+      </div>
+      <div class="grp">
+        <div class="grp-h"><span class="tag perf">Under the hood</span></div>
+        <ul>
+          <li>Every release is now pushed to itch.io automatically by CI, stamped with the release version.</li>
+          <li>The stable-named <code>Warbell-Setup.msi</code> installer is now attached by CI on every release, so this site's download button always points at the newest installer.</li>
+        </ul>
+      </div>
+      <div class="rel-foot"><a href="https://github.com/miskibin/warbell/releases/tag/v0.16.1">Release on GitHub →</a></div>
+    </div>
+  </article>
+
+  <!-- ── v0.16.0 ── -->
+  <article class="rel rv">
+    <div class="rel-head">
+      <span class="rel-ver">v0.16.0</span>
       <span class="rel-date">July 2, 2026</span>
     </div>
     <p class="rel-sum">Sharper fights, a real merchant shop, a rewritten early game, and a snowy ambush hiding among the props.</p>


### PR DESCRIPTION
Release prep for v0.16.1 — the test release for the new itch.io auto-publish pipeline.

- Bump `Cargo.toml`/`Cargo.lock` to 0.16.1
- `site/changelog.html`: new v0.16.1 entry (demotes v0.16.0 from Latest)
- Handwritten release notes at `docs/release-notes/v0.16.1.md`
- `release.yml`: releases cut without `scripts/release.ps1` (e.g. from a cloud session) now stay complete — CI attaches the stable-named `Warbell-Setup.msi` (the asset the website's `latest/download` link resolves to) and uses `docs/release-notes/&lt;tag&gt;.md` as the release body when present, falling back to auto-generated notes.

After merge, tag `v0.16.1` on the merge commit triggers the release build + the first automated itch.io push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016soDPgNGY1tt8vP8sMoDR8

---
_Generated by [Claude Code](https://claude.ai/code/session_016soDPgNGY1tt8vP8sMoDR8)_