### PR TITLE
ci: release automatically when a version bump lands on main

### DIFF
--- a/.github/workflows/release-on-bump.yml
+++ b/.github/workflows/release-on-bump.yml
@@ -1,0 +1,50 @@
+name: Release on version bump
+
+# Cut a release when the version in Cargo.toml changes on main and no tag exists
+# for it yet. This is how a session that cannot push tags or dispatch workflows
+# (e.g. Claude Code on the web — its git proxy only permits the session's work
+# branch, and the integration token can't hit the dispatch API) still cuts a
+# release: merge the version bump to main and this workflow calls release.yml,
+# which creates the tag at the merge commit. On a dev-machine release
+# (scripts/release.ps1 pushes the tag alongside the bump) the tag-exists check
+# makes this a no-op, so the tag-push-triggered run stays the only one.
+on:
+  push:
+    branches: [main]
+    paths: ["Cargo.toml"]
+
+permissions:
+  contents: write # release.yml creates the tag + release and uploads artifacts
+
+jobs:
+  check:
+    name: Check for an unreleased version
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.v.outputs.tag }}
+      release: ${{ steps.v.outputs.release }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: v
+        run: |
+          ver=$(sed -n 's/^version *= *"\([^"]*\)".*/\1/p' Cargo.toml | head -1)
+          [ -n "$ver" ] || { echo "could not read version from Cargo.toml"; exit 1; }
+          tag="v$ver"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" > /dev/null; then
+            echo "Tag $tag already exists — nothing to release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No tag for version $ver yet — releasing $tag."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Release
+    needs: check
+    if: needs.check.outputs.release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.check.outputs.tag }}
+    secrets: inherit # BUTLER_API_KEY for the itch.io publish job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,14 @@ on:
       tag:
         description: "Release tag (vX.Y.Z); created at the dispatched commit if it doesn't exist"
         required: true
+  # Called by release-on-bump.yml when a Cargo.toml version bump lands on main
+  # without a matching tag (the tag-free release path for web sessions).
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag (vX.Y.Z); created at the called commit if it doesn't exist"
+        required: true
+        type: string
 
 env:
   # The single source of the tag name: the pushed tag ref, or the dispatch input.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ members = ["crates/core"]
 
 [package]
 name = "tileworld_bevy_forest"
+# The one source of the release version (build.rs embeds it; the MSI binds to it).
+# Bumping it on main cuts a release: .github/workflows/release-on-bump.yml tags
+# and releases any version that lands here without a matching v* tag.
 version = "0.16.1"
 edition = "2024"
 


### PR DESCRIPTION
Web sessions can neither push tags (git proxy 403) nor dispatch workflows (integration token 403), so this adds the missing release path:

- **`release-on-bump.yml`** — on push to `main` touching `Cargo.toml`, reads the version; if no matching `v*` tag exists, calls `release.yml` with it. Dev-machine releases via `release.ps1` push the tag alongside the bump, so the tag-exists check makes this a no-op there (no duplicate runs).
- **`release.yml`** — gains a `workflow_call` trigger (same `tag` input as `workflow_dispatch`); `action-gh-release` creates the tag at the merge commit.
- `Cargo.toml` — documents the bump-to-release contract above `version` (this also makes this PR's merge fire the new workflow and cut **v0.16.1**, whose bump already landed in #44).

Merging this PR releases v0.16.1 and runs the first automated itch.io publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016soDPgNGY1tt8vP8sMoDR8

---
_Generated by [Claude Code](https://claude.ai/code/session_016soDPgNGY1tt8vP8sMoDR8)_