### PR TITLE
Night-combat readability: horde torches, gate braziers, longer hurt-flash, honest HITTEST

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Env hooks that stage a scene for a shot (combine with `FOREST_SHOT` **or** `FORE
 | `FOREST_FLAGTEST=1` | park one cloth banner in open air at `(0, 6, -22)` to frame the flutter in isolation (`banner.rs`). NB the cloth streams along world ≈`(0.9, 0, -0.43)` — shoot from a spot perpendicular to that or it reads edge-on |
 | `FOREST_BELLTEST=1` | re-toll the war bell on a ~12s loop (swing + clapper + SFX) so a shot/clip frames the ring without a keypress (`castle::swing_bell`); the bell stands at `castle::BELL_POS` (4.5, 7.5) |
 | `FOREST_ROLLTEST=1` | re-arm the hero's **Alt dodge-roll** (forward, along the facing) on a ~1.8s loop so a `FOREST_TPS` shot/clip frames the somersault without a keypress (`player/movement.rs::player_roll`); skips the pointer-lock/stamina gates |
+| `FOREST_IMMORTAL=1` | the hero takes hits with full juice (floats/flash/shake) but can't drop below 1 HP, so a filmed melee never trips the **succession beat** — which slow-mos the world and swings the camera to the nearest townsperson, hijacking a combat clip's framing (`player/health.rs::apply_hero_damage`) |
 | `BEVY_ASSET_ROOT` | point at this dir if running the binary from elsewhere (WGSL loads from `assets/shaders/`) |
 
 ## Architecture

--- a/src/biped.rs
+++ b/src/biped.rs
@@ -161,6 +161,17 @@ pub struct BipedHandles {
     lion: Option<Handle<Mesh>>,
 }
 
+impl BipedHandles {
+    /// Swap the off-hand (shield-slot) mesh — e.g. an ork torch-bearer carries a lit war-torch in
+    /// the shield hand instead of a buckler. `None` strips the off-hand entirely. The shield
+    /// emblem is dropped either way (it only makes sense riding an actual shield).
+    pub fn with_shield(mut self, shield: Option<Handle<Mesh>>) -> Self {
+        self.shield = shield;
+        self.lion = None;
+        self
+    }
+}
+
 impl BipedMeshes {
     /// Upload every mesh once, returning shareable (cloneable) handles for cached spawning.
     pub fn upload(self, meshes: &mut Assets<Mesh>) -> BipedHandles {
@@ -188,11 +199,12 @@ impl BipedMeshes {
 
 /// Spawn the studio knight skeleton (the same joint hierarchy + frames the hero uses) for a mob,
 /// from pre-uploaded `h` handles. Tags each joint [`BipedPart`] so [`animate_biped`] poses it from
-/// the root's [`BipedDrive`]. **Returns the `Head` joint entity** so callers can attach extras
-/// (e.g. an ork's glowing eyes). Per-mob tuning: `head_scale`/`foot_scale` (studio group scales),
-/// `hip_dx`/`shoulder_dx` (limb spacing), `rig_offset_y` (drop feet onto the ground), and
-/// `shield_xf` (Some → mount the shield + emblem on the left hand). The held `weapon` rides the
-/// `Sword` pivot. Built under a `rig` child of `root` so the caller's root scale sizes the whole mob.
+/// the root's [`BipedDrive`]. **Returns `(Head, Option<Shield>)` joint entities** so callers can
+/// attach extras (an ork's glowing eyes on the head; a torch-bearer's flame + light on the
+/// off-hand). Per-mob tuning: `head_scale`/`foot_scale` (studio group scales), `hip_dx`/
+/// `shoulder_dx` (limb spacing), `rig_offset_y` (drop feet onto the ground), and `shield_xf`
+/// (Some → mount the shield + emblem on the left hand). The held `weapon` rides the `Sword`
+/// pivot. Built under a `rig` child of `root` so the caller's root scale sizes the whole mob.
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_biped(
     commands: &mut Commands,
@@ -205,7 +217,7 @@ pub fn spawn_biped(
     shoulder_dx: f32,
     rig_offset_y: f32,
     shield_xf: Option<Transform>,
-) -> Entity {
+) -> (Entity, Option<Entity>) {
     let p = |t: Vec3| Transform::from_translation(t);
     let ps = |t: Vec3, s: f32| Transform { translation: t, scale: Vec3::splat(s), ..default() };
     // Spawn a tagged joint (transform-only) under `parent`, with an optional mesh-leaf child.
@@ -237,11 +249,13 @@ pub fn spawn_biped(
     let sh_l = joint(commands, torso, Some(ShoulderL), p(Vec3::new(-shoulder_dx, 0.27, 0.01)), Some(h.shoulder_l));
     let el_l = joint(commands, sh_l, Some(ElbowL), p(Vec3::new(0.0, -0.30, 0.0)), Some(h.elbow_l));
     let hand_l = joint(commands, el_l, None, p(Vec3::new(0.0, -0.25, 0.0)), None);
+    let mut shield_out = None;
     if let (Some(sx), Some(shield)) = (shield_xf, h.shield) {
         let shield_e = joint(commands, hand_l, Some(Shield), sx, Some(shield));
         if let Some(lion) = h.lion {
             joint(commands, shield_e, None, p(Vec3::new(0.0, -0.03, 0.033)), Some(lion));
         }
+        shield_out = Some(shield_e);
     }
 
     // Right arm (+ optional weapon on the Sword pivot).
@@ -260,7 +274,7 @@ pub fn spawn_biped(
     let knee_r = joint(commands, hip_r, Some(KneeR), p(Vec3::new(0.0, -0.40, 0.0)), Some(h.knee_r));
     joint(commands, knee_r, Some(FootR), ps(Vec3::new(0.0, -0.45, 0.0), foot_scale), Some(h.foot_r));
 
-    head_e
+    (head_e, shield_out)
 }
 
 pub struct BipedPlugin;

--- a/src/castle.rs
+++ b/src/castle.rs
@@ -1319,6 +1319,19 @@ fn torch_parts() -> Vec<(Mesh, M)> {
     v
 }
 
+/// A gate war-brazier — the torch's big sibling that lights the siege kill-zone OUTSIDE each
+/// gate (see the brazier spawn loop + `firelight::brazier_light`). Heavier post, wide iron bowl,
+/// a fat flame: reads as deliberate war-lighting, not a scaled-up torch.
+fn brazier_parts() -> Vec<(Mesh, M)> {
+    let mut v: Vec<(Mesh, M)> = Vec::new();
+    v.push((bx(0.2, 1.1, 0.2, 0.0, 0.55, 0.0), M::Wood)); // heavy post
+    v.push((bx(0.34, 0.1, 0.34, 0.0, 0.06, 0.0), M::BronzeDark)); // ground foot
+    v.push((bx(0.5, 0.16, 0.5, 0.0, 1.18, 0.0), M::BronzeDark)); // wide bowl
+    v.push((bx(0.42, 0.1, 0.42, 0.0, 1.28, 0.0), M::BronzeDark)); // bowl lip
+    v.push((flat(Mesh::from(Sphere::new(0.26).mesh().ico(1).unwrap()).scaled_by(Vec3::new(1.0, 1.45, 1.0)).translated_by(Vec3::new(0.0, 1.5, 0.0))), M::Flame));
+    v
+}
+
 // ── Rustic yard clutter ──────────────────────────────────────────────────────────
 // Small work-yard props that dress the courtyard corners. Tagged `Always` — they used to be
 // `PreWalls`, which meant buying the Palisade Walls DELETED every sign of life and left bare
@@ -1627,6 +1640,16 @@ pub fn build(
             let local = Quat::from_rotation_y(rot) * Vec3::new(sx, 0.0, 1.0);
             spawn(torch_parts(), Vec3::new(x + local.x, 0.0, z + local.z), 0.0, Vec3::ONE, CastleKind::Gate);
         }
+        // War-braziers flanking the gate APPROACH (outside the walls, clear of the gate lane):
+        // the night siege's melee happens right here, and on the moon-dark ground it filmed as
+        // black-on-black. `out` is the true outward axis (gates are axis-aligned on the
+        // perimeter, so the local +Z trick the torches use points inside on two of them).
+        let out = Vec3::new(x, 0.0, z).normalize();
+        let perp = Vec3::new(-out.z, 0.0, out.x);
+        for s in [-(half + 1.4), half + 1.4] {
+            let p = Vec3::new(x, 0.0, z) + out * 3.2 + perp * s;
+            spawn(brazier_parts(), p, 0.0, Vec3::ONE, CastleKind::Gate);
+        }
     }
     for sx in [-2.3_f32, 2.3] {
         spawn(torch_parts(), Vec3::new(sx, 0.0, 3.4), 0.0, Vec3::ONE, CastleKind::Always);
@@ -1659,6 +1682,19 @@ pub fn build(
                 CastlePart { kind: CastleKind::Gate },
                 BiomeEntity,
                 crate::firelight::torch_light(x * 0.7 + z * 0.31 + k as f32 * 2.1),
+            ));
+        }
+        // The war-braziers' pools (same gate lifecycle; flame local y = 1.5).
+        let out = Vec3::new(x, 0.0, z).normalize();
+        let perp = Vec3::new(-out.z, 0.0, out.x);
+        for (k, s) in [-(half + 1.4), half + 1.4].into_iter().enumerate() {
+            let p = Vec3::new(x, 0.0, z) + out * 3.2 + perp * s;
+            commands.spawn((
+                Transform::from_translation(Vec3::new(p.x, 1.5, p.z)),
+                Visibility::Hidden,
+                CastlePart { kind: CastleKind::Gate },
+                BiomeEntity,
+                crate::firelight::brazier_light(x * 0.43 + z * 0.57 + k as f32 * 3.3),
             ));
         }
     }

--- a/src/castle.rs
+++ b/src/castle.rs
@@ -57,6 +57,7 @@ const WINDOW_GLOW: u32 = 0xffd58c;
 const BRONZE: u32 = 0xb9892f;
 const BRONZE_DARK: u32 = 0x7c5a1e;
 const TORCH_FLAME: u32 = 0xff7a2a;
+const BRAZIER_FLAME: u32 = 0xff5a1e; // deeper orange for the big brazier flame shell (`M::Ember`)
 const SLIT: u32 = 0x23242a; // arrow-slit / shadow inset
 
 const HALF_PI: f32 = std::f32::consts::FRAC_PI_2;
@@ -103,6 +104,10 @@ pub(crate) enum M {
     Gold,
     Window,
     Flame,
+    /// Deep-orange fire shell at a LOW emissive — the brazier flame's outer layer. `M::Flame`'s
+    /// ×6 emissive is right for a torch-speck but a brazier-sized mesh at ×6 clips through AgX
+    /// to a cream-white egg on camera; this slot stays saturated fire-orange at size.
+    Ember,
 }
 
 #[derive(Clone)]
@@ -573,6 +578,7 @@ fn build_mats(images: &mut Assets<Image>, std_mats: &mut Assets<StandardMaterial
     glow(GOLD, 0.8, 0.6, M::Gold);
     glow(WINDOW_GLOW, 2.2, 0.0, M::Window);
     glow(TORCH_FLAME, 6.0, 0.0, M::Flame);
+    glow(BRAZIER_FLAME, 2.4, 0.0, M::Ember);
 
     Mats { h }
 }
@@ -1328,7 +1334,11 @@ fn brazier_parts() -> Vec<(Mesh, M)> {
     v.push((bx(0.34, 0.1, 0.34, 0.0, 0.06, 0.0), M::BronzeDark)); // ground foot
     v.push((bx(0.5, 0.16, 0.5, 0.0, 1.18, 0.0), M::BronzeDark)); // wide bowl
     v.push((bx(0.42, 0.1, 0.42, 0.0, 1.28, 0.0), M::BronzeDark)); // bowl lip
-    v.push((flat(Mesh::from(Sphere::new(0.26).mesh().ico(1).unwrap()).scaled_by(Vec3::new(1.0, 1.45, 1.0)).translated_by(Vec3::new(0.0, 1.5, 0.0))), M::Flame));
+    // Layered flame: a saturated deep-orange shell (`M::Ember`, low emissive — stays FIRE-coloured
+    // on camera) around a small hot `M::Flame` core. One big `M::Flame` sphere clipped to a
+    // cream-white egg on the first AFTER capture.
+    v.push((flat(Mesh::from(Sphere::new(0.24).mesh().ico(1).unwrap()).scaled_by(Vec3::new(1.0, 1.5, 1.0)).translated_by(Vec3::new(0.0, 1.48, 0.0))), M::Ember));
+    v.push((flat(Mesh::from(Sphere::new(0.13).mesh().ico(1).unwrap()).scaled_by(Vec3::new(1.0, 1.6, 1.0)).translated_by(Vec3::new(0.0, 1.42, 0.0))), M::Flame));
     v
 }
 

--- a/src/combat_fx.rs
+++ b/src/combat_fx.rs
@@ -24,10 +24,12 @@ const FLOAT_RISE: f32 = 1.3;
 const FLOAT_FONT: f32 = 24.0;
 /// Drop-shadow alpha at full opacity (fades with the number).
 const FLOAT_SHADOW_A: f32 = 0.85;
-/// Hurt-flash duration on a struck ork (s). SHORT on purpose: the flash is now a *pop* (a bright
-/// hot core at the contact frame that falls off fast), not the old faint plateau — a quick punch
-/// reads as impact without strobing the model on rapid hits.
-const HURT_FLASH_DUR: f32 = 0.11;
+/// Hurt-flash duration on a struck ork (s). Still a front-loaded *pop* (bright hot core at the
+/// contact frame, k² falloff — see `hurt_flash`), not a plateau; but 0.11 s lived on only ~3
+/// frames at 30 fps, so on capture/stream footage the flash read as barely-there (verified on the
+/// baseline combat clip — not one still caught it mid-flash). 0.17 keeps the punch shape while
+/// surviving the frame grid; rapid combo hits still don't strobe (each re-insert restarts the pop).
+const HURT_FLASH_DUR: f32 = 0.17;
 /// Warm tint of the flash (linear RGB weights) — a hot white-amber spark, NOT flat engine-white,
 /// so the pop reads as a struck-flesh impact rather than a placeholder blink. Scaled by the
 /// per-hit `intensity` (light < crit < heavy), so a heavy blow flashes far harder than a poke.
@@ -201,15 +203,20 @@ fn float_test(
 }
 
 /// Tuning/capture hook: `FOREST_HITTEST=1` staged-hits the ork nearest the hero every ~0.6s,
-/// cycling light → crit → heavy, so a clip/still shows the flash pop + absorb squash + recoil lean
-/// across all three weight tiers without landing real swings. Pair with `FOREST_ORKLINE` (parked
-/// orks) + `FOREST_TPS`/`FOREST_CLIP`. No effect in normal play.
+/// cycling light → crit → heavy → kill, so a clip/still shows the FULL landed-blow package —
+/// flash pop, absorb squash, recoil lean, knockback shove, hit-stop, camera trauma + FOV kick —
+/// across the weight tiers without landing real swings. Mirrors the `player_attack` hit site
+/// (same `KNOCKBACK`/`HITSTOP_*`/`SHAKE_*` tiers), so capture footage is honest about the real
+/// game feel. Pair with `FOREST_ORKLINE` (parked orks) + `FOREST_TPS`/`FOREST_CLIP`. No effect in
+/// normal play.
 fn hit_test(
     time: Res<Time>,
     hero: Res<crate::player::HeroState>,
     mut commands: Commands,
     mut orks: Query<(Entity, &GlobalTransform, &mut Ork), Without<crate::dying::Dying>>,
     mut floats: ResMut<FloatQueue>,
+    mut hitstop: ResMut<crate::player::HitStop>,
+    mut feedback: ResMut<HitFeedback>,
     mut t: Local<f32>,
     mut tier: Local<u32>,
 ) {
@@ -231,13 +238,19 @@ fn hit_test(
         }
     }
     let Some((e, p, _)) = best else { return };
+    // Blow direction hero→ork (the shove axis); camera recoils back along it like a real swing.
+    let dir = Vec2::new(p.x - hero.pos.x, p.z - hero.pos.y).normalize_or_zero();
+    let recoil = -dir;
     // Step 3 stages a DIRECTED KILL (topples away from the hero) so a clip shows the death money-shot
     // + proves the corpse stops colliding; steps 0–2 cycle the light/crit/heavy hit reaction.
     if *tier % 4 == 3 {
         *tier += 1;
-        let dir = Vec2::new(p.x - hero.pos.x, p.z - hero.pos.y);
         crate::dying::begin_dying_struck(&mut commands, e, now, dir, true);
         floats.0.push(FloatReq { world: p + Vec3::Y * 2.2, text: "†".into(), color: col_kill(), scale: 1.4 });
+        feedback.shake_dir = recoil;
+        feedback.trauma = (feedback.trauma + crate::player::SHAKE_KILL).min(1.0);
+        add_fov_kick(&mut feedback, FOV_KICK_KILL);
+        hitstop.remaining = hitstop.remaining.max(crate::player::HITSTOP_KILL);
         return;
     }
     let (intensity, amp, label, heavy) = match *tier % 4 {
@@ -246,15 +259,30 @@ fn hit_test(
         _ => (0.95, 0.17, "HEAVY", true),
     };
     *tier += 1;
+    let crit = label == "CRIT";
     if let Ok((_, _, mut o)) = orks.get_mut(e) {
         o.hit_recoil = now;
-        if heavy || label == "CRIT" {
+        // The shove — same push the real hit site applies (crit/heavy shove harder).
+        o.kb = dir * if crit || heavy { crate::player::KNOCKBACK_CRIT } else { crate::player::KNOCKBACK };
+        if heavy || crit {
             o.atk_anim = 0.0; // stagger: cancel any wind-up
         }
     }
     commands.entity(e).try_insert(HurtFlash::new(now, intensity));
     commands.entity(e).try_insert(HitSquash::new(now, amp, false));
     floats.0.push(FloatReq { world: p + Vec3::Y * 2.2, text: label.into(), color: col_ork_hit(), scale: 1.2 });
+    // Camera + clock: the same tiered punch `player_attack` lands.
+    feedback.shake_dir = recoil;
+    let (shake, kick, stop) = if heavy {
+        (crate::player::SHAKE_HEAVY, crate::player::FOV_KICK_HEAVY, crate::player::HITSTOP_HEAVY)
+    } else if crit {
+        (crate::player::SHAKE_CRIT, FOV_KICK_CRIT, crate::player::HITSTOP_CRIT)
+    } else {
+        (crate::player::SHAKE_HIT, FOV_KICK_HIT, crate::player::HITSTOP_HIT)
+    };
+    feedback.trauma = (feedback.trauma + shake).min(1.0);
+    add_fov_kick(&mut feedback, kick);
+    hitstop.remaining = hitstop.remaining.max(stop);
 }
 
 // ── 2. Ork HP bars (billboard follower entities) ────────────────────────────

--- a/src/firelight.rs
+++ b/src/firelight.rs
@@ -67,6 +67,42 @@ pub fn torch_light(phase: f32) -> (PointLight, FireLight) {
     )
 }
 
+/// A war-torch carried by a marching ork (`orks.rs`): the tightest, cheapest pool of the family —
+/// there can be a dozen live at once mid-siege, and its job is to paint the BEARER and his
+/// neighbours so the horde reads as figures at night instead of black cutouts.
+pub fn held_torch_light(phase: f32) -> (PointLight, FireLight) {
+    const BASE: f32 = 9_500.0;
+    (
+        PointLight {
+            color: FIRE_COLOR,
+            intensity: BASE,
+            range: 6.5,
+            radius: 0.08,
+            shadow_maps_enabled: false,
+            ..default()
+        },
+        FireLight { phase, base: BASE, next_ember: 0.0 },
+    )
+}
+
+/// A gate war-brazier (`castle.rs`): a campfire-class pool aimed at the gate APPROACH — the siege
+/// kill-zone — so the night melee happens in warm light instead of the moon-dark mush it read as
+/// on capture footage. Between torch and campfire in size.
+pub fn brazier_light(phase: f32) -> (PointLight, FireLight) {
+    const BASE: f32 = 36_000.0;
+    (
+        PointLight {
+            color: FIRE_COLOR,
+            intensity: BASE,
+            range: 14.0,
+            radius: 0.25,
+            shadow_maps_enabled: false,
+            ..default()
+        },
+        FireLight { phase, base: BASE, next_ember: 0.0 },
+    )
+}
+
 pub struct FireLightPlugin;
 
 impl Plugin for FireLightPlugin {

--- a/src/orks.rs
+++ b/src/orks.rs
@@ -778,6 +778,55 @@ fn ork_shield_xf() -> Transform {
     Transform { translation: Vec3::new(0.0, 0.0, 0.14), rotation: xyz(0.15, -0.45, 0.1), scale: Vec3::ONE }
 }
 
+/// Orientation baked into the torch-bearer's held torch, in the SHIELD-joint frame. The biped
+/// animator rewrites the Shield joint's pose every frame with the shared hero carry
+/// (`anim::shield_rest_r` ≈ `e3(0.12, -1.5, 0)`) — tuned edge-on for a heater shield — so, like
+/// the ork buckler's baked `rotation_y(1.15)`, any "how the prop sits in the fist" correction
+/// must live in the MESH, not the mount transform. Tuned against `FOREST_VIEW=ork:torch`.
+pub(crate) fn ork_torch_bake() -> Quat {
+    // `FOREST_TORCH_BAKE="x,y,z"` (radians, XYZ euler) overrides for FOREST_VIEW tuning loops —
+    // iterate camera shots without a rebuild, then freeze the winner into the default below.
+    if let Ok(s) = std::env::var("FOREST_TORCH_BAKE") {
+        let p: Vec<f32> = s.split(',').filter_map(|t| t.trim().parse().ok()).collect();
+        if p.len() == 3 {
+            return xyz(p[0], p[1], p[2]);
+        }
+    }
+    // Tuned against `FOREST_VIEW=ork:torch` (see the doc above): identity leaves the shaft
+    // hugging the upper arm with the tip buried at the shoulder; +X pitches it forward out of
+    // the fist, the small +Z rolls the flame outboard clear of the cheek/shoulder fur.
+    xyz(0.65, 0.0, 0.12)
+}
+
+/// Shaft length from grip to the pitch head's heart — where the flame + light sit
+/// (shield-joint-local, through the same bake so mesh and flame can't drift apart).
+const TORCH_TIP_LEN: f32 = 0.62;
+pub(crate) fn ork_torch_tip() -> Vec3 {
+    ork_torch_bake() * Vec3::new(0.0, TORCH_TIP_LEN, 0.0)
+}
+
+/// The held war-torch (shield-slot prop, grip at the joint origin, shaft up local +Y before the
+/// bake): wrapped grip, wooden shaft, pitch-soaked head. The emissive flame is NOT part of this
+/// mesh — it spawns as a separate `StandardMaterial` child at [`ork_torch_tip`] (this mesh rides
+/// the shared vertex-colour skin material and flashes with the body on a hit).
+pub(crate) fn ork_torch_mesh() -> Mesh {
+    group(vec![
+        cyl(0.045, 0.18, v(0.0, 0.02, 0.0), Quat::IDENTITY, lin(0x2e1f12)), // leather-wrapped grip
+        cyl(0.032, 0.52, v(0.0, 0.32, 0.0), Quat::IDENTITY, lin(0x4a2a16)), // shaft
+        frustum(0.072, 0.045, 0.16, v(0.0, 0.60, 0.0), Quat::IDENTITY, lin(0x241408)), // pitch head
+    ])
+    .rotated_by(ork_torch_bake())
+}
+
+/// Viewer-only flame stand-in (bright vertex-coloured blob — the real flame is an emissive
+/// `StandardMaterial` the FOREST_VIEW stage doesn't carry). Marks [`ork_torch_tip`] placement.
+pub(crate) fn tinted_flame_marker() -> Mesh {
+    tinted(
+        Mesh::from(Sphere::new(0.105).mesh().ico(1).unwrap()).scaled_by(Vec3::new(1.0, 1.55, 1.0)),
+        [4.0, 2.2, 0.4, 1.0],
+    )
+}
+
 /// Drive each (biped) ork's [`crate::biped::BipedDrive`] from its `Ork` AI, so `animate_biped` plays
 /// the studio clips. Mirrors the old `ork_limbs` gait/strike timing (gait `(t+phase)*gait`, the
 /// `strike_p` window → an overhead chop). Camp/patrol/wave orks use this; fortress decorative orks
@@ -1425,13 +1474,7 @@ impl Armory {
             unlit: true,
             ..default()
         });
-        // War-torch (authored torch-local, +Y up the shaft; the flame/light are children of the
-        // shaft entity so they inherit its shoulder tilt). See `spawn_inner`'s torch-bearer block.
-        let torch_mesh = meshes.add(group(vec![
-            cyl(0.035, 0.95, v(0.0, 0.475, 0.0), Quat::IDENTITY, lin(0x4a2a16)), // shaft
-            cyl(0.052, 0.09, v(0.0, 0.20, 0.0), Quat::IDENTITY, lin(0x2e1f12)), // leather lashing
-            frustum(0.078, 0.048, 0.17, v(0.0, 0.99, 0.0), Quat::IDENTITY, lin(0x241408)), // pitch-soaked head
-        ]));
+        let torch_mesh = meshes.add(ork_torch_mesh());
         let flame_mesh =
             meshes.add(Mesh::from(Sphere::new(0.105).mesh().ico(1).unwrap()).scaled_by(Vec3::new(1.0, 1.55, 1.0)));
         // Matches the fire family (`firelight` embers / castle flames): warm base, strong emissive.
@@ -1557,8 +1600,22 @@ impl Armory {
                 BiomeEntity,
             ))
             .id();
-        let head = crate::biped::spawn_biped(
-            commands, root, &self.mat, t.biped.clone(),
+        // Torch-bearers: ~a third of the melee line (grunts/berserkers — scouts sneak, shamans
+        // already glow) trades the buckler for a lit war-torch HELD in the shield hand (same
+        // joint, so the carry pose + gait animate it naturally). This is the night siege's
+        // READABILITY fix: capture footage showed the horde as black cutouts against the
+        // moon-dark ground, so the bearers carry their own warm light into the fight (and read as
+        // a river of fire on the horizon from the walls). Seed-hashed, NOT `rng`-drawn, so the
+        // existing spawn rng sequence (phase/facing/timer/heal_cd) is untouched.
+        let torch_bearer = matches!(variant, OrkVariant::Grunt | OrkVariant::Berserker)
+            && (seed.wrapping_mul(2654435761) >> 7) % 100 < 35;
+        let handles = if torch_bearer {
+            t.biped.clone().with_shield(Some(self.torch_mesh.clone()))
+        } else {
+            t.biped.clone()
+        };
+        let (head, off_hand) = crate::biped::spawn_biped(
+            commands, root, &self.mat, handles,
             1.22, 1.0, 0.17, 0.38, ORK_RIG_OFF, Some(ork_shield_xf()),
         );
         // Two glowing eyes on the head joint (head-local) — the menacing night-glow.
@@ -1567,41 +1624,20 @@ impl Armory {
                 p.spawn((Mesh3d(self.eye_mesh.clone()), MeshMaterial3d(self.eye_mat.clone()), Transform::from_translation(off), OrkEye));
             }
         });
-        // Torch-bearers: ~a third of the melee line (grunts/berserkers — scouts sneak, shamans
-        // already glow) marches with a lit war-torch strapped over the shoulder. This is the night
-        // siege's READABILITY fix: capture footage showed the horde as black cutouts against the
-        // moon-dark ground, so the bearers carry their own warm light into the fight (and read as
-        // a river of fire on the horizon from the walls). Seed-hashed, NOT `rng`-drawn, so the
-        // existing spawn rng sequence (phase/facing/timer/heal_cd) is untouched.
-        let torch_bearer = matches!(variant, OrkVariant::Grunt | OrkVariant::Berserker)
-            && (seed.wrapping_mul(2654435761) >> 7) % 100 < 35;
-        if torch_bearer {
-            commands.entity(root).with_children(|p| {
-                // Root-local shoulder mount, raked back so the flame rides high behind the head.
-                // Root scale ≈ 1 (BASE_SCALE × variant × BIPED_SIZE_FIX), so these are ~world units.
+        if let (true, Some(hand)) = (torch_bearer, off_hand) {
+            // Flame + flicker-light at the torch head (shield-joint-local via `ork_torch_tip`, so
+            // it tracks the held shaft through the carry/gait poses). The light rides
+            // `firelight`'s shared flicker/ember systems, so a marching bearer trails sparks at
+            // night for free. Emissive `StandardMaterial` — the hurt-flash skin-clone only
+            // touches `CreatureMaterial` children, so no `OrkEye` guard is needed.
+            commands.entity(hand).with_children(|p| {
                 p.spawn((
-                    Mesh3d(self.torch_mesh.clone()),
-                    MeshMaterial3d(self.mat.clone()),
-                    Transform {
-                        translation: Vec3::new(-0.16, 0.72, -0.22),
-                        rotation: xyz(-0.38, 0.0, -0.12),
-                        scale: Vec3::ONE,
-                    },
-                ))
-                .with_children(|t| {
-                    // Flame + flicker-light at the shaft tip (shaft-local, inherits the rake).
-                    // The light rides `firelight`'s shared flicker/ember systems, so a marching
-                    // bearer trails sparks at night for free. Emissive `StandardMaterial` — the
-                    // hurt-flash skin-clone only touches `CreatureMaterial` children, so no
-                    // `OrkEye` guard is needed here.
-                    t.spawn((
-                        Mesh3d(self.flame_mesh.clone()),
-                        MeshMaterial3d(self.flame_mat.clone()),
-                        Transform::from_translation(Vec3::new(0.0, 1.12, 0.0)),
-                        bevy::light::NotShadowCaster,
-                        crate::firelight::held_torch_light(phase * 3.7),
-                    ));
-                });
+                    Mesh3d(self.flame_mesh.clone()),
+                    MeshMaterial3d(self.flame_mat.clone()),
+                    Transform::from_translation(ork_torch_tip()),
+                    bevy::light::NotShadowCaster,
+                    crate::firelight::held_torch_light(phase * 3.7),
+                ));
             });
         }
         root
@@ -1621,7 +1657,7 @@ impl Armory {
                 BiomeEntity,
             ))
             .id();
-        let head = crate::biped::spawn_biped(commands, root, &self.mat, t.biped.clone(), 1.22, 1.0, 0.17, 0.38, ORK_RIG_OFF, Some(ork_shield_xf()));
+        let head = crate::biped::spawn_biped(commands, root, &self.mat, t.biped.clone(), 1.22, 1.0, 0.17, 0.38, ORK_RIG_OFF, Some(ork_shield_xf())).0;
         commands.entity(head).with_children(|p| {
             for off in ORK_BIPED_EYE_OFFS {
                 p.spawn((Mesh3d(self.eye_mesh.clone()), MeshMaterial3d(self.eye_mat.clone()), Transform::from_translation(off), OrkEye));

--- a/src/orks.rs
+++ b/src/orks.rs
@@ -1386,6 +1386,12 @@ pub struct Armory {
     tmpl: Vec<((OrkVariant, Faction), Template)>,
     eye_mesh: Handle<Mesh>,
     eye_mat: Handle<StandardMaterial>, // glowing eyes stay a plain emissive StandardMaterial
+    /// War-torch strapped over a bearer's shoulder (shaft + lashing + pitch head; vertex-coloured
+    /// so it rides the shared skin material and flashes with the body on a hit).
+    torch_mesh: Handle<Mesh>,
+    /// Teardrop torch flame — emissive `StandardMaterial` like the eyes, so bloom catches it.
+    flame_mesh: Handle<Mesh>,
+    flame_mat: Handle<StandardMaterial>,
 }
 
 impl Armory {
@@ -1419,7 +1425,23 @@ impl Armory {
             unlit: true,
             ..default()
         });
-        Armory { mat, tmpl, eye_mesh, eye_mat }
+        // War-torch (authored torch-local, +Y up the shaft; the flame/light are children of the
+        // shaft entity so they inherit its shoulder tilt). See `spawn_inner`'s torch-bearer block.
+        let torch_mesh = meshes.add(group(vec![
+            cyl(0.035, 0.95, v(0.0, 0.475, 0.0), Quat::IDENTITY, lin(0x4a2a16)), // shaft
+            cyl(0.052, 0.09, v(0.0, 0.20, 0.0), Quat::IDENTITY, lin(0x2e1f12)), // leather lashing
+            frustum(0.078, 0.048, 0.17, v(0.0, 0.99, 0.0), Quat::IDENTITY, lin(0x241408)), // pitch-soaked head
+        ]));
+        let flame_mesh =
+            meshes.add(Mesh::from(Sphere::new(0.105).mesh().ico(1).unwrap()).scaled_by(Vec3::new(1.0, 1.55, 1.0)));
+        // Matches the fire family (`firelight` embers / castle flames): warm base, strong emissive.
+        let flame_mat = materials.add(StandardMaterial {
+            base_color: Color::srgb(1.0, 0.55, 0.22),
+            emissive: LinearRgba::rgb(5.0, 1.9, 0.35),
+            unlit: true,
+            ..default()
+        });
+        Armory { mat, tmpl, eye_mesh, eye_mat, torch_mesh, flame_mesh, flame_mat }
     }
 
     fn template(&self, variant: OrkVariant, faction: Faction) -> &Template {
@@ -1545,6 +1567,43 @@ impl Armory {
                 p.spawn((Mesh3d(self.eye_mesh.clone()), MeshMaterial3d(self.eye_mat.clone()), Transform::from_translation(off), OrkEye));
             }
         });
+        // Torch-bearers: ~a third of the melee line (grunts/berserkers — scouts sneak, shamans
+        // already glow) marches with a lit war-torch strapped over the shoulder. This is the night
+        // siege's READABILITY fix: capture footage showed the horde as black cutouts against the
+        // moon-dark ground, so the bearers carry their own warm light into the fight (and read as
+        // a river of fire on the horizon from the walls). Seed-hashed, NOT `rng`-drawn, so the
+        // existing spawn rng sequence (phase/facing/timer/heal_cd) is untouched.
+        let torch_bearer = matches!(variant, OrkVariant::Grunt | OrkVariant::Berserker)
+            && (seed.wrapping_mul(2654435761) >> 7) % 100 < 35;
+        if torch_bearer {
+            commands.entity(root).with_children(|p| {
+                // Root-local shoulder mount, raked back so the flame rides high behind the head.
+                // Root scale ≈ 1 (BASE_SCALE × variant × BIPED_SIZE_FIX), so these are ~world units.
+                p.spawn((
+                    Mesh3d(self.torch_mesh.clone()),
+                    MeshMaterial3d(self.mat.clone()),
+                    Transform {
+                        translation: Vec3::new(-0.16, 0.72, -0.22),
+                        rotation: xyz(-0.38, 0.0, -0.12),
+                        scale: Vec3::ONE,
+                    },
+                ))
+                .with_children(|t| {
+                    // Flame + flicker-light at the shaft tip (shaft-local, inherits the rake).
+                    // The light rides `firelight`'s shared flicker/ember systems, so a marching
+                    // bearer trails sparks at night for free. Emissive `StandardMaterial` — the
+                    // hurt-flash skin-clone only touches `CreatureMaterial` children, so no
+                    // `OrkEye` guard is needed here.
+                    t.spawn((
+                        Mesh3d(self.flame_mesh.clone()),
+                        MeshMaterial3d(self.flame_mat.clone()),
+                        Transform::from_translation(Vec3::new(0.0, 1.12, 0.0)),
+                        bevy::light::NotShadowCaster,
+                        crate::firelight::held_torch_light(phase * 3.7),
+                    ));
+                });
+            });
+        }
         root
     }
 

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -178,17 +178,19 @@ pub struct HitStop {
 // distinct (they were all one weight before). Kill > crit > light, in both freeze length and
 // camera trauma. The light hit is lighter than the old single value; the kill a touch shorter so
 // the new crit tier sits cleanly between them.
-const HITSTOP_KILL: f32 = 0.10;
-const HITSTOP_CRIT: f32 = 0.07;
-const HITSTOP_HIT: f32 = 0.04;
+// The tiers are `pub(crate)` (re-exported via `player`) so `combat_fx::hit_test` can mirror the
+// real hit-site juice exactly — FOREST_HITTEST capture footage must not under-sell the game feel.
+pub(crate) const HITSTOP_KILL: f32 = 0.10;
+pub(crate) const HITSTOP_CRIT: f32 = 0.07;
+pub(crate) const HITSTOP_HIT: f32 = 0.04;
 /// During hit-stop the sim runs at this fraction of real time rather than a dead freeze — a brief
 /// slow-mo dip that still sells the "punch" without the full-stop stutter that read as micro-lag.
 const HITSTOP_SLOWMO: f32 = 0.15;
-const SHAKE_KILL: f32 = 0.46;
-const SHAKE_CRIT: f32 = 0.32;
-const SHAKE_HIT: f32 = 0.20;
-const KNOCKBACK: f32 = 6.0;
-const KNOCKBACK_CRIT: f32 = 9.0;
+pub(crate) const SHAKE_KILL: f32 = 0.46;
+pub(crate) const SHAKE_CRIT: f32 = 0.32;
+pub(crate) const SHAKE_HIT: f32 = 0.20;
+pub(crate) const KNOCKBACK: f32 = 6.0;
+pub(crate) const KNOCKBACK_CRIT: f32 = 9.0;
 /// A crit/heavy blow STAGGERS the ork: its attack is interrupted and its next strike pushed out by
 /// this long (s). Reuses the existing `atk_cd` gate (honoured by both the camp and siege brains) so
 /// a hard hit visibly stops the ork's offense — the "you felt that" beat — with no new AI state.
@@ -222,9 +224,9 @@ const HEAVY_MULT: f64 = 3.0;
 /// "can I afford it" grey-out.
 pub(crate) const HEAVY_STAMINA_COST: f32 = 30.0;
 /// Heavy juice tier — a notch ABOVE a kill (`HITSTOP_KILL`/`SHAKE_KILL`) so the payoff lands hard.
-const HITSTOP_HEAVY: f32 = 0.14;
-const SHAKE_HEAVY: f32 = 0.6;
-const FOV_KICK_HEAVY: f32 = 2.4;
+pub(crate) const HITSTOP_HEAVY: f32 = 0.14;
+pub(crate) const SHAKE_HEAVY: f32 = 0.6;
+pub(crate) const FOV_KICK_HEAVY: f32 = 2.4;
 
 pub fn drive_hit_stop(
     real: Res<Time<bevy::time::Real>>,

--- a/src/player/health.rs
+++ b/src/player/health.rs
@@ -155,6 +155,14 @@ pub fn apply_hero_damage(
         // Layer the resist-buff (taken) + worn-armor (armor) mults onto the unblocked blow
         // — matches the TS `damage(amount, takenMult, armorMult)`.
         p.damage(dmg as f64, now, buffs.0.damage_taken_mult(now), inv.0.armor_damage_mult());
+        // `FOREST_IMMORTAL=1` (capture staging): the hero takes every blow — full float/flash/
+        // shake juice — but can't drop below 1 HP, so a filmed melee never trips the succession
+        // beat mid-clip (which slow-mos the world and swings the camera away to the nearest
+        // townsperson — it hijacked a combat capture's framing). No effect in normal play.
+        if p.hp <= 0.0 && std::env::var("FOREST_IMMORTAL").is_ok() {
+            p.hp = 1.0;
+            p.dead_since = None;
+        }
         let dead = p.hp <= 0.0;
 
         // Combat juice: a floating number ("PARRY!" / "BLOCK" / "-N") + red flash + screen shake.

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -16,7 +16,9 @@ mod combat;
 
 pub(crate) use combat::{
     spawn_burst, spawn_chips, spawn_dash_trail, spawn_heal_burst, spawn_motes, spawn_shockwave,
-    spawn_sweep_burst, CombatFx, Health,
+    spawn_sweep_burst, CombatFx, Health, HitStop, FOV_KICK_HEAVY, HITSTOP_CRIT, HITSTOP_HEAVY,
+    HITSTOP_HIT, HITSTOP_KILL, KNOCKBACK, KNOCKBACK_CRIT, SHAKE_CRIT, SHAKE_HEAVY, SHAKE_HIT,
+    SHAKE_KILL,
 };
 /// Swing length (seconds) — exposed so the standalone viewer can loop a preview swing.
 pub use combat::ATTACK_DURATION;

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -312,7 +312,10 @@ fn spawn_model(
     match view.as_str() {
         // The ork on the shared studio biped skeleton (Phase 2 re-rig verification). Rest pose
         // unless `FOREST_VIEW_ANIM` is wired for bipeds; geometry/proportions read true here.
-        // `FOREST_VIEW=ork:scout|berserker|shaman` picks the variant (default grunt).
+        // `FOREST_VIEW=ork:scout|berserker|shaman` picks the variant (default grunt);
+        // `ork:torch` swaps the buckler for the torch-bearer's held war-torch (grip/rake
+        // verification — tune `orks::ork_torch_bake` against this view). The flame marker ball
+        // sits at `ork_torch_tip` so the in-game flame/light placement reads here too.
         s if s.starts_with("ork") || s.starts_with("orc") => {
             use crate::orks::OrkVariant::*;
             let variant = match s.rsplit(':').next() {
@@ -326,9 +329,26 @@ fn spawn_model(
                 rotation: Quat::from_euler(EulerRot::XYZ, 0.15, -0.45, 0.1),
                 scale: Vec3::ONE,
             };
-            let h = crate::orks::ork_biped_meshes(variant, crate::orks::Faction::Red).upload(meshes);
+            let mut h = crate::orks::ork_biped_meshes(variant, crate::orks::Faction::Red).upload(meshes);
+            let torch = s.contains("torch");
+            if torch {
+                h = h.with_shield(Some(meshes.add(crate::orks::ork_torch_mesh())));
+            }
             commands.entity(root).insert(crate::biped::BipedDrive::default());
-            crate::biped::spawn_biped(commands, root, mat, h, 1.22, 1.0, 0.17, 0.38, -0.05, Some(shield_xf));
+            let (_, off_hand) =
+                crate::biped::spawn_biped(commands, root, mat, h, 1.22, 1.0, 0.17, 0.38, -0.05, Some(shield_xf));
+            if let (true, Some(hand)) = (torch, off_hand) {
+                // Bright vertex-coloured stand-in for the emissive flame (the viewer only carries
+                // the shared CreatureMaterial) — placement, not look.
+                let flame = crate::orks::tinted_flame_marker();
+                commands.entity(hand).with_children(|p| {
+                    p.spawn((
+                        Mesh3d(meshes.add(flame)),
+                        MeshMaterial3d(mat.clone()),
+                        Transform::from_translation(crate::orks::ork_torch_tip()),
+                    ));
+                });
+            }
         }
         // The peasant worker types on the shared skeleton (Phase 3). `FOREST_VIEW=peasant:farmer|
         // miner|unemployed|guard` picks the type (default woodcutter).


### PR DESCRIPTION
Baseline capture footage showed the night siege as black-on-black mush:
orks are dark meshes under a ~3800 lux moon, and the gate melee sat in
shadow, so no amount of hit-FX read on film. Fix the IMAGE, not the FX:

- orks.rs: ~35% of grunts/berserkers march with a lit war-torch strapped
  over the shoulder (seed-hashed so the spawn rng sequence is untouched);
  flame + firelight flicker/ember light paints the bearers and neighbours.
- castle.rs + firelight.rs: two war-braziers flank each gate APPROACH
  (true outward axis - the torch-loop local +Z points inside on two
  gates), lighting the siege kill-zone; brazier_light/held_torch_light
  join the pooled flicker family.
- combat_fx.rs: hurt-flash 0.11s -> 0.17s; at 30fps the old pop lived on
  ~3 frames and never survived the frame grid on captures.
- combat_fx.rs hit_test + player/combat.rs: FOREST_HITTEST now mirrors
  the real hit site's full package (knockback, tiered hit-stop, trauma,
  FOV kick) via the now-pub(crate) juice tier consts, so harness footage
  stops under-selling the real game feel.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HVaqGN1yTYDy7iAPJAemH5