### PR TITLE
Cage rescue overhaul: real peasant captives, natural cage, animated door, freed-NPC comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Env hooks that stage a scene for a shot (combine with `FOREST_SHOT` **or** `FORE
 | `FOREST_WAVE` / `FOREST_DEFEND=1` | stage a night siege / arm all defenses + walls |
 | `FOREST_MUSTER=1` | rally the whole town into the **war party** at boot (as if pressing `K`) so a shot frames the muster; pair with `FOREST_DEMO=work` (stages a 14-pop town) for a full host (`villagers.rs::stage_muster`) |
 | `FOREST_ORKLINE="x,z"` | park one ork of each variant in an idle line at a world XZ (model close-ups) |
+| `FOREST_CAGETEST="x,z"` | park the prisoner-cage rescue's before/after states side by side at a world XZ: a CLOSED cage of real seated peasant captives + an OPENED emptied one 5.5u further +X (`camps::spawn_cage`); both doors face +X, so frame from the east. Film the actual door-swing + walk-out with `FOREST_DEMO=rescue` + `FOREST_CLIP` instead |
 | `FOREST_BREACH=1` | auto-break the Hold gate on the first sim frame so a shot/clip films the woken garrison + the Warlord boss without a keypress (`ork_fortress::stage_breach`); pair with `FOREST_HERO`/`FOREST_CAM` inside the walls |
 | `FOREST_RIVAL=<n>` | instantly raise `n` buildings in the **rival stronghold** (the desert AI opponent, `rival.rs`) so a shot frames a grown rival town instead of waiting out its economy (default: fill the bailey); the rival keep/walls/garrison spawn regardless. Frame it at world ≈`(54, -72)` (NE desert) |
 | `FOREST_TREELINE="x,z"` | park one of each `TreeKind` (broadleaf/birch/pine/poplar/autumn/dead/stump) in a 2× row at a world XZ (tree-model close-ups, `trees.rs`) |

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -121,8 +121,10 @@ pub enum AudioCue {
     Gold,
     /// Shop purchase confirmed.
     ShopBuy,
-    /// Camp captive freed.
-    CampRescue,
+    /// Camp/Blight captive freed — carries the cage's world position so the freed peasant's
+    /// voiced `Rescued` reaction (`npc.rs`) speaks from the cage, not from some random
+    /// townsperson across the map.
+    CampRescue(Vec3),
     /// Hero HP crossed the low threshold.
     LowHp,
     /// The ork fortress sounds its war-horn (sampled `war-horn.ogg` — a sharp wood crack,

--- a/src/audio/npc.rs
+++ b/src/audio/npc.rs
@@ -151,6 +151,10 @@ pub(crate) fn detect_villager_events(
     use crate::siege::GamePhase;
     let now = time.elapsed_secs();
     let mut concept: Option<Concept> = None;
+    // A rescue line speaks from the CAGE (the freed captive's own mouth), not from whichever
+    // townsperson happens to stand near the hero — camps are deep in the wilderness, where the
+    // old nearest-villager rule usually found nobody and the line was silently dropped.
+    let mut rescue_at: Option<Vec3> = None;
 
     if let Some(siege) = &siege {
         let phase = siege.phase;
@@ -166,8 +170,9 @@ pub(crate) fn detect_villager_events(
 
     // Always drain the cue stream; a rescue (rare) trumps a phase line if both land this frame.
     for c in cues.read() {
-        if matches!(c, super::AudioCue::CampRescue) {
+        if let super::AudioCue::CampRescue(at) = c {
             concept = Some(Concept::Rescued);
+            rescue_at = Some(*at);
         }
     }
 
@@ -175,6 +180,10 @@ pub(crate) fn detect_villager_events(
     // One-mouth courtesy: don't speak over the hero. On a rescue, the hero fires his own
     // `FirstRescue` reaction the same frame — he claims it, the villager reacts on later ones.
     if mgr.hero_speaking(now) {
+        return;
+    }
+    if let Some(at) = rescue_at {
+        speak.write(Speak::at(c, at)); // the freed captive thanks you from the cage
         return;
     }
     let Ok(hero) = hero.single() else { return };

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -349,14 +349,14 @@ pub(crate) fn play_cues(
             | AudioCue::ChestOpen
             | AudioCue::Gold
             | AudioCue::ShopBuy
-            | AudioCue::CampRescue
+            | AudioCue::CampRescue(_)
             | AudioCue::LowHp => {
                 let sting = match *cue {
                     AudioCue::OreShatter => Sting::OreShatter,
                     AudioCue::ChestOpen => Sting::ChestOpen,
                     AudioCue::Gold => Sting::Gold,
                     AudioCue::ShopBuy => Sting::ShopBuy,
-                    AudioCue::CampRescue => Sting::CampRescue,
+                    AudioCue::CampRescue(_) => Sting::CampRescue,
                     _ => Sting::LowHp,
                 };
                 if let Some(h) = stings.handle(sting) {

--- a/src/camps.rs
+++ b/src/camps.rs
@@ -32,12 +32,106 @@ pub struct CampsPlugin;
 
 impl Plugin for CampsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (flicker_flames, drift_smoke));
+        // swing_cage_doors + reconcile_cages_on_load are UNGATED: the door swing is cosmetic
+        // (a mid-swing door finishing under a pause is harmless), and the load reconcile must
+        // fire on the GameLoaded message whenever it lands.
+        app.add_systems(Update, (flicker_flames, drift_smoke, swing_cage_doors, reconcile_cages_on_load));
         app.add_systems(
             Update,
             respawn_warbands.run_if(in_state(crate::game_state::Modal::None)),
         );
     }
+}
+
+/// Ease every cage door toward its `open` target — the rescue "animation": a quick fling that
+/// settles (cubic ease-out). The door is a child of the cage frame, so this writes rotation
+/// only; the frame (and its blocker) never change.
+fn swing_cage_doors(time: Res<Time>, mut q: Query<(&mut Transform, &mut CageDoor)>) {
+    let dt = time.delta_secs();
+    for (mut tf, mut d) in &mut q {
+        let step = dt / CAGE_DOOR_SWING;
+        d.t = (d.t + if d.open { step } else { -step }).clamp(0.0, 1.0);
+        let s = 1.0 - (1.0 - d.t).powi(3);
+        tf.rotation = Quat::from_rotation_y(CAGE_DOOR_OPEN_YAW * s);
+    }
+}
+
+/// Post-load reconcile: a restored run's cages must match its `rescued_camps` /
+/// `blight_captives_freed` flags, whatever state the live world is in (a fresh world rebuild
+/// spawns every cage closed + stocked; an in-process Continue may have them open from the dead
+/// run). Snap each door to its saved state and despawn the captives of already-freed cages.
+fn reconcile_cages_on_load(
+    mut ev: MessageReader<crate::savegame::GameLoaded>,
+    mut doors: Query<&mut CageDoor>,
+    captives: Query<(Entity, &crate::villagers::Captive)>,
+    mut commands: Commands,
+) {
+    let Some(crate::savegame::GameLoaded(data)) = ev.read().last() else { return };
+    let freed = |key: CageKey| match key {
+        CageKey::Camp(i) => data.rescued_camps.get(i).copied().unwrap_or(false),
+        CageKey::Blight(i) => data.blight_captives_freed.get(i).copied().unwrap_or(false),
+        CageKey::Decor => false,
+    };
+    for mut d in &mut doors {
+        d.open = freed(d.key);
+        d.t = if d.open { 1.0 } else { 0.0 }; // snap — no ghost swing on load
+    }
+    for (e, c) in &captives {
+        if freed(c.key) {
+            commands.entity(e).try_despawn(); // rescued long ago — walked home already
+        }
+    }
+}
+
+/// Spawn one prisoner cage: the natural-timber frame (`ork_fortress::cage_mesh`), the separate
+/// hinged door child, and `captives` REAL seated peasants inside
+/// (`villagers::spawn_cage_captive`, one per `ork_fortress::CAGE_SEATS` straw bed). A rescue
+/// opens the door by ANIMATION and walks the peasants out — nothing about the cage is swapped
+/// or despawned. Callers register their own collision blocker (footprints differ per site).
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_cage(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    creature_mats: &mut Assets<crate::creature::CreatureMaterial>,
+    prop_mat: &Handle<StandardMaterial>,
+    tf: Transform,
+    key: CageKey,
+    captives: usize,
+    seed: u32,
+    open: bool,
+) -> Entity {
+    use crate::ork_fortress::{cage_door_mesh, cage_mesh, CAGE_SEATS, CAGE_W};
+    let mut rng = seed | 1;
+    let root = commands
+        .spawn((
+            Mesh3d(meshes.add(cage_mesh(&mut rng))),
+            MeshMaterial3d(prop_mat.clone()),
+            tf,
+            Cage { key },
+            BiomeEntity,
+        ))
+        .id();
+    // The door hangs just proud of the (+X, +Z) corner post. No BiomeEntity of its own — it
+    // despawns with the frame (child cascade), and a second tag would double-despawn.
+    let door = commands
+        .spawn((
+            Mesh3d(meshes.add(cage_door_mesh(&mut rng))),
+            MeshMaterial3d(prop_mat.clone()),
+            Transform::from_translation(v(CAGE_W / 2.0 + 0.07, 0.0, CAGE_W / 2.0)),
+            // `open` pre-opens the door (the `FOREST_CAGETEST` after-state cage) — it eases
+            // from shut on the first frames, which is invisible during boot.
+            CageDoor { key, open, t: 0.0 },
+        ))
+        .id();
+    commands.entity(root).add_child(door);
+    // The captives: real peasants seated on the straw beds (roots of their own — they stand up
+    // and WALK OUT on rescue, so they can't be children of the frame).
+    for (sx, sz, syaw) in CAGE_SEATS.iter().take(captives) {
+        let seat = tf.transform_point(v(*sx, 0.148, *sz)); // on the plank floor
+        let facing = tf.rotation * ry(*syaw);
+        crate::villagers::spawn_cage_captive(commands, meshes, creature_mats, seat, facing, key, next_u32(&mut rng));
+    }
+    root
 }
 
 /// Campfire flame marker — also the anchor the audio module hangs a spatial campfire loop
@@ -54,16 +148,42 @@ struct CampSmoke {
     speed: f32,
 }
 
-/// Tags JUST the prisoner-cage prop of a camp so the rescue system can despawn it (open the
-/// cage) when the warband is cleared. `camp` = the enumerate index of `plan()` — the same index
-/// [`cage_positions`] and `villagers::camp_rescue` use.
-#[derive(Component)]
-pub struct Cage {
-    pub camp: usize,
+/// Which prisoner cage an entity belongs to — shared by the cage frame ([`Cage`]), its hinged
+/// door ([`CageDoor`]) and the seated peasants inside (`villagers::Captive`), so a rescue can
+/// address all three parts of one cage.
+#[derive(Component, Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CageKey {
+    /// A wilderness camp's cage — the enumerate index of [`plan`] (the same index
+    /// [`cage_positions`] and `villagers::camp_rescue` use).
+    Camp(usize),
+    /// A Blight cage outside Gnashfang Hold — the `ork_fortress::BLIGHT_CAGES` slot.
+    Blight(usize),
+    /// Decorative only (the Hold's own hoard-cage, the `FOREST_CAGETEST` stage) — never freed.
+    Decor,
 }
 
-/// Index of the cage within the per-camp `solids` vec in [`build`].
-const CAGE_SOLID: usize = 3;
+/// Tags the prisoner-cage FRAME. The frame persists through a rescue — opening is the hinged
+/// [`CageDoor`] child swinging (an animation), never a model swap.
+#[derive(Component)]
+pub struct Cage {
+    pub key: CageKey,
+}
+
+/// The cage's hinged door (a child of the frame, hung at the (+X, +Z) corner post). A rescue
+/// sets `open`; [`swing_cage_doors`] eases the yaw so the door visibly swings out.
+#[derive(Component)]
+pub struct CageDoor {
+    pub key: CageKey,
+    /// Target state — set true by the rescue systems (or snapped by the save-load reconcile).
+    pub open: bool,
+    /// Swing progress 0 (shut) → 1 (fully open). Snap to 1.0 to open instantly (load reconcile).
+    pub t: f32,
+}
+
+/// How far the door swings (rad about the hinge post; negative = outward past perpendicular).
+const CAGE_DOOR_OPEN_YAW: f32 = -2.05;
+/// Full swing duration (s).
+const CAGE_DOOR_SWING: f32 = 1.4;
 
 /// Seconds after a camp's warband is wiped before it repopulates. 3× the old 60s (TS
 /// `OrkCamp.tsx` used 60) so clearing a camp buys real breathing room instead of an endless
@@ -305,6 +425,32 @@ pub fn build(
         }
     }
 
+    // Screenshot hook: `FOREST_CAGETEST="x,z"` parks the rescue's before/after states side by
+    // side at the given world XZ: a CLOSED cage full of seated peasant captives, and 5.5u
+    // further +X an OPEN, emptied one — so one still verifies the captive models, the natural
+    // frame and the swung door. (The swing ANIMATION itself films best via the real rescue:
+    // `FOREST_DEMO=rescue` + `FOREST_CLIP`.) Both doors face +X; frame from the east.
+    if let Ok(s) = std::env::var("FOREST_CAGETEST") {
+        let p: Vec<f32> = s.split(',').filter_map(|t| t.trim().parse().ok()).collect();
+        if p.len() == 2 {
+            for (dx, open) in [(0.0, false), (5.5, true)] {
+                let (x, z) = (p[0] + dx, p[1]);
+                let y = worldmap::ground_at_world(x, z).unwrap_or(0.0);
+                spawn_cage(
+                    commands,
+                    meshes,
+                    creature_mats,
+                    &prop_mat,
+                    Transform::from_xyz(x, y, z),
+                    CageKey::Decor,
+                    if open { 0 } else { crate::ork_fortress::CAGE_SEATS.len() },
+                    0xca6e_7e57 + dx as u32,
+                    open,
+                );
+            }
+        }
+    }
+
     for (camp, site) in sites.iter().enumerate() {
         // Logged so staging tools (screenshot framing, debugging) can find each camp.
         info!("camp {camp} at {:.1},{:.1}", site.centre.x, site.centre.y);
@@ -314,10 +460,9 @@ pub fn build(
         let place = |local: Vec3| centre3 + rot_q * local;
 
         // Static props: (mesh, camp-local pos, local yaw, footprint half-extents (hw,hd) in the
-        // prop's own frame; (0,0) = no collision). The tent + cage are the FORTRESS models
-        // (`ork_fortress::tent_mesh`/`cage_mesh`) so every warband pitches the same gear as
-        // Gnashfang Hold; both are SOLID — they register blocker boxes, so the hero and the
-        // warband route around them.
+        // prop's own frame; (0,0) = no collision). The tent is the FORTRESS model
+        // (`ork_fortress::tent_mesh`) so every warband pitches the same gear as Gnashfang Hold;
+        // it's SOLID — it registers a blocker box, so the hero and the warband route around it.
         // Tent NW (−z), cage SW (+z), well apart so the bigger fortress models don't overlap
         // (they did at the old −2.4/+2.2 spots). Tent at 0.7× the fortress size to fit the camp.
         let mut prop_rng = site.seed | 1;
@@ -325,28 +470,40 @@ pub fn build(
             (crate::ork_fortress::tent_mesh(0.7, &mut prop_rng), v(-2.3, 0.0, -2.1), 0.0_f32, (1.3_f32, 1.1_f32)),
             (banner_mesh(site.faction), v(0.0, 0.0, 0.0), 0.0, (0.25, 0.25)),
             (spikes_mesh(), v(0.0, 0.0, 0.0), 0.0, (0.0, 0.0)),
-            (crate::ork_fortress::cage_mesh(), v(-2.4, 0.0, 2.2), 0.6, (1.2, 1.2)),
             (fire_base_mesh(), v(0.2, 0.0, 0.0), 0.0, (0.55, 0.55)),
         ];
-        for (idx, (m, local, lyaw, (hw, hd))) in solids.into_iter().enumerate() {
+        for (m, local, lyaw, (hw, hd)) in solids {
             let h = meshes.add(m);
             let world = place(local);
-            let mut e = commands.spawn((
+            commands.spawn((
                 Mesh3d(h),
                 MeshMaterial3d(prop_mat.clone()),
                 Transform { translation: world, rotation: rot_q * ry(lyaw), scale: Vec3::ONE },
                 BiomeEntity,
             ));
-            if idx == CAGE_SOLID {
-                // The cage: tag it for rescue-despawn. It blocks like any solid prop — you walk
-                // UP TO it to rescue, not through it. The blocker set is append-only, so the husk
-                // left after the cage opens stays solid too (a closed→open cage is a fine wall).
-                e.insert(Cage { camp });
-                crate::blockers::add_obb(world.x, world.z, hw, hd, site.rot + lyaw);
-            } else if hw > 0.0 && hd > 0.0 {
+            if hw > 0.0 && hd > 0.0 {
                 crate::blockers::add_obb(world.x, world.z, hw, hd, site.rot + lyaw);
             }
         }
+
+        // The prisoner cage: the fortress frame + hinged door + a full cage of real seated
+        // peasants (`spawn_cage`). It blocks like any solid prop — you walk UP TO it to rescue,
+        // not through it. The blocker set is append-only, so the frame stays solid after the
+        // door opens too (an opened cage is a fine wall; the peasants leave through the door
+        // mouth, which sits outside the box).
+        let cage_world = place(v(-2.4, 0.0, 2.2));
+        spawn_cage(
+            commands,
+            meshes,
+            creature_mats,
+            &prop_mat,
+            Transform { translation: cage_world, rotation: rot_q * ry(0.6), scale: Vec3::ONE },
+            CageKey::Camp(camp),
+            crate::villagers::CAMP_RESCUE_POP as usize,
+            site.seed ^ 0xca6e_0000,
+            false,
+        );
+        crate::blockers::add_obb(cage_world.x, cage_world.z, 1.2, 1.2, site.rot + 0.6);
 
         // Log sit-stumps ringing the fire (fire is at local (0.2,0,0)) — orks roost on these
         // between musters. Small footprint blockers so the hero bumps them but they don't wall
@@ -473,11 +630,6 @@ fn respawn_warbands(
 
 const POLE: u32 = 0x3a2a1a;
 const SKULL: u32 = 0xe0d8c0;
-const WOOD: u32 = 0x4b3724;
-const WOOD_DARK: u32 = 0x33271a;
-const BAR: u32 = 0x6b6f76;
-const CAPTIVE_BODY: u32 = 0x7c6a54;
-const CAPTIVE_HEAD: u32 = 0xcaa980;
 const STONE: u32 = 0x6e6e76;
 const LOG_LIGHT: u32 = 0x7a4a26;
 const LOG_DARK: u32 = 0x3a2a1a;
@@ -505,53 +657,9 @@ fn spikes_mesh() -> Mesh {
     group(parts)
 }
 
-// (The camps' bespoke closed cage is gone too — the closed state is the fortress cage,
-//  `ork_fortress::cage_mesh` (W 2.2 / H 1.8); only the opened husk below remains local,
-//  scaled up at spawn to match the bigger closed cage it replaces.)
-
-/// The OPENED cage — the fortress cage's frame proportions, the east-face bars gone (door
-/// swung out) and no captives inside. Spawned in place of the closed cage on a rescue, so
-/// it reads as the cage *opening* rather than vanishing.
-fn cage_open_mesh() -> Mesh {
-    const W: f32 = 1.7;
-    const H: f32 = 1.5;
-    const HW: f32 = W / 2.0;
-    let wood = lin(WOOD);
-    let dark = lin(WOOD_DARK);
-    let bar = lin(BAR);
-    let mut p: Vec<Mesh> = Vec::new();
-    p.push(bx(W + 0.12, 0.12, W + 0.12, v(0.0, 0.06, 0.0), dark)); // floor
-    for (sx, sz) in [(-HW, -HW), (HW, -HW), (-HW, HW), (HW, HW)] {
-        p.push(bx(0.14, H, 0.14, v(sx, H / 2.0, sz), wood)); // corner posts
-    }
-    p.push(bx(W, 0.1, 0.1, v(0.0, H - 0.05, -HW), wood));
-    p.push(bx(W, 0.1, 0.1, v(0.0, H - 0.05, HW), wood));
-    p.push(bx(0.1, 0.1, W, v(-HW, H - 0.05, 0.0), wood));
-    p.push(bx(0.1, 0.1, W, v(HW, H - 0.05, 0.0), wood));
-    // Bars on N / S / W only — the EAST side is the door, now open.
-    for o in [-0.45f32, 0.0, 0.45] {
-        p.push(bx(0.07, H - 0.06, 0.07, v(o, H / 2.0, -HW), bar)); // north
-        p.push(bx(0.07, H - 0.06, 0.07, v(o, H / 2.0, HW), bar)); // south
-        p.push(bx(0.07, H - 0.06, 0.07, v(-HW, H / 2.0, o), bar)); // west
-    }
-    // The swung-open door panel, hinged at the SE post and flung outward.
-    p.push(bxr(0.06, H - 0.1, W - 0.12, v(HW + 0.55, H / 2.0, HW - 0.45), ry(FRAC_PI_2 * 0.85), bar));
-    group(p)
-}
-
-/// Replace a closed cage with the opened husk at the same pose (called by the rescue path).
-pub fn open_cage(
-    commands: &mut Commands,
-    meshes: &mut Assets<Mesh>,
-    materials: &mut Assets<StandardMaterial>,
-    at: Transform,
-) {
-    let mat = materials.add(StandardMaterial { base_color: Color::WHITE, perceptual_roughness: 0.9, ..default() });
-    // ×1.25: the open husk is authored at the OLD cage size (W 1.7); the closed cage it
-    // replaces is now the fortress one (W 2.2), so scale up to swing open at the same bulk.
-    let at = Transform { scale: at.scale * 1.25, ..at };
-    commands.spawn((Mesh3d(meshes.add(cage_open_mesh())), MeshMaterial3d(mat), at, BiomeEntity));
-}
+// (The opened-husk cage model is gone — a rescue no longer swaps meshes at all. The one cage
+//  model (`ork_fortress::cage_mesh`) persists and its hinged door child swings open by
+//  animation: see [`spawn_cage`] / [`swing_cage_doors`].)
 
 /// Campfire base — a ring of stones + two crossed logs (the solid, vertex-coloured part).
 fn fire_base_mesh() -> Mesh {
@@ -618,9 +726,6 @@ fn group(parts: Vec<Mesh>) -> Mesh {
 }
 fn bx(w: f32, h: f32, d: f32, off: Vec3, c: [f32; 4]) -> Mesh {
     tinted(Cuboid::new(w, h, d).mesh().build().translated_by(off), c)
-}
-fn bxr(w: f32, h: f32, d: f32, off: Vec3, rot: Quat, c: [f32; 4]) -> Mesh {
-    tinted(Cuboid::new(w, h, d).mesh().build().rotated_by(rot).translated_by(off), c)
 }
 fn cyl(r: f32, h: f32, off: Vec3, rot: Quat, c: [f32; 4]) -> Mesh {
     tinted(Cylinder::new(r, h).mesh().resolution(6).build().rotated_by(rot).translated_by(off), c)

--- a/src/ork_fortress.rs
+++ b/src/ork_fortress.rs
@@ -884,8 +884,19 @@ pub fn build(
         commands.entity(flag).insert(BiomeEntity);
     }
 
-    // ── Prisoner cage (bigger than a camp's; the hold hoards captives) ──
-    spawn_solid(commands, meshes, &timber_mat, cage_mesh(), at(CAGE_AT), ry(0.4));
+    // ── Prisoner cage (decorative — the hold's captives are beyond rescue; that's the story
+    //    it tells). Real seated peasants behind a hinged door that never opens. ──
+    crate::camps::spawn_cage(
+        commands,
+        meshes,
+        creature_mats,
+        &timber_mat,
+        Transform { translation: at(CAGE_AT), rotation: ry(0.4), scale: Vec3::ONE },
+        crate::camps::CageKey::Decor,
+        CAGE_SEATS.len(),
+        next_u32(&mut rng),
+        false, // the Hold's door never opens
+    );
     crate::blockers::add_obb(CAGE_AT.x, CAGE_AT.y, 1.25, 1.25, 0.4);
 
     // ── War totems: one OUTSIDE on the causeway and two inside, all glaring at the
@@ -1143,17 +1154,22 @@ pub fn build(
     commands.insert_resource(BlightPatrols { armory, sites });
 
     // ── Caged captives: closed cages staked by two patrols (the raid objective). Each blocks
-    //    like a solid prop — you walk UP to it; `blight_rescue` opens it when its squad falls. ──
+    //    like a solid prop — you walk UP to it; `blight_rescue` swings the door open when its
+    //    squad falls and the captive (a real seated peasant) walks out and marches home. ──
     for (slot, (at_xz, _patrol)) in BLIGHT_CAGES.iter().enumerate() {
         let yaw = rng_range(&mut rng, 0.0, TAU);
         crate::blockers::add_obb(at_xz.x, at_xz.y, 1.1, 1.0, yaw);
-        commands.spawn((
-            Mesh3d(meshes.add(cage_mesh())),
-            MeshMaterial3d(timber_mat.clone()),
+        crate::camps::spawn_cage(
+            commands,
+            meshes,
+            creature_mats,
+            &timber_mat,
             Transform { translation: at(*at_xz), rotation: ry(yaw), scale: Vec3::ONE },
-            BiomeEntity,
-            BlightCage { slot },
-        ));
+            crate::camps::CageKey::Blight(slot),
+            1, // one captive per Blight cage — the rescue grows the town by exactly one
+            next_u32(&mut rng),
+            false, // closed until its patrol falls
+        );
     }
     commands.insert_resource(BlightCaptives::default());
 
@@ -1264,17 +1280,13 @@ const PATROL_RESPAWN_FAR: f32 = 45.0;
 
 // ── Caged captives: the orks' plundered townsfolk, the reason to raid the mire ──────────
 //
+// (The cage prop itself — frame, hinged door, seated peasants — is `camps::spawn_cage`,
+// keyed `CageKey::Blight(slot)`; this module owns only the WHEN of the rescue.)
+//
 // A couple of barred cages are staked in the open Blight, each guarded by one patrol squad.
 // Wipe the guards (one-time — patrols respawn, captives don't) and the cage swings open +
 // one townsperson joins the castle (grows the bloodline). Mirrors `villagers::camp_rescue`,
 // keyed off the Blight patrols instead of the wilderness camps.
-
-/// A closed captive cage in the mire — `patrol` indexes [`PATROL_SITES`] (the squad guarding
-/// it; cleared = freed) and `i` is its slot in [`BlightCaptives`].
-#[derive(Component)]
-struct BlightCage {
-    slot: usize,
-}
 
 /// `(cage world XZ, guarding PATROL_SITES index)`. Both cages sit a few units OUTSIDE the
 /// walls in walkable mire, hard by their patrol's home so the squad reads as their jailers.
@@ -1350,23 +1362,26 @@ fn patrol_respawn(
     }
 }
 
-/// Free a caged captive once the patrol guarding it is wiped (one-time): swap the closed cage
-/// for the opened husk, grow the town by one, float + voice the rescue. Mirrors
-/// `villagers::camp_rescue` but keyed off the [`BlightPatrols`] homes. `seen` stops a cage from
-/// freeing before its squad has even spawned; wave invaders are excluded so a night siege at the
-/// keep can't read as "guards cleared".
+/// Free a caged captive once the patrol guarding it is wiped (one-time): swing the cage door
+/// open IN PLACE (an animation — the cage model never swaps), stand the captive up and walk it
+/// out (`villagers::release_captives` — it comments as it goes, then marches home and joins the
+/// town), grow the town by one, float + voice the rescue. Mirrors `villagers::camp_rescue` but
+/// keyed off the [`BlightPatrols`] homes. `seen` stops a cage from freeing before its squad has
+/// even spawned; wave invaders are excluded so a night siege at the keep can't read as "guards
+/// cleared".
 #[allow(clippy::too_many_arguments)]
 fn blight_rescue(
+    time: Res<Time>,
     mut town: ResMut<crate::town::TownRes>,
     captives: Option<ResMut<BlightCaptives>>,
     orks: Query<&crate::orks::Ork, (Without<crate::orks::WaveInvader>, Without<crate::dying::Dying>)>,
-    cages_q: Query<(Entity, &BlightCage, &Transform)>,
+    cages_q: Query<(&crate::camps::Cage, &Transform)>,
+    mut doors_q: Query<&mut crate::camps::CageDoor>,
+    caged_q: Query<(Entity, &crate::villagers::Captive)>,
     mut floats: ResMut<crate::combat_fx::FloatQueue>,
     mut cues: MessageWriter<crate::audio::AudioCue>,
     mut speak: MessageWriter<crate::audio::Speak>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let Some(mut captives) = captives else { return };
     for (slot, (at_xz, patrol)) in BLIGHT_CAGES.iter().enumerate() {
@@ -1382,24 +1397,32 @@ fn blight_rescue(
             continue; // patrol not spawned yet — don't auto-free
         }
         captives.freed[slot] = true;
-        // Open the cage in place (swap the closed prop for the husk at its exact pose).
+        let key = crate::camps::CageKey::Blight(slot);
+        // Swing the door open where it stands and start the captive's walk-out.
         let y = ground_y(at_xz.x, at_xz.y).unwrap_or(0.0);
-        let mut cage_tf = Transform::from_xyz(at_xz.x, y, at_xz.y);
-        for (e, c, tf) in &cages_q {
-            if c.slot == slot {
-                cage_tf = *tf;
-                commands.entity(e).try_despawn();
+        let cage_tf = cages_q
+            .iter()
+            .find(|(c, _)| c.key == key)
+            .map(|(_, tf)| *tf)
+            .unwrap_or_else(|| Transform::from_xyz(at_xz.x, y, at_xz.y));
+        for mut d in &mut doors_q {
+            if d.key == key {
+                d.open = true;
             }
         }
-        crate::camps::open_cage(&mut commands, &mut meshes, &mut materials, cage_tf);
-        town.0.population += 1; // the freed townsperson appears via town::sync_population_bodies
+        let freed: Vec<(Entity, u32)> =
+            caged_q.iter().filter(|(_, c)| c.key == key).map(|(e, c)| (e, c.seed)).collect();
+        crate::villagers::release_captives(&mut commands, time.elapsed_secs(), &cage_tf, &freed);
+        // Population grows NOW (the walker counts as a body — see `release_captives`), so the
+        // headcount sync never races the walk-out.
+        town.0.population += 1;
         floats.0.push(crate::combat_fx::FloatReq {
             world: Vec3::new(at_xz.x, cage_tf.translation.y + 1.8, at_xz.y),
             text: "Captive freed!  +1 townsperson".into(),
             color: Color::srgb(0.5, 1.0, 0.6),
             scale: 1.2,
         });
-        cues.write(crate::audio::AudioCue::CampRescue);
+        cues.write(crate::audio::AudioCue::CampRescue(Vec3::new(at_xz.x, cage_tf.translation.y + 1.2, at_xz.y)));
         speak.write(crate::audio::Speak::new(crate::audio::Concept::FirstRescue));
     }
 }
@@ -2279,34 +2302,119 @@ fn totem_mesh(rng: &mut u32) -> Mesh {
     group(p)
 }
 
-/// A heavy prisoner cage with three huddled captives (decorative — the hold's are beyond
-/// rescue; that's the story it tells). `pub(crate)`: the wilderness camps use the same
-/// cage for their closed (pre-rescue) state.
-pub(crate) fn cage_mesh() -> Mesh {
-    const W: f32 = 2.2;
-    const H: f32 = 1.8;
+/// Cage footprint (outer width) + height — shared with `camps::spawn_cage`, which parents the
+/// hinged door onto this frame and seats the captives against its geometry.
+pub(crate) const CAGE_W: f32 = 2.2;
+pub(crate) const CAGE_H: f32 = 1.8;
+/// Captive seat spots: cage-local `(x, z, yaw)`. A straw bedding lump is built into
+/// [`cage_mesh`] at each, and `camps::spawn_cage` sits one real peasant biped on it
+/// (`villagers::spawn_cage_captive`), faced loosely toward the door (+X) so the huddle
+/// reads as watching for rescue.
+pub(crate) const CAGE_SEATS: [(f32, f32, f32); 3] = [(-0.52, 0.30, 1.25), (0.28, -0.48, 2.0), (0.05, 0.62, 0.7)];
+
+// Cage dressing hues (rough rope lashings + the captives' straw bedding).
+const ROPE: u32 = 0x8a6f46;
+const STRAW: u32 = 0xb59245;
+const STRAW_DARK: u32 = 0x94743a;
+
+/// A heavy prisoner cage — rough-hewn crooked logs lashed with rope, a plank floor and straw
+/// bedding lumps (one per [`CAGE_SEATS`] spot). Branch bars cover only THREE faces: the +X face
+/// is the doorway, closed by the separate hinged [`cage_door_mesh`] that `camps::spawn_cage`
+/// parents onto the cage — so a rescue OPENS the same model by animation (the door swings),
+/// never a mesh swap. The captives are real seated peasants, not baked boxes. `pub(crate)`:
+/// the wilderness camps and the Blight both stake this same cage.
+pub(crate) fn cage_mesh(rng: &mut u32) -> Mesh {
+    const W: f32 = CAGE_W;
+    const H: f32 = CAGE_H;
     const HW: f32 = W / 2.0;
-    let wood = lin(TIMBER);
-    let dark = lin(TIMBER_DARK);
-    let bar = lin(IRON);
     let mut p: Vec<Mesh> = Vec::new();
-    p.push(bx(W + 0.14, 0.14, W + 0.14, v(0.0, 0.07, 0.0), dark));
+    // Plank floor: a dark base slab + a few lighter worn boards laid over it.
+    p.push(bx(W + 0.14, 0.14, W + 0.14, v(0.0, 0.07, 0.0), lin(TIMBER_DARK)));
+    for i in 0..3 {
+        let x = -0.62 + i as f32 * 0.62 + rng_range(rng, -0.05, 0.05);
+        let d = W - rng_range(rng, 0.15, 0.4);
+        p.push(bx(0.5, 0.02, d, v(x, 0.148, rng_range(rng, -0.08, 0.08)), lin(TIMBER)));
+    }
+    // Crooked corner posts — rough logs, each with its own lean, rope-lashed at the head.
     for (sx, sz) in [(-HW, -HW), (HW, -HW), (-HW, HW), (HW, HW)] {
-        p.push(bx(0.16, H, 0.16, v(sx, H / 2.0, sz), wood));
+        let lean = Quat::from_euler(
+            EulerRot::XYZ,
+            rng_range(rng, -0.045, 0.045),
+            0.0,
+            rng_range(rng, -0.045, 0.045),
+        );
+        let h = H + rng_range(rng, 0.02, 0.18);
+        p.push(cyl(0.085, h, v(sx, h / 2.0, sz), lean, lin(TIMBER)));
+        p.push(cyl(0.105, 0.1, v(sx, H - 0.08, sz), lean, lin(ROPE)));
     }
-    p.push(bx(W, 0.12, 0.12, v(0.0, H - 0.06, -HW), wood));
-    p.push(bx(W, 0.12, 0.12, v(0.0, H - 0.06, HW), wood));
-    p.push(bx(0.12, 0.12, W, v(-HW, H - 0.06, 0.0), wood));
-    p.push(bx(0.12, 0.12, W, v(HW, H - 0.06, 0.0), wood));
-    for o in [-0.66f32, -0.22, 0.22, 0.66] {
-        p.push(bx(0.08, H - 0.07, 0.08, v(o, H / 2.0, -HW), bar));
-        p.push(bx(0.08, H - 0.07, 0.08, v(o, H / 2.0, HW), bar));
-        p.push(bx(0.08, H - 0.07, 0.08, v(-HW, H / 2.0, o), bar));
-        p.push(bx(0.08, H - 0.07, 0.08, v(HW, H / 2.0, o), bar));
+    // Top rails: rough poles post-to-post on all four sides (the door swings under the +X one),
+    // each riding at its own slightly-off height so the frame reads hand-lashed, not machined.
+    p.push(cyl(0.055, W + 0.1, v(rng_range(rng, -0.03, 0.03), H - 0.05, -HW), rz(FRAC_PI_2), lin(TIMBER)));
+    p.push(cyl(0.055, W + 0.1, v(rng_range(rng, -0.03, 0.03), H - 0.02, HW), rz(FRAC_PI_2), lin(TIMBER)));
+    p.push(cyl(0.055, W + 0.1, v(-HW, H - 0.04, rng_range(rng, -0.03, 0.03)), rx(FRAC_PI_2), lin(TIMBER)));
+    p.push(cyl(0.055, W + 0.1, v(HW, H - 0.07, rng_range(rng, -0.03, 0.03)), rx(FRAC_PI_2), lin(TIMBER)));
+    // Mid rails on the three CLOSED faces (the bars lash against them).
+    p.push(cyl(0.04, W, v(0.0, 0.95 + rng_range(rng, -0.05, 0.05), -HW), rz(FRAC_PI_2), lin(TIMBER_DARK)));
+    p.push(cyl(0.04, W, v(0.0, 0.9 + rng_range(rng, -0.05, 0.05), HW), rz(FRAC_PI_2), lin(TIMBER_DARK)));
+    p.push(cyl(0.04, W, v(-HW, 0.92 + rng_range(rng, -0.05, 0.05), 0.0), rx(FRAC_PI_2), lin(TIMBER_DARK)));
+    // Branch bars on N / S / W — pale saplings, each its own thickness and tilt. The +X face
+    // stays open: that's the doorway.
+    for o in [-0.72f32, -0.24, 0.24, 0.72] {
+        for face in 0..3 {
+            let tilt = Quat::from_euler(
+                EulerRot::XYZ,
+                rng_range(rng, -0.05, 0.05),
+                0.0,
+                rng_range(rng, -0.05, 0.05),
+            );
+            let h = H - 0.18 + rng_range(rng, -0.08, 0.08);
+            let r = rng_range(rng, 0.03, 0.042);
+            let jo = o + rng_range(rng, -0.05, 0.05);
+            let at = match face {
+                0 => v(jo, h / 2.0 + 0.12, -HW),
+                1 => v(jo, h / 2.0 + 0.12, HW),
+                _ => v(-HW, h / 2.0 + 0.12, jo),
+            };
+            p.push(cyl(r, h, at, tilt, lin(TIMBER_PALE)));
+        }
     }
-    for (cx, cz) in [(-0.45f32, 0.25f32), (0.4, -0.3), (0.05, 0.55)] {
-        p.push(bx(0.34, 0.58, 0.24, v(cx, 0.34, cz), lin(0x7c6a54)));
-        p.push(bx(0.24, 0.24, 0.24, v(cx, 0.78, cz), lin(0xcaa980)));
+    // Straw bedding heaped at each seat spot (the captives sit on these).
+    for (sx, sz, _) in CAGE_SEATS {
+        let spin = ry(rng_range(rng, 0.0, TAU));
+        p.push(cyl(0.30, 0.22, v(sx, 0.25, sz), spin, lin(STRAW_DARK)));
+        p.push(cyl(0.24, 0.18, v(sx + rng_range(rng, -0.04, 0.04), 0.42, sz + rng_range(rng, -0.04, 0.04)), spin, lin(STRAW)));
+    }
+    group(p)
+}
+
+/// The cage DOOR — a lashed branch panel authored with its HINGE at the local origin (it hangs
+/// on the cage's (+X, +Z) corner post; the panel extends toward −Z across the +X face).
+/// `camps::spawn_cage` parents it onto the cage frame and `camps::swing_cage_doors` swings its
+/// yaw on a rescue — the opening is an animation of this one mesh, never a model swap.
+pub(crate) fn cage_door_mesh(rng: &mut u32) -> Mesh {
+    const H: f32 = CAGE_H;
+    let span = CAGE_W - 0.16; // panel width, fitted between the corner posts
+    let mut p: Vec<Mesh> = Vec::new();
+    // Two horizontal carry-rails the bars are lashed to, plus a diagonal brace.
+    for y in [0.42, H - 0.38] {
+        p.push(cyl(0.045, span, v(0.0, y + rng_range(rng, -0.03, 0.03), -span / 2.0 - 0.04), rx(FRAC_PI_2), lin(TIMBER)));
+    }
+    p.push(cyl(0.035, 2.05, v(0.0, 0.92, -1.02), rx(-1.07), lin(TIMBER_DARK)));
+    // Vertical branch bars — same pale saplings as the walls, each its own lean.
+    for z in [-0.30f32, -0.75, -1.20, -1.65] {
+        let h = H - 0.2 + rng_range(rng, -0.06, 0.08);
+        let tilt = Quat::from_euler(
+            EulerRot::XYZ,
+            rng_range(rng, -0.04, 0.04),
+            0.0,
+            rng_range(rng, -0.04, 0.04),
+        );
+        p.push(cyl(rng_range(rng, 0.032, 0.042), h, v(0.0, h / 2.0 + 0.12, z + rng_range(rng, -0.04, 0.04)), tilt, lin(TIMBER_PALE)));
+    }
+    // A heavier stile at the free (latch) edge + rope hinge-wraps at the hung edge.
+    p.push(cyl(0.05, H - 0.12, v(0.0, (H - 0.12) / 2.0 + 0.1, -1.97), Quat::IDENTITY, lin(TIMBER)));
+    for y in [0.42, H - 0.38] {
+        p.push(cyl(0.075, 0.12, v(0.0, y, -0.06), rx(FRAC_PI_2), lin(ROPE)));
     }
     group(p)
 }

--- a/src/savegame.rs
+++ b/src/savegame.rs
@@ -451,8 +451,9 @@ fn apply_pending_load(
     camps.done = data.rescued_camps.clone();
     camps.seen = data.rescued_camps.clone();
     // Blight cages: restore the freed flags so respawned patrols can't re-free an already-freed
-    // captive (which would dup `population`). In-process Continue keeps the live cage visuals, so
-    // only the flag matters here. Element-wise copy guards a length mismatch from an older save.
+    // captive (which would dup `population`). The cage VISUALS (door open/shut, captives seated
+    // or gone) reconcile from the GameLoaded message below — `camps::reconcile_cages_on_load`.
+    // Element-wise copy guards a length mismatch from an older save.
     if let Some(mut captives) = captives {
         for (i, &f) in data.blight_captives_freed.iter().enumerate() {
             if i < captives.freed.len() {

--- a/src/villagers.rs
+++ b/src/villagers.rs
@@ -349,7 +349,7 @@ const CAMP_HOME_R: f32 = 6.0;
 /// the main way the town grows: 5 camps × 3 = +15, the army's backbone. Raw-added (uncapped, like
 /// the old +1) — the realistic max (camps + start ≈ 17) stays under the 24 house cap, and a farm
 /// feeds far more than the headcount, so over-house peasants don't starve.
-const CAMP_RESCUE_POP: u32 = 3;
+pub(crate) const CAMP_RESCUE_POP: u32 = 3; // == captives seated per camp cage (`camps::spawn_cage`)
 
 impl Plugin for VillagersPlugin {
     fn build(&self, app: &mut App) {
@@ -397,6 +397,7 @@ impl Plugin for VillagersPlugin {
                     rearm_townsfolk,
                     reskin_townsfolk,
                     camp_rescue,
+                    walk_out_captives,
                     recruit,
                 )
                     .run_if(in_state(crate::game_state::Modal::None)),
@@ -577,22 +578,204 @@ pub fn spawn_scene_peasant(
     e
 }
 
-/// Clear a camp's warband and its captives are **automatically** freed (the TS behaviour): a cage
-/// of [`CAMP_RESCUE_POP`] joins the castle as militia (new guards) and grows the bloodline, with a
-/// float over the cage so you see it happen. `seen` gates against freeing a camp before its orks
-/// have even spawned.
+// ── Caged captives: real peasants behind bars, freed by clearing their jailers ────────────
+
+/// A caged peasant — a REAL peasant biped (`peasant_model`) huddled on the straw of a prisoner
+/// cage (`camps::spawn_cage`), not a baked box. No brain, no HP: it only sits (its
+/// [`BipedDrive::sitting`] pose) until a rescue tags it [`WalkOut`]. `seed` fixes its face and
+/// clothes so the townsperson it becomes on walking out is visibly the SAME person.
+#[derive(Component)]
+pub struct Captive {
+    pub key: crate::camps::CageKey,
+    pub(crate) seed: u32,
+}
+
+/// A freed captive mid walk-out: it stands after `start` (staggered so a cage files out, not
+/// pops out), speaks its `line`, shuffles to `target` (the door mouth, clear of the cage's
+/// blocker box) and there converts into a real townsperson ([`walk_out_captives`]).
+#[derive(Component)]
+pub(crate) struct WalkOut {
+    target: Vec2,
+    start: f32,
+    line: &'static str,
+}
+
+/// What the freed peasants say as they step out of an opened cage (one line each, floated over
+/// their head — the voiced `Concept::Rescued` reaction plays from the cage too, but only one
+/// mouth gets a clip; these floats let every captive react).
+const FREED_LINES: [&str; 6] = [
+    "We're free! Bless you, m'lord!",
+    "Thank you! I'll not forget this.",
+    "Sweet air at last!",
+    "To the castle \u{2014} I'll take up a spear!",
+    "I thought the orks would eat us\u{2026}",
+    "My family will hear of this kindness.",
+];
+/// Pace of the walk-out shuffle (u/s) — slower than a guard's march; they're stiff from the cage.
+const WALK_OUT_SPEED: f32 = 2.0;
+
+/// Spawn one seated captive peasant at `pos` (world; on the cage's plank floor), facing
+/// `facing`. Called by `camps::spawn_cage` — one per straw bed.
+pub fn spawn_cage_captive(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    creature_mats: &mut Assets<crate::creature::CreatureMaterial>,
+    pos: Vec3,
+    facing: Quat,
+    key: crate::camps::CageKey,
+    seed: u32,
+) -> Entity {
+    let mat = crate::creature::make_creature_material(creature_mats);
+    let skin = SKIN[(seed as usize) % SKIN.len()];
+    let tunic = TUNIC[(seed as usize >> 3) % TUNIC.len()];
+    let root = commands
+        .spawn((
+            Transform { translation: pos, rotation: facing, scale: Vec3::splat(SCALE) },
+            Visibility::Visible,
+            BipedDrive { sitting: true, phase: (seed % 628) as f32 / 100.0, ..default() },
+            Captive { key, seed },
+            BiomeEntity,
+        ))
+        .id();
+    build_biped_body(commands, root, Kind::Peasant { skin, tunic, hat: false }, seed, false, false, &mat, meshes);
+    root
+}
+
+/// Begin the walk-out for an opened cage's captives: each stands after a staggered delay and
+/// files out through the door face (cage-local +X), one comment line each. The captives are
+/// tagged [`Townsfolk`] NOW so `town::sync_population_bodies` counts them against the
+/// population the rescue just grew — no courtyard double-spawn while they're still walking.
+pub(crate) fn release_captives(commands: &mut Commands, now: f32, cage_tf: &Transform, captives: &[(Entity, u32)]) {
+    let door3 = cage_tf.rotation * Vec3::X;
+    let out = Vec2::new(door3.x, door3.z).normalize_or_zero();
+    let perp = Vec2::new(-out.y, out.x);
+    let cage_pos = Vec2::new(cage_tf.translation.x, cage_tf.translation.z);
+    let n = captives.len() as f32;
+    for (i, (e, seed)) in captives.iter().enumerate() {
+        let spread = (i as f32 - (n - 1.0) * 0.5) * 0.55;
+        commands.entity(*e).try_insert((
+            WalkOut {
+                // Past the door mouth, clear of the cage's blocker box (half-extent 1.2).
+                target: cage_pos + out * 2.7 + perp * spread,
+                start: now + 1.1 + i as f32 * 0.5, // let the door swing crack open first
+                line: FREED_LINES[(*seed as usize + i) % FREED_LINES.len()],
+            },
+            Townsfolk,
+        ));
+    }
+}
+
+/// Walk freed captives out of their cage: stand up (drop the sitting pose), float their comment,
+/// shuffle to the door mouth, then convert into a REAL townsperson on the spot — the same face
+/// and clothes (same `seed`), now with the full militia identity — which the guard AI marches
+/// home to the courtyard through the gates (the `NavPath` A* in [`guard_combat`]).
+fn walk_out_captives(
+    time: Res<Time>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut creature_mats: ResMut<Assets<crate::creature::CreatureMaterial>>,
+    mut floats: ResMut<crate::combat_fx::FloatQueue>,
+    mut q: Query<(Entity, &Captive, &WalkOut, &mut Transform, &mut BipedDrive)>,
+) {
+    let now = time.elapsed_secs();
+    let tw = time.elapsed_secs_wrapped();
+    let dt = time.delta_secs();
+    for (e, cap, w, mut tf, mut d) in &mut q {
+        if now < w.start {
+            continue; // still huddled — the door is swinging open
+        }
+        if d.sitting {
+            d.sitting = false; // stand up…
+            floats.0.push(crate::combat_fx::FloatReq {
+                // …and say thanks (one float per captive, staggered by the walk-out starts).
+                world: tf.translation + Vec3::Y * 1.7,
+                text: w.line.into(),
+                color: Color::srgb(0.85, 0.92, 1.0),
+                scale: 0.95,
+            });
+        }
+        let pos = Vec2::new(tf.translation.x, tf.translation.z);
+        let to = w.target - pos;
+        if to.length() < 0.2 {
+            // Out and clear: become a real townsperson mid-stride (same seed → same look).
+            spawn_freed_townsfolk(&mut commands, &mut meshes, &mut creature_mats, pos, cap.seed);
+            commands.entity(e).try_despawn();
+            continue;
+        }
+        let dir = to.normalize_or_zero();
+        tf.translation.x += dir.x * WALK_OUT_SPEED * dt;
+        tf.translation.z += dir.y * WALK_OUT_SPEED * dt;
+        // Step down from the plank floor onto the ground as they clear the cage.
+        let gy = crate::worldmap::ground_at_world(tf.translation.x, tf.translation.z).unwrap_or(0.0);
+        tf.translation.y += (gy - tf.translation.y) * (dt * 4.0).min(1.0);
+        let yaw = dir.x.atan2(dir.y);
+        tf.rotation = tf.rotation.slerp(Quat::from_rotation_y(yaw), (dt * 8.0).min(1.0));
+        // Drive the shared biped gait by hand (no `Villager` brain on a captive).
+        d.moving_amt += (1.0 - d.moving_amt) * (dt * 8.0).min(1.0);
+        d.walk_phase = (tw + d.phase) * 8.0;
+    }
+}
+
+/// The townsperson a freed captive becomes: the same peasant (same `seed` → same face/clothes,
+/// no helmet pop) with the full town-pool identity — militia guard posted to a courtyard spot,
+/// so the guard AI walks it home from the wilderness. `Role::Guard` from the start means
+/// [`reskin_townsfolk`] won't touch the body until a real job change redresses it.
+fn spawn_freed_townsfolk(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    creature_mats: &mut Assets<crate::creature::CreatureMaterial>,
+    pos: Vec2,
+    seed: u32,
+) -> Entity {
+    let mat = crate::creature::make_creature_material(creature_mats);
+    let mut rng = seed | 1;
+    let skin = SKIN[(seed as usize) % SKIN.len()];
+    let tunic = TUNIC[(seed as usize >> 3) % TUNIC.len()];
+    let half = crate::castle::courtyard_half();
+    let home = courtyard_spot(&mut rng, half, &[]).unwrap_or(Vec2::new(0.0, 5.0));
+    let e = spawn(
+        commands,
+        meshes,
+        &mat,
+        Kind::Peasant { skin, tunic, hat: false },
+        home,
+        pos,
+        GUARD_SPEED,
+        1.0,
+        SCALE,
+        seed,
+        false,
+    );
+    commands.entity(e).insert((
+        Guard { atk_cd: 0.0, post: home },
+        NpcHp { hp: NPC_MAX_HP, max: NPC_MAX_HP },
+        crate::navgrid::NavPath::default(),
+        Townsfolk,
+        Folk { skin, tunic, seed },
+        Role::Guard,
+        BodyMat(mat),
+    ));
+    e
+}
+
+/// Clear a camp's warband and its captives are **automatically** freed (the TS behaviour): the
+/// cage door swings open IN PLACE (an animation — the model never swaps), the cage of
+/// [`CAMP_RESCUE_POP`] peasants stands up, comments, files out and marches home to join the
+/// militia and the bloodline, with a float over the cage so you see it happen. `seen` gates
+/// against freeing a camp before its orks have even spawned.
 #[allow(clippy::too_many_arguments)]
 fn camp_rescue(
+    time: Res<Time>,
     mut town: ResMut<crate::town::TownRes>,
     mut rescued: ResMut<RescuedCamps>,
     orks: Query<&crate::orks::Ork, Without<crate::orks::WaveInvader>>,
-    cages_q: Query<(Entity, &crate::camps::Cage, &Transform)>,
+    cages_q: Query<(&crate::camps::Cage, &Transform)>,
+    mut doors_q: Query<&mut crate::camps::CageDoor>,
+    caged_q: Query<(Entity, &Captive)>,
     mut floats: ResMut<crate::combat_fx::FloatQueue>,
     mut cues: MessageWriter<crate::audio::AudioCue>,
     mut speak: MessageWriter<crate::audio::Speak>,
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     let cages = crate::camps::cage_positions();
     if rescued.done.len() != cages.len() {
@@ -612,18 +795,24 @@ fn camp_rescue(
         }
         // Warband wiped → free the captives.
         rescued.done[i] = true;
+        let key = crate::camps::CageKey::Camp(i);
         let y = crate::worldmap::ground_at_world(cage.x, cage.y).unwrap_or(0.0);
-        // Open the cage IN PLACE: swap the closed prop for the opened husk at the same pose.
-        let mut cage_tf = Transform::from_xyz(cage.x, y, cage.y);
-        for (e, c, tf) in &cages_q {
-            if c.camp == i {
-                cage_tf = *tf;
-                commands.entity(e).try_despawn();
+        let cage_tf = cages_q
+            .iter()
+            .find(|(c, _)| c.key == key)
+            .map(|(_, tf)| *tf)
+            .unwrap_or_else(|| Transform::from_xyz(cage.x, y, cage.y));
+        for mut d in &mut doors_q {
+            if d.key == key {
+                d.open = true; // the door swings — the cage itself never changes
             }
         }
-        crate::camps::open_cage(&mut commands, &mut meshes, &mut materials, cage_tf);
-        // The freed captives join the town's population (guards appear in the courtyard via
-        // `sync_population_bodies`) — and the bloodline with them: heirs ARE the headcount.
+        let freed: Vec<(Entity, u32)> =
+            caged_q.iter().filter(|(_, c)| c.key == key).map(|(e, c)| (e, c.seed)).collect();
+        release_captives(&mut commands, time.elapsed_secs(), &cage_tf, &freed);
+        // The freed captives join the town's population — and the bloodline with them: heirs
+        // ARE the headcount. Counted NOW (the walkers carry `Townsfolk`, so the body sync
+        // stays balanced while they file out and march home).
         town.0.population += CAMP_RESCUE_POP;
         floats.0.push(crate::combat_fx::FloatReq {
             world: Vec3::new(cage.x, y + 1.8, cage.y),
@@ -631,7 +820,7 @@ fn camp_rescue(
             color: Color::srgb(0.5, 1.0, 0.6),
             scale: 1.2,
         });
-        cues.write(crate::audio::AudioCue::CampRescue);
+        cues.write(crate::audio::AudioCue::CampRescue(Vec3::new(cage.x, y + 1.2, cage.y)));
         speak.write(crate::audio::Speak::new(crate::audio::Concept::FirstRescue));
     }
 }


### PR DESCRIPTION
- Captives are now REAL seated peasant bipeds (peasant_model + the shared
  sit pose) on straw bedding inside every prisoner cage (camps, Blight,
  the Hold's decorative hoard-cage) — no more merged colour boxes.
- The cage model is rebuilt as rough-hewn crooked logs lashed with rope,
  with a separate hinged branch-door child. A rescue now swings the door
  open IN PLACE (eased animation) — the old closed->open-husk model swap
  (camps::open_cage / cage_open_mesh) is gone.
- Freed captives stand up (staggered), each floats a thank-you line,
  files out through the open door, then converts into a real townsperson
  (same seed -> same face/clothes) that the guard AI marches home to the
  courtyard through the gates. AudioCue::CampRescue now carries the cage
  position so the voiced 'Rescued' line speaks from the freed captive at
  the cage instead of a random distant villager (which usually meant the
  line was silently dropped in the wilderness).
- Save/load: camps::reconcile_cages_on_load snaps doors + despawns
  captives of already-freed cages from the GameLoaded snapshot.
- FOREST_CAGETEST="x,z" stages the before/after cages side by side for
  screenshot verification.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UXmF6nnHvVp5Bw1SY5jbyU