### PR TITLE
FP viewmodel: full handedness mirror + combat-gated weapon raise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,11 +328,20 @@ reads it to drop a beaten warden). `Lives.heirs` mirrors `town.population`, so i
   view-model knobs: `fp_keep` in `player/mod.rs::spawn_hero_meshes` picks which limb meshes survive
   FP (hide the **upper-arm** meshes — they balloon at the eye — but KEEP the forearm so the weapon
   has a hand and doesn't levitate); `camera::fp_body_visibility` applies it; the FP arm/sword/shield
-  poses are the `fp_amt` overrides in `anim::hero_anim`; the eye sits at `FP_EYE_H`/`FP_FWD_OFF` in
-  `player/camera.rs`; and the main-camera **near-plane** (`scene.rs::setup_camera`, `near: 0.04`) is
-  lowered so the close-held weapon doesn't slice the near-plane (that slicing was the walk-time
-  "flicker"). NB: FP melee inherently puts the enemy in your face — no view-model trick fixes that;
-  third-person is the design's combat view.
+  poses live in `anim::hero_anim` (July 2026 rework): the arms are **always viewmodel-driven in FP**
+  (the eye sits AT the chest, so third-person clips orbit the lens itself — never let them play on
+  the FP arms), a `fp_ready` weight keeps the gear in a low carry at the frame edges out of combat
+  and draws it up when a threat is near / attacking / blocking, and the whole arm chains are
+  **handedness-MIRRORED** in FP (the studio rig renders its "R" joints on the viewer's left;
+  translations flip X, rotations conjugate `(x,-y,-z)`) so the sword reads bottom-right / shield
+  bottom-left. The FP wrist/shield angles were **solved from `FOREST_FPDBG=1` camera-space probes,
+  not eyeballed** — pose-space intuition is useless through the tilted FP hand frame, so tune
+  against the probe vectors (NB: FPDBG needs `FOREST_SHOT` too — without the shot harness the app
+  idles on the start screen and the probes read the menu camera). The eye sits at
+  `FP_EYE_H`/`FP_FWD_OFF` in `player/camera.rs`; and the main-camera **near-plane**
+  (`scene.rs::setup_camera`, `near: 0.04`) is lowered so the close-held weapon doesn't slice the
+  near-plane (that slicing was the walk-time "flicker"). NB: FP melee inherently puts the enemy in
+  your face — no view-model trick fixes that; third-person is the design's combat view.
 - **Capture-harness flakes — confirm the `Screenshot saved` log line, and retry before debugging.**
   A `FOREST_SHOT` run can emit a junk frame that is NOT a code bug: a **black** frame (cold pipeline,
   see the bevy-0.19 note) or an **overview/god-cam** frame (the follow-cam hadn't engaged yet under

--- a/src/player/anim.rs
+++ b/src/player/anim.rs
@@ -1050,19 +1050,28 @@ pub fn hero_anim(
                 let elbow = part.joint == Joint::ElbowR;
                 if let Some((Some((sh, el)), _)) = gesture {
                     rot = if elbow { el } else { sh };
-                } else if attack.is_none() && hero.charge_t <= CHARGE_GRACE && fp_amt > 0.0 {
-                    // First-person sword viewmodel, two carries blended by `fp_ready`: out of
-                    // combat a calm LOW carry (arm hanging easy at the side, the resting blade's
-                    // tip just grazing the bottom-right frame corner — out of the way, per the
-                    // design); in combat the Skyrim-style READY (hilt low bottom-right, blade
-                    // angled up-and-inward). Breath/bob/sway keep both alive, damped in the low
-                    // carry so the idle arm doesn't wave across the frame edge.
+                } else if fp_amt > 0.0 {
+                    // First-person sword ARM. The eye sits AT the chest, so the third-person
+                    // clips (whose swings/braces orbit the chest) land ON the lens — the arm is
+                    // therefore ALWAYS viewmodel-driven in FP. Two carries blended by `fp_ready`:
+                    // out of combat a calm LOW carry (arm hanging easy, the resting blade's tip
+                    // just grazing the bottom-right corner); in combat the Skyrim-style READY.
+                    // An attack layers a compact wind→punch envelope on top (the blade's sweep
+                    // itself plays on the Sword joint below). Breath/bob/sway keep it alive.
+                    let (back, fwd) = match &attack {
+                        Some((Phase::Wind, p)) => (*p, 0.0),
+                        Some((Phase::Strike, p)) => (1.0 - *p, *p),
+                        Some((Phase::Recovery, p)) => (0.0, 1.0 - *p),
+                        None => (0.0, 0.0),
+                    };
                     let target = if elbow {
-                        rx(lerp(-0.35, -1.30, fp_ready) + fp_bob_v * 0.6)
+                        rx(lerp(-0.35, -1.30, fp_ready) - 0.30 * back + 0.75 * fwd + fp_bob_v * 0.6)
                     } else {
                         e3(
-                            lerp(0.10, -0.70, fp_ready) + fp_breath + fp_bob_v,
-                            -(fp_sway + fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.35 * fp_ready,
+                            lerp(0.10, -0.70, fp_ready) - 0.25 * back + 0.15 * fwd + fp_breath + fp_bob_v,
+                            -(fp_sway + fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.35 * fp_ready
+                                - 0.20 * back
+                                + 0.25 * fwd,
                             lerp(0.12, 0.10, fp_ready),
                         )
                     };
@@ -1073,7 +1082,9 @@ pub fn hero_anim(
                 // FP ready: blade diagonal up-inward toward frame centre (Skyrim ready stance).
                 // X≈1.30 rises the hilt from the corner; Y sweeps the blade toward upper-centre.
                 // Scaled by `fp_ready` so the low carry keeps the rest tilt (blade forward-down,
-                // tip at the corner). Attack/block/charge own it otherwise.
+                // tip at the corner). Attack/block/charge keep the CLIP's wrist rotation — with
+                // the hand pinned by the FP arm above, the clip's big sword sweeps read as the
+                // FP slash arcs.
                 if attack.is_none() && block_amt < 0.5 && hero.charge_t <= CHARGE_GRACE && fp_amt > 0.0 {
                     let ready = e3(1.30 + fp_bob_v * 0.5, -(0.60 + fp_sway), 0.15);
                     rot = rot.slerp(ready, fp_amt * fp_ready);
@@ -1083,19 +1094,20 @@ pub fn hero_anim(
                 let elbow = part.joint == Joint::ElbowL;
                 if let Some((_, Some((sh, el)))) = gesture {
                     rot = if elbow { el } else { sh };
-                } else if attack.is_none() && block_amt < 0.5 && fp_amt > 0.0 {
-                    // First-person shield viewmodel (mirror of the sword arm): the low carry hangs
-                    // the shield edge-on beside the thigh (out of frame bar a sliver in the
-                    // bottom-left corner); ready raises the forearm so it rides the corner as a
-                    // guard. Skipped while blocking — `defend_pose` braces the shield flat in
-                    // front, which should win.
+                } else if fp_amt > 0.0 {
+                    // First-person shield ARM (always viewmodel-driven in FP — see the sword arm
+                    // note): the low carry hangs the shield edge-on beside the thigh (out of
+                    // frame bar a sliver in the bottom-left corner); ready raises the forearm to
+                    // ride the corner as a guard; a raised guard (`block_amt`) BRACES it up into
+                    // the lower-left of frame, where the pose's face-on Shield rotation turns the
+                    // plate to the camera.
                     let target = if elbow {
-                        rx(lerp(-0.55, -1.25, fp_ready) + fp_bob_v * 0.6)
+                        rx(lerp(lerp(-0.55, -1.25, fp_ready), -1.50, block_amt) + fp_bob_v * 0.6)
                     } else {
                         e3(
-                            lerp(0.10, -1.05, fp_ready) + fp_breath + fp_bob_v,
+                            lerp(lerp(0.10, -1.05, fp_ready), -1.15, block_amt) + fp_breath + fp_bob_v,
                             -(fp_sway - fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.15 * fp_ready,
-                            lerp(-0.12, -0.05, fp_ready),
+                            lerp(lerp(-0.12, -0.05, fp_ready), -0.02, block_amt),
                         )
                     };
                     rot = rot.slerp(target, fp_amt);

--- a/src/player/anim.rs
+++ b/src/player/anim.rs
@@ -1138,7 +1138,8 @@ pub fn hero_anim(
                 // the FPDBG probes like the sword wrist. Out of block, no override — the rest
                 // carry keeps the shield edge-on along the forearm (a subtle corner sliver).
                 if fp_amt > 0.0 && block_amt > 0.001 {
-                    rot = rot.slerp(e3(-0.98, -0.02, 0.17), fp_amt * block_amt);
+                    // Z carries a π roll — the other solution branch held the heater point-UP.
+                    rot = rot.slerp(e3(-0.98, -0.02, -2.97), fp_amt * block_amt);
                 }
             }
             _ => {}

--- a/src/player/anim.rs
+++ b/src/player/anim.rs
@@ -947,6 +947,20 @@ pub fn hero_anim(
     *fp_ready += ((if fp_want_ready { 1.0 } else { 0.0 }) - *fp_ready) * (dt * fp_ready_rate).min(1.0);
     let fp_ready = fp_ready.clamp(0.0, 1.0);
 
+    // FP attack envelope, shared by the sword arm and wrist: `back` coils through the wind (and
+    // through a held Heavy-Strike charge), `fwd` punches through the strike and eases out across
+    // the recovery.
+    let (fp_atk_back, fp_atk_fwd) = if hero.charge_t > CHARGE_GRACE && attack.is_none() {
+        (1.0, 0.0)
+    } else {
+        match &attack {
+            Some((Phase::Wind, p)) => (*p, 0.0),
+            Some((Phase::Strike, p)) => (1.0 - *p, *p),
+            Some((Phase::Recovery, p)) => (0.0, 1.0 - *p),
+            None => (0.0, 0.0),
+        }
+    };
+
     let (fp_breath, fp_bob_v, fp_bob_l, fp_sway) = if fp_amt > 0.0 {
         let breath = (now * 3.1).sin() * 0.018; // ~0.5 Hz idle heave
         // Vertical pump at 2× stride (one dip per footfall), light lateral sway at 1×; a touch
@@ -1058,12 +1072,7 @@ pub fn hero_anim(
                     // just grazing the bottom-right corner); in combat the Skyrim-style READY.
                     // An attack layers a compact wind→punch envelope on top (the blade's sweep
                     // itself plays on the Sword joint below). Breath/bob/sway keep it alive.
-                    let (back, fwd) = match &attack {
-                        Some((Phase::Wind, p)) => (*p, 0.0),
-                        Some((Phase::Strike, p)) => (1.0 - *p, *p),
-                        Some((Phase::Recovery, p)) => (0.0, 1.0 - *p),
-                        None => (0.0, 0.0),
-                    };
+                    let (back, fwd) = (fp_atk_back, fp_atk_fwd);
                     let target = if elbow {
                         rx(lerp(-0.35, -1.05, fp_ready) - 0.30 * back + 0.75 * fwd + fp_bob_v * 0.6)
                     } else {
@@ -1079,17 +1088,24 @@ pub fn hero_anim(
                 }
             }
             Joint::Sword => {
-                // FP ready: blade angled up-forward from the bottom-right hilt toward frame
-                // centre (Skyrim ready stance). NB the FP arm tilts the HAND frame back, so the
-                // wrist X here is far smaller than the pose-space intuition suggests — tuned
-                // against the FPDBG camera-space blade probes, not by eye. A raised guard tucks
-                // the blade back down to the rest carry (out of frame — the shield is the story).
-                // Attack/charge keep the CLIP's wrist rotation — with the hand pinned by the FP
-                // arm above, the clip's big sword sweeps read as the FP slash arcs.
-                if attack.is_none() && hero.charge_t <= CHARGE_GRACE && fp_amt > 0.0 {
-                    let ready = e3(0.35 + fp_bob_v * 0.5, -(0.60 + fp_sway), 0.15);
-                    let target = ready.slerp(e3(1.95, 0.30, 0.0), block_amt);
-                    rot = rot.slerp(target, fp_amt * fp_ready.max(block_amt));
+                // FP wrist — fully viewmodel-owned in first person: the FP arm tilts the HAND
+                // frame so far back that EVERY pose-space wrist angle (rest 1.95, the clips'
+                // sweeps) points the blade up at / behind the lens. These angles are SOLVED from
+                // the FPDBG camera-space probes (reconstruct the hand basis, invert the desired
+                // camera-space blade line back to joint-local Euler), not eyeballed:
+                // - ready: blade up-forward from the bottom-right hilt toward frame centre
+                // - attack: the envelope cocks it back-right through the wind, sweeps it across
+                //   toward centre-down through the strike (the arm punch carries the hilt)
+                // - guard: tucked down-forward-right, out of frame — the shield is the story.
+                if fp_amt > 0.0 {
+                    let combat = e3(
+                        2.68 - 0.70 * fp_atk_back + 0.55 * fp_atk_fwd + fp_bob_v * 0.5,
+                        -(0.60 + fp_sway + 0.35 * fp_atk_back - 0.65 * fp_atk_fwd),
+                        -0.44,
+                    );
+                    let target = combat.slerp(e3(-2.42, -0.60, -0.33), block_amt);
+                    let w = if attack.is_some() { fp_amt } else { fp_amt * fp_ready.max(block_amt) };
+                    rot = rot.slerp(target, w);
                 }
             }
             Joint::ShoulderL | Joint::ElbowL => {
@@ -1104,10 +1120,10 @@ pub fn hero_anim(
                     // the lower-left of frame, where the pose's face-on Shield rotation turns the
                     // plate to the camera.
                     let target = if elbow {
-                        rx(lerp(lerp(-0.55, -0.90, fp_ready), -1.20, block_amt) + fp_bob_v * 0.6)
+                        rx(lerp(lerp(-0.55, -1.00, fp_ready), -1.20, block_amt) + fp_bob_v * 0.6)
                     } else {
                         e3(
-                            lerp(lerp(0.10, -0.50, fp_ready), -0.75, block_amt) + fp_breath + fp_bob_v,
+                            lerp(lerp(0.10, -0.55, fp_ready), -0.75, block_amt) + fp_breath + fp_bob_v,
                             -(fp_sway - fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.15 * fp_ready,
                             lerp(lerp(-0.12, -0.05, fp_ready), -0.02, block_amt),
                         )
@@ -1115,10 +1131,15 @@ pub fn hero_anim(
                     rot = rot.slerp(target, fp_amt);
                 }
             }
-            // NB: no FP override on Joint::Shield — the rest carry keeps the shield edge-on along
-            // the forearm. Tilting it "open" here showed its BACK/strap side whenever the stride
-            // threw it into frame (the "holds the shield backwards" bug); the block pose is where
-            // the face turns to the camera deliberately.
+            Joint::Shield => {
+                // FP block: turn the plate's FACE to the camera, low in frame — the pose-space
+                // defend brace (rx(π/2)) shows its BACK through the FP hand frame. Solved from
+                // the FPDBG probes like the sword wrist. Out of block, no override — the rest
+                // carry keeps the shield edge-on along the forearm (a subtle corner sliver).
+                if fp_amt > 0.0 && block_amt > 0.001 {
+                    rot = rot.slerp(e3(-0.98, -0.02, 0.17), fp_amt * block_amt);
+                }
+            }
             _ => {}
         }
 

--- a/src/player/anim.rs
+++ b/src/player/anim.rs
@@ -883,6 +883,8 @@ pub fn hero_anim(
     // FP turn-sway state: last frame's view yaw + the low-passed yaw rate (rad/s).
     mut fp_prev_yaw: Local<f32>,
     mut fp_sway_amt: Local<f32>,
+    // Smoothed FP "weapon drawn" weight (0 = calm low carry at the frame edges, 1 = combat-ready).
+    mut fp_ready: Local<f32>,
 ) {
     let Ok((hero, hh)) = hero_q.single() else { return };
     let now = time.elapsed_secs();
@@ -932,6 +934,19 @@ pub fn hero_anim(
     // "glued to the camera". Three small joint-space layers (radians), all camera-untouched (the FP
     // eye stays rigid — motion-sickness guard): breath (idle heave), walk-bob (stride pump),
     // turn-sway (weapon lags the view yaw).
+    // FP weapon-ready weight: out of combat the arms settle into a calm low carry (gear barely
+    // peeking into the bottom frame corners); a hostile nearby, a swing, a charge, or a raised
+    // guard DRAWS them up into the ready stance. Quick raise (~0.15s) so an ambush reads
+    // instantly; slow lower (~0.5s + the 6s `combat_until` linger) so it never pumps mid-fight.
+    let fp_want_ready = hero.attacking
+        || hero.charge_t > CHARGE_GRACE
+        || hh.blocking
+        || hero.threats > 0
+        || now < hero.combat_until;
+    let fp_ready_rate = if fp_want_ready { 12.0 } else { 3.0 };
+    *fp_ready += ((if fp_want_ready { 1.0 } else { 0.0 }) - *fp_ready) * (dt * fp_ready_rate).min(1.0);
+    let fp_ready = fp_ready.clamp(0.0, 1.0);
+
     let (fp_breath, fp_bob_v, fp_bob_l, fp_sway) = if fp_amt > 0.0 {
         let breath = (now * 3.1).sin() * 0.018; // ~0.5 Hz idle heave
         // Vertical pump at 2× stride (one dip per footfall), light lateral sway at 1×; a touch
@@ -1027,43 +1042,41 @@ pub fn hero_anim(
         let mut rot = jp.r;
 
         // Arm overrides: the Director's staged gesture wins on the arms; otherwise the first-person
-        // viewmodel raises the sword arm into frame. (Combat/locomotion already in `rot`.)
+        // viewmodel carries the arms (low at rest, raised when `fp_ready`). All FP targets here are
+        // authored in RIG space — the handedness mirror below flips the finished chains onto the
+        // correct screen sides. (Combat/locomotion already in `rot`.)
         match part.joint {
             Joint::ShoulderR | Joint::ElbowR => {
                 let elbow = part.joint == Joint::ElbowR;
                 if let Some((Some((sh, el)), _)) = gesture {
                     rot = if elbow { el } else { sh };
-                } else if attack.is_none() && fp_amt > 0.0 {
-                    // First-person sword viewmodel — Skyrim-style ready: hilt low bottom-right,
-                    // blade angled up-and-inward, kept alive by breath/bob/sway instead of frozen.
-                    // NB the FP anchor-swap below moves this whole chain to the frame's RIGHT, so
-                    // the Y/Z angles here are authored for the swapped side (mirror of the rig's).
+                } else if attack.is_none() && hero.charge_t <= CHARGE_GRACE && fp_amt > 0.0 {
+                    // First-person sword viewmodel, two carries blended by `fp_ready`: out of
+                    // combat a calm LOW carry (arm hanging easy at the side, the resting blade's
+                    // tip just grazing the bottom-right frame corner — out of the way, per the
+                    // design); in combat the Skyrim-style READY (hilt low bottom-right, blade
+                    // angled up-and-inward). Breath/bob/sway keep both alive, damped in the low
+                    // carry so the idle arm doesn't wave across the frame edge.
                     let target = if elbow {
-                        rx(-1.30 + fp_bob_v * 0.6)
+                        rx(lerp(-0.35, -1.30, fp_ready) + fp_bob_v * 0.6)
                     } else {
-                        e3(-0.70 + fp_breath + fp_bob_v, 0.35 + fp_sway + fp_bob_l, -0.10)
+                        e3(
+                            lerp(0.10, -0.70, fp_ready) + fp_breath + fp_bob_v,
+                            -(fp_sway + fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.35 * fp_ready,
+                            lerp(0.12, 0.10, fp_ready),
+                        )
                     };
                     rot = rot.slerp(target, fp_amt);
-                }
-                // FP anchor-swap (shoulders only): the studio port left the rig HANDEDNESS mirrored
-                // — the joint named ShoulderR renders on the viewer's LEFT (three.js +Z-toward-
-                // viewer vs Bevy -Z-forward). Invisible in third person behind the low-poly
-                // silhouette, glaring at eye height (shield slab on the right = "holds the shield
-                // backwards"). Swap the two shoulder anchors across the body in FP so the sword
-                // reads bottom-RIGHT / shield bottom-LEFT like every FP melee game; third person
-                // keeps the rig as authored. Translation-only + fp-blended (the FP dolly-in masks
-                // the glide across).
-                if !elbow {
-                    let home = super::model::SHOULDER_DX; // spawn |x|; R sits at +x, L at -x
-                    tf.translation.x = lerp(home, -home, fp_amt);
                 }
             }
             Joint::Sword => {
                 // FP ready: blade diagonal up-inward toward frame centre (Skyrim ready stance).
-                // X≈1.30 rises the hilt from the corner; Y sweeps the blade toward upper-centre
-                // (angles mirrored for the FP anchor-swap). Attack/block own it otherwise.
-                if attack.is_none() && block_amt < 0.5 && fp_amt > 0.0 {
-                    rot = rot.slerp(e3(1.30 + fp_bob_v * 0.5, 0.60 + fp_sway, -0.15), fp_amt);
+                // X≈1.30 rises the hilt from the corner; Y sweeps the blade toward upper-centre.
+                // Scaled by `fp_ready` so the low carry keeps the rest tilt (blade forward-down,
+                // tip at the corner). Attack/block/charge own it otherwise.
+                if attack.is_none() && block_amt < 0.5 && hero.charge_t <= CHARGE_GRACE && fp_amt > 0.0 {
+                    let ready = e3(1.30 + fp_bob_v * 0.5, -(0.60 + fp_sway), 0.15);
+                    rot = rot.slerp(ready, fp_amt * fp_ready);
                 }
             }
             Joint::ShoulderL | Joint::ElbowL => {
@@ -1071,27 +1084,60 @@ pub fn hero_anim(
                 if let Some((_, Some((sh, el)))) = gesture {
                     rot = if elbow { el } else { sh };
                 } else if attack.is_none() && block_amt < 0.5 && fp_amt > 0.0 {
-                    // First-person shield viewmodel (mirror of the sword arm): upper arm forward,
-                    // elbow bent so the shield rides LOW in the bottom-left corner, alive on the
-                    // same breath/bob/sway (angles mirrored for the FP anchor-swap). Skipped while
-                    // blocking — `defend_pose` braces the shield flat in front, which should win.
+                    // First-person shield viewmodel (mirror of the sword arm): the low carry hangs
+                    // the shield edge-on beside the thigh (out of frame bar a sliver in the
+                    // bottom-left corner); ready raises the forearm so it rides the corner as a
+                    // guard. Skipped while blocking — `defend_pose` braces the shield flat in
+                    // front, which should win.
                     let target = if elbow {
-                        rx(-1.25 + fp_bob_v * 0.6)
+                        rx(lerp(-0.55, -1.25, fp_ready) + fp_bob_v * 0.6)
                     } else {
-                        e3(-1.05 + fp_breath + fp_bob_v, 0.15 + fp_sway - fp_bob_l, 0.05)
+                        e3(
+                            lerp(0.10, -1.05, fp_ready) + fp_breath + fp_bob_v,
+                            -(fp_sway - fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.15 * fp_ready,
+                            lerp(-0.12, -0.05, fp_ready),
+                        )
                     };
                     rot = rot.slerp(target, fp_amt);
-                }
-                // FP anchor-swap — see the ShoulderR note (shield chain moves to the frame's LEFT).
-                if !elbow {
-                    let home = -super::model::SHOULDER_DX;
-                    tf.translation.x = lerp(home, -home, fp_amt);
                 }
             }
             // NB: no FP override on Joint::Shield — the rest carry keeps the shield edge-on along
             // the forearm. Tilting it "open" here showed its BACK/strap side whenever the stride
-            // threw it into frame (the "holds the shield backwards" bug); the FP block pose
-            // (Task 2) is where the face turns to the camera deliberately.
+            // threw it into frame (the "holds the shield backwards" bug); the block pose is where
+            // the face turns to the camera deliberately.
+            _ => {}
+        }
+
+        // ── FP handedness mirror ──
+        // The studio port left the rig handedness-MIRRORED: the joint named ShoulderR renders on
+        // the viewer's LEFT through the FP eye (three.js +Z-toward-viewer vs Bevy -Z-forward).
+        // Invisible in third person behind the low-poly silhouette, glaring at eye height ("holds
+        // the sword left-handed"). In first person, mirror the whole arm chains + held gear across
+        // the body plane — translations flip X, rotations conjugate by the reflection (keep x,
+        // negate y/z) — so the sword reads bottom-RIGHT / shield bottom-LEFT like every FP melee
+        // game, and EVERY authored pose (attack sweeps, the block brace, the charge coil) stays
+        // correct-handed with no FP-specific re-authoring. (The earlier translation-only
+        // anchor-swap left the un-mirrored rotations sweeping attacks/blocks the wrong way —
+        // the "FP is completely broken" bug.) Third person keeps the rig as authored; sword and
+        // heater shield are x-symmetric meshes, so the un-mirrored geometry doesn't tell.
+        match part.joint {
+            Joint::ShoulderR | Joint::ShoulderL | Joint::ElbowR | Joint::ElbowL | Joint::Sword | Joint::Shield => {
+                if fp_amt > 0.0 {
+                    let mirrored = Quat::from_xyzw(rot.x, -rot.y, -rot.z, rot.w);
+                    rot = rot.slerp(mirrored, fp_amt);
+                }
+                // Anchors: the shoulders are never written by poses (they spawn at ±SHOULDER_DX),
+                // so cross-fade them to the opposite side from their homes — unconditionally, so
+                // leaving FP restores them. The shield's per-pose local offset was freshly written
+                // above, so a plain X flip mirrors it (identity at fp_amt = 0).
+                let home = super::model::SHOULDER_DX;
+                match part.joint {
+                    Joint::ShoulderR => tf.translation.x = lerp(home, -home, fp_amt),
+                    Joint::ShoulderL => tf.translation.x = lerp(-home, home, fp_amt),
+                    Joint::Shield => tf.translation.x = lerp(tf.translation.x, -tf.translation.x, fp_amt),
+                    _ => {}
+                }
+            }
             _ => {}
         }
         tf.rotation = rot;

--- a/src/player/anim.rs
+++ b/src/player/anim.rs
@@ -1099,8 +1099,8 @@ pub fn hero_anim(
                 // - guard: tucked down-forward-right, out of frame — the shield is the story.
                 if fp_amt > 0.0 {
                     let combat = e3(
-                        2.68 - 0.70 * fp_atk_back + 0.55 * fp_atk_fwd + fp_bob_v * 0.5,
-                        -(0.60 + fp_sway + 0.35 * fp_atk_back - 0.65 * fp_atk_fwd),
+                        2.68 - 0.55 * fp_atk_back + 0.55 * fp_atk_fwd + fp_bob_v * 0.5,
+                        -(0.60 + fp_sway - 0.40 * fp_atk_back - 0.65 * fp_atk_fwd),
                         -0.44,
                     );
                     let target = combat.slerp(e3(-2.42, -0.60, -0.33), block_amt);
@@ -1114,18 +1114,19 @@ pub fn hero_anim(
                     rot = if elbow { el } else { sh };
                 } else if fp_amt > 0.0 {
                     // First-person shield ARM (always viewmodel-driven in FP — see the sword arm
-                    // note): the low carry hangs the shield edge-on beside the thigh (out of
-                    // frame bar a sliver in the bottom-left corner); ready raises the forearm to
-                    // ride the corner as a guard; a raised guard (`block_amt`) BRACES it up into
-                    // the lower-left of frame, where the pose's face-on Shield rotation turns the
-                    // plate to the camera.
+                    // note): it STAYS in the low carry even at combat-ready — the shield rides
+                    // edge-on beside the thigh, out of frame bar a sliver in the bottom-left
+                    // corner (raising it at ready laid the plate ALONG the lifted forearm, whose
+                    // far end crossed the lens as a wall). Only a raised guard (`block_amt`)
+                    // BRACES it up into the lower-left of frame, where the FP Shield override
+                    // below turns the plate's face to the camera.
                     let target = if elbow {
-                        rx(lerp(lerp(-0.55, -1.00, fp_ready), -1.20, block_amt) + fp_bob_v * 0.6)
+                        rx(lerp(-0.55, -1.20, block_amt) + fp_bob_v * 0.6)
                     } else {
                         e3(
-                            lerp(lerp(0.10, -0.55, fp_ready), -0.75, block_amt) + fp_breath + fp_bob_v,
-                            -(fp_sway - fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.15 * fp_ready,
-                            lerp(lerp(-0.12, -0.05, fp_ready), -0.02, block_amt),
+                            lerp(0.10, -0.75, block_amt) + fp_breath + fp_bob_v,
+                            -(fp_sway - fp_bob_l) * 0.5,
+                            lerp(-0.12, -0.02, block_amt),
                         )
                     };
                     rot = rot.slerp(target, fp_amt);

--- a/src/player/anim.rs
+++ b/src/player/anim.rs
@@ -1065,7 +1065,7 @@ pub fn hero_anim(
                         None => (0.0, 0.0),
                     };
                     let target = if elbow {
-                        rx(lerp(-0.35, -1.30, fp_ready) - 0.30 * back + 0.75 * fwd + fp_bob_v * 0.6)
+                        rx(lerp(-0.35, -1.05, fp_ready) - 0.30 * back + 0.75 * fwd + fp_bob_v * 0.6)
                     } else {
                         e3(
                             lerp(0.10, -0.70, fp_ready) - 0.25 * back + 0.15 * fwd + fp_breath + fp_bob_v,
@@ -1079,15 +1079,17 @@ pub fn hero_anim(
                 }
             }
             Joint::Sword => {
-                // FP ready: blade diagonal up-inward toward frame centre (Skyrim ready stance).
-                // X≈1.30 rises the hilt from the corner; Y sweeps the blade toward upper-centre.
-                // Scaled by `fp_ready` so the low carry keeps the rest tilt (blade forward-down,
-                // tip at the corner). Attack/block/charge keep the CLIP's wrist rotation — with
-                // the hand pinned by the FP arm above, the clip's big sword sweeps read as the
-                // FP slash arcs.
-                if attack.is_none() && block_amt < 0.5 && hero.charge_t <= CHARGE_GRACE && fp_amt > 0.0 {
-                    let ready = e3(1.30 + fp_bob_v * 0.5, -(0.60 + fp_sway), 0.15);
-                    rot = rot.slerp(ready, fp_amt * fp_ready);
+                // FP ready: blade angled up-forward from the bottom-right hilt toward frame
+                // centre (Skyrim ready stance). NB the FP arm tilts the HAND frame back, so the
+                // wrist X here is far smaller than the pose-space intuition suggests — tuned
+                // against the FPDBG camera-space blade probes, not by eye. A raised guard tucks
+                // the blade back down to the rest carry (out of frame — the shield is the story).
+                // Attack/charge keep the CLIP's wrist rotation — with the hand pinned by the FP
+                // arm above, the clip's big sword sweeps read as the FP slash arcs.
+                if attack.is_none() && hero.charge_t <= CHARGE_GRACE && fp_amt > 0.0 {
+                    let ready = e3(0.35 + fp_bob_v * 0.5, -(0.60 + fp_sway), 0.15);
+                    let target = ready.slerp(e3(1.95, 0.30, 0.0), block_amt);
+                    rot = rot.slerp(target, fp_amt * fp_ready.max(block_amt));
                 }
             }
             Joint::ShoulderL | Joint::ElbowL => {
@@ -1102,10 +1104,10 @@ pub fn hero_anim(
                     // the lower-left of frame, where the pose's face-on Shield rotation turns the
                     // plate to the camera.
                     let target = if elbow {
-                        rx(lerp(lerp(-0.55, -1.25, fp_ready), -1.50, block_amt) + fp_bob_v * 0.6)
+                        rx(lerp(lerp(-0.55, -0.90, fp_ready), -1.20, block_amt) + fp_bob_v * 0.6)
                     } else {
                         e3(
-                            lerp(lerp(0.10, -1.05, fp_ready), -1.15, block_amt) + fp_breath + fp_bob_v,
+                            lerp(lerp(0.10, -0.50, fp_ready), -0.75, block_amt) + fp_breath + fp_bob_v,
                             -(fp_sway - fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.15 * fp_ready,
                             lerp(lerp(-0.12, -0.05, fp_ready), -0.02, block_amt),
                         )

--- a/src/player/block.rs
+++ b/src/player/block.rs
@@ -39,6 +39,13 @@ pub fn player_block(
         return;
     }
 
+    // Capture hook: `FOREST_ANIMTEST=block` stages the guard from `player::animtest`; yield here
+    // so this system (whose scheduling order vs. animtest is arbitrary) can't clear the staged
+    // flag on the frames where it runs second — the race made block captures a coin-flip.
+    if std::env::var("FOREST_ANIMTEST").is_ok_and(|v| v == "block" || v == "defend") {
+        return;
+    }
+
     // The block SFX is NOT fired here — raising the shield is silent. The knock plays only when
     // a hit is actually absorbed (see `health::apply_hero_damage`), matching `playerStore.ts`.
     let want = buttons.pressed(MouseButton::Right) && !hh.block_locked && hh.stamina > 0.0;

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -98,12 +98,23 @@ pub fn fp_debug_dump(
     fp: Res<camera::FirstPerson>,
     cam: Query<&GlobalTransform, With<Camera3d>>,
     parts: Query<(&HeroPart, &GlobalTransform)>,
+    hero_q: Query<(&Hero, &HeroHealth)>,
     mut next: Local<f32>,
 ) {
     if std::env::var("FOREST_FPDBG").is_err() || fp.blend < 0.9 || time.elapsed_secs() < *next {
         return;
     }
     *next = time.elapsed_secs() + 2.0;
+    if let Ok((hero, hh)) = hero_q.single() {
+        info!(
+            "FPDBG state threats={} combat_in={:.1} attacking={} blocking={} blend={:.2}",
+            hero.threats,
+            hero.combat_until - time.elapsed_secs(),
+            hero.attacking,
+            hh.blocking,
+            fp.blend
+        );
+    }
     let Ok(cam_gt) = cam.single() else { return };
     let inv = cam_gt.affine().inverse();
     for (p, gt) in &parts {

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -125,9 +125,13 @@ pub fn fp_debug_dump(
             let pos = inv.transform_point3(gt.translation());
             // A point 0.5 rig-units up the joint's local +Y — for the sword that's along the blade.
             let tip = inv.transform_point3(gt.transform_point(Vec3::Y * 0.5));
+            // Unit direction probes in camera space (-Z = forward): the blade line (+Y) and the
+            // face normal (+Z — the shield's face points at local +Z).
+            let up = (tip - pos).normalize_or_zero();
+            let face = (inv.transform_point3(gt.transform_point(Vec3::Z * 0.5)) - pos).normalize_or_zero();
             info!(
-                "FPDBG {:?} pos({:.2},{:.2},{:.2}) tip({:.2},{:.2},{:.2})",
-                p.joint, pos.x, pos.y, pos.z, tip.x, tip.y, tip.z
+                "FPDBG {:?} pos({:.2},{:.2},{:.2}) up({:.2},{:.2},{:.2}) face({:.2},{:.2},{:.2})",
+                p.joint, pos.x, pos.y, pos.z, up.x, up.y, up.z, face.x, face.y, face.z
             );
         }
     }


### PR DESCRIPTION
First person was broken two ways: the old translation-only shoulder
anchor-swap left the un-mirrored arm rotations sweeping attacks and the
block brace the wrong way on the wrong side, and the weapons sat raised
mid-frame at all times.

- Mirror the whole arm chains + sword/shield across the body plane in FP
  (translations flip X, rotations conjugate by the reflection), so every
  authored pose — attack sweeps, block, charge coil — reads correct-handed:
  sword bottom-right, shield bottom-left.
- New fp_ready weight: out of combat the arms settle into a calm low carry
  (gear barely peeking into the bottom frame corners); a nearby threat, a
  swing, a charge or a raised guard draws them up into the ready stance
  (fast raise, slow lower + the combat_until linger).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R5wZDWn34S1bDRrtcGpbtB