### PR TITLE
Landmark set-pieces overhaul: five animated biome monuments

### DIFF
--- a/.claude/skills/model-viewer/SKILL.md
+++ b/.claude/skills/model-viewer/SKILL.md
@@ -42,8 +42,19 @@ FOREST_VIEW=hero FOREST_SHOT=/tmp/hero.png \
 
 - `FOREST_VIEW=hero` (default / any unknown value) — the player knight in **rest pose**.
   `FOREST_EQUIP="weapon_id,armor_id"` swaps gear (e.g. `FOREST_EQUIP="sword_gold,gold_armor"`).
-- New models slot into the `match` in `spawn_model()` in `src/viewer.rs` — add an arm like
-  `"ork" => { … build + spawn … }` calling that model's builder against the creature material.
+- `FOREST_VIEW=ork:scout|berserker|shaman|torch`, `peasant:farmer|miner|guard|archer[:desert]`,
+  `animal:wolf|dog|horse|deer|camel|bear|polar`, `boss:forest|snow|rocky|desert|swamp`,
+  `knight2` — the other creature families (see `spawn_model()` in `src/viewer.rs`).
+- `FOREST_VIEW=landmark:mill|hut|spire|pyramid|stones` — a full biome landmark SET-PIECE
+  (`landmark_models.rs`): the merged base mesh on the white vertex-colour material **plus its
+  animated/glowing parts**, with the real `RuinsFxPlugin` animators running — a `FOREST_CLIP`
+  here shows the mill sails actually turning, the wisps orbiting, the glows pulsing. The camera
+  **auto-fits from the model's bounds** (no hand-tuned `FOREST_CAM` needed; it still overrides).
+  Biome aliases work (`landmark:forest`, `landmark:swamp`, …).
+- `FOREST_VIEW=trees` — the harvestable tree kinds + saguaro in a row.
+- New CREATURE models slot into the `match` in `spawn_model()`; new PROPS (bare vertex-coloured
+  meshes / LandmarkModels) go in the `landmark_model()` registry instead — props don't use the
+  creature material.
 
 ### Framing
 
@@ -67,9 +78,11 @@ FOREST_VIEW=hero FOREST_CLIP=/tmp/turn FOREST_CLIP_FRAMES=120 FOREST_CLIP_FPS=30
 
 ## Notes / limits
 
-- The viewer shows the model's **rest/spawn pose** (no animator runs here). To inspect the hero's
-  *animations*, use the in-game `FOREST_ANIMTEST=walk|block` staging hook with the normal
-  `FOREST_SHOT`/`FOREST_CLIP` (that path runs the real animator).
+- Character models show their **rest/spawn pose** by default; `FOREST_VIEW_ANIM=walk|run|block|
+  attack1-3|heavy|charge|dash|jump|bow|carry|sit|…` drives the REAL game animator on the
+  previewed hero/biped/quadruped (see `viewer.rs::anim_drive` + `biped_anim_drive` +
+  `quad_anim_drive` for each family's clip list). Landmark set-pieces always run their part
+  animators (sails/orbits/pulses) — no extra flag needed.
 - Lighting here is a neutral 3-point rig, NOT the game's atmosphere/IBL — geometry, proportions
   and per-surface texture (the `surf` codes) read true, but final in-game tone differs. For a
   lighting/atmosphere check, capture in the real game (`visual-debug-cloud`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,13 +128,15 @@ keeps a `FOREST_WAVE` assault topped up so a long siege actually films a battle.
 
 ```powershell
 # island/biome flyover (orbit "cx,cy,cz,radius,height,deg_per_sec")
-$env:FOREST_CLIP="target/clips/desert"; $env:FOREST_CLIP_ORBIT="60,1.5,-39,22,14,7"; $env:FOREST_TIME="0.24"; cargo run
+$env:FOREST_CLIP="target/clips/desert"; $env:FOREST_CLIP_ORBIT="71,1.5,-46,22,14,7"; $env:FOREST_TIME="0.24"; cargo run
 # sustained night siege
 $env:FOREST_CLIP="target/clips/siege"; $env:FOREST_WAVE="1"; $env:FOREST_DEFEND="1"; $env:FOREST_TOWN="1"; $env:FOREST_CAM="0,15,30,0,2,-8"; cargo run
 # stitch (per-clip mp4 + gif): ffmpeg -framerate 30 -i frame_%05d.png -pix_fmt yuv420p out.mp4
 ```
-Biome region centres (world XZ): snow (-69,-45) · desert (60,-39) · rock (66,4) · forest (-60,39) ·
-swamp (0,57). Clip knobs: `FOREST_CLIP_FRAMES` (150) · `FOREST_CLIP_FPS` (30) · `FOREST_CLIP_WARMUP` (30).
+Biome region centres (world XZ, at `MAP_SCALE` 2.6): snow (-82,-53) · desert (71,-46) · rock (78,5) ·
+forest (-71,46) · swamp (0,67). These scale with `MAP_SCALE` — code with a hand-authored world coord
+should route it through `worldmap::world22` (rescales 2.2-era coords) instead of baking the scale in.
+Clip knobs: `FOREST_CLIP_FRAMES` (150) · `FOREST_CLIP_FPS` (30) · `FOREST_CLIP_WARMUP` (30).
 
 Env hooks that stage a scene for a shot (combine with `FOREST_SHOT` **or** `FOREST_CLIP`), all read at startup:
 
@@ -151,7 +153,7 @@ Env hooks that stage a scene for a shot (combine with `FOREST_SHOT` **or** `FORE
 | `FOREST_ARCHERS=<n>` | retrain the whole standing militia as **longbow archers** at boot (`villagers.rs::stage_archers`); numeric `n ≥ 2` also raises `town.population` to `n` so a whole squad grows in to retrain. Pair with `FOREST_MUSTER`+`FOREST_HERO` to park a volleying rank anywhere, `FOREST_ORKLINE` for live targets, or `FOREST_WAVE` for a defended siege. (`FOREST_VIEW=peasant:archer` + `FOREST_VIEW_ANIM=bow` previews the model / draw-loose clip in the viewer.) |
 | `FOREST_CAGETEST="x,z"` | park the prisoner-cage rescue's before/after states side by side at a world XZ: a CLOSED cage of real seated peasant captives + an OPENED emptied one 5.5u further +X (`camps::spawn_cage`); both doors face +X, so frame from the east. Film the actual door-swing + walk-out with `FOREST_DEMO=rescue` + `FOREST_CLIP` instead |
 | `FOREST_BREACH=1` | auto-break the Hold gate on the first sim frame so a shot/clip films the woken garrison + the Warlord boss without a keypress (`ork_fortress::stage_breach`); pair with `FOREST_HERO`/`FOREST_CAM` inside the walls |
-| `FOREST_RIVAL=<n>` | instantly raise `n` buildings in the **rival stronghold** (the desert AI opponent, `rival.rs`) so a shot frames a grown rival town instead of waiting out its economy (default: fill the bailey); the rival keep/walls/garrison spawn regardless. Frame it at world ≈`(54, -72)` (NE desert) |
+| `FOREST_RIVAL=<n>` | instantly raise `n` buildings in the **rival stronghold** (the desert AI opponent, `rival.rs`) so a shot frames a grown rival town instead of waiting out its economy (default: fill the bailey); the rival keep/walls/garrison spawn regardless. Frame it at `rival::RIVAL_CENTRE` ≈ world `(78, -104)` at MAP_SCALE 2.6 (NE desert) |
 | `FOREST_TREELINE="x,z"` | park one of each `TreeKind` (broadleaf/birch/pine/poplar/autumn/dead/stump) in a 2× row at a world XZ (tree-model close-ups, `trees.rs`) |
 | `FOREST_FISHLINE="x,z"` | park one of each fish variety (silver/blue/gold) frozen mid-leap in a lit row at a world XZ (fish-model close-ups, `fish.rs`) |
 | `FOREST_MENU=1` | shoot the start screen |

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -56,6 +56,23 @@ Remove-Item Env:FOREST_FREEROAM,Env:FOREST_CAM,Env:FOREST_NOCULL -ErrorAction Si
 
 Read `main_opaque_pass_3d` from F2 in each — identical view, so the delta is purely the culling.
 
+## Terrain far-LOD (July 2026, with the MAP_SCALE 2.2 → 2.6 bump)
+
+The terrain sheets were the last full-res-everywhere geometry: chunked (48-tile blocks) and
+frustum-culled, but every on-screen chunk drew 1 quad/tile + terrace walls + marching-squares
+river banks regardless of distance. `worldmap::build_terrain_chunk_coarse` now builds a second,
+stride-4 **coarse drape** per chunk (~1/16th the vertices; no walls, no river cuts — the channel
+just dips under the always-drawn water plane; short perimeter skirts hide LOD seams). The two
+meshes swap via `VisibilityRange` at **110–136u** (camera→chunk-AABB, `use_aabb`) with a dithered
+crossfade — unlike the scatter culls this band is deliberately NON-abrupt: terrain is huge and a
+hard swap pops its silhouette; only the ring of chunks currently inside the band pays the
+per-fragment discard. The coarse mesh is `NotShadowCaster` (cascades end ~150 anyway).
+
+This is what pays for MAP_SCALE 2.6 (tiles ∝ scale², ~1.4× vs 2.2): beyond ~136u only ~1/16-density
+terrain draws, so the full-res vertex load now tracks the LOD radius, not the island size.
+`FOREST_NOCULL=1` disables the LOD together with the scatter culls (same A/B protocol above; the
+whole-island map-shot recipe already sets it).
+
 ## GPU pass breakdown (reference, from baseline F2)
 
 Captured on `igpu-strong-cpu`, boot-day, to know what each pass costs and what to target.

--- a/src/biome_forest.rs
+++ b/src/biome_forest.rs
@@ -13,7 +13,7 @@
 
 use bevy::prelude::*;
 
-use crate::biome::{Backdrop, Biome, BiomeConfig, BiomeEntity, GroundDetail, ParticleKind, PropClass};
+use crate::biome::{Backdrop, Biome, BiomeConfig, GroundDetail, ParticleKind, PropClass};
 use crate::groundcover as gc;
 use crate::palette::FOREST_GROUND;
 use crate::props;
@@ -222,29 +222,13 @@ pub fn config() -> BiomeConfig {
     }
 }
 
-/// Ruins + the decor charm.
+/// The decor charm (the old dead `landmarks()` set-piece pair was dropped in the July 2026
+/// landmark overhaul — the real set-pieces live in `landmark_models.rs` now).
+#[allow(dead_code)]
 pub fn landmarks(
     commands: &mut Commands,
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<StandardMaterial>,
 ) {
-    let mat = materials.add(StandardMaterial {
-        base_color: Color::WHITE,
-        perceptual_roughness: 0.9,
-        ..default()
-    });
-    commands.spawn((
-        Mesh3d(meshes.add(crate::ruins::build_trilithon_mesh())),
-        MeshMaterial3d(mat.clone()),
-        Transform::from_xyz(-11.0, 0.0, -12.0).with_rotation(Quat::from_rotation_y(0.4)),
-        BiomeEntity,
-    ));
-    commands.spawn((
-        Mesh3d(meshes.add(crate::ruins::build_giant_dead_tree_mesh())),
-        MeshMaterial3d(mat),
-        Transform::from_xyz(10.0, 0.0, -13.0),
-        BiomeEntity,
-    ));
-
     crate::decor::build(commands, meshes, materials);
 }

--- a/src/boss/mod.rs
+++ b/src/boss/mod.rs
@@ -74,14 +74,16 @@ fn melee_dmg(level: i32) -> f32 {
     BASE_MELEE * DMG_GROWTH.powi((level - 1).max(0))
 }
 
-/// Biome region centres (world XZ) — where each warden spawns + roams (see CLAUDE.md).
+/// Biome region centres — where each warden spawns + roams (see CLAUDE.md). Authored in
+/// MAP_SCALE-2.2-era world coords; `world22` rescales them to the current map size.
 fn region_center(b: Biome) -> Vec2 {
+    use crate::worldmap::world22;
     match b {
-        Biome::Snow => Vec2::new(-69.0, -45.0),
-        Biome::Desert => Vec2::new(60.0, -39.0),
-        Biome::Rocky => Vec2::new(66.0, 4.0),
-        Biome::Forest => Vec2::new(-60.0, 39.0),
-        Biome::Swamp => Vec2::new(0.0, 57.0),
+        Biome::Snow => world22(-69.0, -45.0),
+        Biome::Desert => world22(60.0, -39.0),
+        Biome::Rocky => world22(66.0, 4.0),
+        Biome::Forest => world22(-60.0, 39.0),
+        Biome::Swamp => world22(0.0, 57.0),
     }
 }
 

--- a/src/bridges.rs
+++ b/src/bridges.rs
@@ -120,16 +120,18 @@ fn spans() -> &'static [Span] {
     })
 }
 
-/// [`nearest_crossing`]'s ring-probe, for boardwalks over bog pools.
+/// [`nearest_crossing`]'s ring-probe, for boardwalks over bog pools. Same on-road gate: the
+/// snap must not carry the deck centre off the path it exists to serve.
 fn nearest_boardwalk(x: f32, z: f32) -> Option<Span> {
-    if let Some(s) = boardwalk_at(x, z) {
+    let on_road_walk = |s: &Span| crate::roads::on_road(s.cx, s.cz);
+    if let Some(s) = boardwalk_at(x, z).filter(on_road_walk) {
         return Some(s);
     }
     let mut r = 1.0;
     while r <= 4.0 {
         let mut a = 0.0;
         while a < std::f32::consts::TAU {
-            if let Some(s) = boardwalk_at(x + r * a.cos(), z + r * a.sin()) {
+            if let Some(s) = boardwalk_at(x + r * a.cos(), z + r * a.sin()).filter(on_road_walk) {
                 return Some(s);
             }
             a += std::f32::consts::FRAC_PI_4;
@@ -187,17 +189,21 @@ fn boardwalk_at(x: f32, z: f32) -> Option<Span> {
 
 /// A road's river-crossing midpoint can sit a touch off the channel's narrow axis (the centreline
 /// crosses on the diagonal), so probe at the point and then on a small expanding ring for the first
-/// spot that validates as a real deck. `None` if nothing nearby is a clean crossing (e.g. the road
-/// forded a too-wide span) — then that crossing simply gets no bridge.
+/// spot that validates as a real deck. The snap (probe ring + `water_run` recentring) can walk the
+/// deck centre off the road that justified it — reject those, or the "bridge only where a path
+/// crosses" invariant breaks (first bitten by the MAP_SCALE 2.6 bump). `None` if nothing nearby is
+/// a clean ON-ROAD crossing (e.g. the road forded a too-wide span) — then that crossing simply
+/// gets no bridge.
 fn nearest_crossing(x: f32, z: f32) -> Option<Span> {
-    if let Some(s) = crossing_at(x, z) {
+    let on_road_deck = |s: &Span| crate::roads::on_road(s.cx, s.cz);
+    if let Some(s) = crossing_at(x, z).filter(on_road_deck) {
         return Some(s);
     }
     let mut r = 1.0;
     while r <= 4.0 {
         let mut a = 0.0;
         while a < std::f32::consts::TAU {
-            if let Some(s) = crossing_at(x + r * a.cos(), z + r * a.sin()) {
+            if let Some(s) = crossing_at(x + r * a.cos(), z + r * a.sin()).filter(on_road_deck) {
                 return Some(s);
             }
             a += std::f32::consts::FRAC_PI_4;

--- a/src/chest.rs
+++ b/src/chest.rs
@@ -406,7 +406,8 @@ pub fn populate_chests(commands: &mut Commands, meshes: &mut Assets<Mesh>, mater
         placed += 1;
     }
 
-    // ── Deep-rim war hoards: one rare top-tier reward per biome, far past the safe zone. ──
+    // ── Deep-rim war hoards: one rare top-tier reward per biome, far past the safe zone.
+    // Authored at MAP_SCALE 2.2 (`world22` rescales to the current map size).
     const HOARD_SPOTS: [(f32, f32); 5] = [
         (-69.0, -45.0), // snow massif
         (60.0, -39.0),  // desert deep
@@ -414,7 +415,9 @@ pub fn populate_chests(commands: &mut Commands, meshes: &mut Assets<Mesh>, mater
         (-60.0, 39.0),  // forest heart
         (0.0, 57.0),    // swamp mire
     ];
-    for (i, &(ax, az)) in HOARD_SPOTS.iter().enumerate() {
+    for (i, &(ax22, az22)) in HOARD_SPOTS.iter().enumerate() {
+        let spot22 = worldmap::world22(ax22, az22);
+        let (ax, az) = (spot22.x, spot22.y);
         let mut spot = None;
         'search: for ring in 0..6 {
             let r = ring as f32 * 3.0;

--- a/src/landmark_models.rs
+++ b/src/landmark_models.rs
@@ -1,0 +1,963 @@
+//! The five signature biome landmarks, rebuilt as animated set-pieces (map-character overhaul,
+//! July 2026): the **Old Mill** (forest — sails that still turn), the **Witch's Hut** (swamp —
+//! green-lit windows, a bubbling cauldron, swaying charms), the **Frozen Spire** (snow — a
+//! glowing ice heart circled by levitating shards), the **Sunken Pyramid** (desert — a grand
+//! half-buried ziggurat crowned by a spinning sun-disc relic) and the **Standing Stones**
+//! (rocky — a walkable rune circle around a hovering keystone).
+//!
+//! Each builder returns a [`crate::ruins::LandmarkModel`]: ONE merged vertex-coloured base mesh
+//! (all the static geometry — batches against the scene's shared white material) plus a handful
+//! of [`crate::ruins::AnimPart`] children for whatever moves or glows. Authored in model-local
+//! units with the base at y=0; `ruins::populate_landmarks` scales ≈1.4–1.5× into the world.
+//! Sizes matter twice: `interaction::LANDMARK_DIST` (3.6u from the root) must stay reachable
+//! past the blockers, and the whole silhouette should break its biome's treeline — these are
+//! the island's skyline flags. Preview any of them with `FOREST_VIEW=landmark:mill|hut|spire|
+//! pyramid|stones` (the viewer runs the same FX systems, so the motion reads there too).
+
+use bevy::prelude::*;
+use std::f32::consts::{FRAC_PI_2, TAU};
+
+use crate::palette::{lin, lin_scaled};
+use crate::ruins::{
+    ball, box_at, box_rot, chunk_at, cone_at, cyl, cyl_rot, facet_at, facet_tinted, flat_shaded,
+    flat_stone, frustum, hash3, lichen_at, limb, merged, mottle, slab_at, slab_ground, tinted, yv,
+    AnimPart, Fx, Glow, LandmarkModel,
+};
+
+/// A tinted axis-aligned box (the yard-dressing workhorse).
+fn tbox(x: f32, y: f32, z: f32, center: Vec3, c: u32) -> Mesh {
+    tinted(box_at(x, y, z, center), lin(c))
+}
+
+/// A faceted icosphere `Mesh` (unbuilt — chain `scaled_by`/`rotated_by`/`translated_by`).
+fn ico(r: f32, detail: u32) -> Mesh {
+    Sphere::new(r).mesh().ico(detail).expect("ico detail in range")
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  THE OLD MILL — forest. A weathered smock windmill: fieldstone footing, tapered
+//  eight-sided timber tower, thatched cap, and four lattice sails that STILL TURN
+//  though no miller has climbed the hill in years. One sail's canvas hangs torn;
+//  ivy takes the shaded side; a millstone leans by the door; a candle burns.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const MILL_STONE: u32 = 0x8a8074; // fieldstone footing
+const MILL_STONE_DK: u32 = 0x6b655c;
+const MILL_TIMBER: u32 = 0x6e5a42; // weathered oak boards
+const MILL_TIMBER_DK: u32 = 0x52422f; // weather bands / lattice
+const MILL_TIMBER_XDK: u32 = 0x3a2e20; // door frame / spars / iron-dark wood
+const MILL_THATCH: u32 = 0x96713f; // straw cap
+const MILL_THATCH_DK: u32 = 0x7a5a30;
+const MILL_CANVAS: u32 = 0xcfc2a2; // sailcloth
+const MILL_CANVAS_DK: u32 = 0xb0a284; // the torn, mildewed panel
+const MILL_IVY: u32 = 0x5a7a3a;
+const MILL_IVY_DK: u32 = 0x47632c;
+const MILL_SACK: u32 = 0xb59a6a;
+const MILL_DOOR: u32 = 0x241b10; // dark doorway recess
+
+/// Sail hub mount (model-local): on the cap's +Z face, high enough that the lowest
+/// sail tip clears a rider's head.
+const MILL_HUB: Vec3 = Vec3::new(0.0, 4.75, 1.58);
+const SAIL_LEN: f32 = 2.3;
+
+pub fn old_mill() -> LandmarkModel {
+    let mut parts: Vec<Mesh> = Vec::new();
+
+    // ── Fieldstone footing: a faceted drum ringed by a rough boulder course.
+    parts.push(frustum(1.75, 1.5, 0.6, yv(0.3), 10, MILL_STONE));
+    for i in 0..9 {
+        let a = i as f32 * TAU / 9.0 + 0.23;
+        let r = 0.24 + hash3(a, 1.0, 0.0) * 0.14;
+        parts.push(chunk_at(
+            r,
+            Vec3::new(a.cos() * 1.66, r * 0.6, a.sin() * 1.66),
+            Vec3::new(1.15, 0.8, 1.0),
+            a,
+            0.1,
+            0,
+            if i % 2 == 0 { MILL_STONE } else { MILL_STONE_DK },
+        ));
+    }
+
+    // ── Smock tower: tapered eight-sided timber body + darker weather bands.
+    parts.push(frustum(1.42, 0.95, 3.6, yv(2.4), 8, MILL_TIMBER));
+    for &(y, r) in &[(1.55_f32, 1.32_f32), (2.55, 1.2), (3.55, 1.07)] {
+        parts.push(frustum(r + 0.045, r - 0.02, 0.12, yv(y), 8, MILL_TIMBER_DK));
+    }
+    // (No corner staves — a first pass had them, but leaning limbs off a tapered shell read
+    // as stray scaffold poles; the weather-band frustums carry the "boarded" look alone.)
+
+    // ── Door (+Z face): dark recess, heavy jambs + lintel, a stone step.
+    parts.push(tbox(0.62, 1.15, 0.16, Vec3::new(0.0, 0.85, 1.52), MILL_DOOR));
+    parts.push(box_rot(0.14, 1.25, 0.2, Vec3::new(-0.42, 0.88, 1.5), Quat::from_rotation_z(0.04), MILL_TIMBER_XDK));
+    parts.push(box_rot(0.14, 1.25, 0.2, Vec3::new(0.42, 0.88, 1.5), Quat::from_rotation_z(-0.04), MILL_TIMBER_XDK));
+    parts.push(box_rot(0.95, 0.16, 0.24, Vec3::new(0.0, 1.5, 1.48), Quat::from_rotation_z(0.03), MILL_TIMBER_XDK));
+    parts.push(flat_stone(0.85, 0.14, 0.55, Vec3::new(0.0, 0.07, 1.85), 0.06, MILL_STONE_DK));
+    // A shuttered dark window round the -X side.
+    parts.push(box_rot(0.16, 0.4, 0.34, Vec3::new(-1.22, 2.5, 0.3), Quat::from_rotation_y(0.25), MILL_DOOR));
+
+    // ── Thatch cap: flared skirt + dome + finial knob (overhangs the tower top).
+    parts.push(frustum(1.22, 0.78, 0.55, yv(4.48), 8, MILL_THATCH));
+    parts.push(frustum(0.78, 0.3, 0.5, yv(5.0), 8, MILL_THATCH_DK));
+    parts.push(cone_at(0.32, 0.42, yv(5.46), 8, MILL_THATCH));
+    parts.push(ball(0.09, yv(5.62), 1.0, MILL_TIMBER_XDK));
+    parts.push(frustum(1.24, 1.1, 0.07, yv(4.24), 8, MILL_THATCH_DK));
+
+    // ── Ivy: splotches climbing the shaded (-Z/-X) quarter, thickest at the foot.
+    for &(x, y, z, r, c) in &[
+        (-0.95_f32, 0.55_f32, -1.15_f32, 0.42_f32, MILL_IVY),
+        (-1.25, 1.1, -0.65, 0.34, MILL_IVY_DK),
+        (-1.05, 1.75, -0.85, 0.3, MILL_IVY),
+        (-1.2, 2.4, -0.35, 0.26, MILL_IVY_DK),
+        (-0.85, 3.0, -0.75, 0.22, MILL_IVY),
+        (-0.55, 0.4, -1.45, 0.3, MILL_IVY_DK),
+    ] {
+        // Pressed onto the tapering wall: pull each splotch to the local wall radius.
+        let rad = (x * x + z * z).sqrt();
+        let wall = 1.44 - y * 0.13;
+        let (nx, nz) = (x / rad * wall, z / rad * wall);
+        parts.push(lichen_at(r, Vec3::new(nx, y, nz), c));
+        parts.push(facet_at(r * 0.6, Vec3::new(nx, y + r * 0.3, nz), 0.5, c));
+    }
+
+    // ── Yard: leaning millstone, grain sacks, a broken cartwheel, path flagstones.
+    let stone_rot = Quat::from_rotation_y(0.5) * Quat::from_rotation_x(1.32);
+    parts.push(cyl_rot(0.58, 0.16, 12, Vec3::new(1.62, 0.56, 0.95), stone_rot, MILL_STONE));
+    parts.push(cyl_rot(0.13, 0.18, 6, Vec3::new(1.62, 0.56, 0.95), stone_rot, MILL_STONE_DK));
+    for &(x, z, r) in &[(0.95_f32, 1.7_f32, 0.3_f32), (1.3, 1.45, 0.24), (1.05, 1.35, 0.2)] {
+        parts.push(ball(r, Vec3::new(x, r * 0.72, z), 0.78, MILL_SACK));
+        parts.push(facet_tinted(r * 0.4, Vec3::new(x, r * 1.32, z), 0.5, lin_scaled(MILL_SACK, 0.82)));
+    }
+    let wheel_rot = Quat::from_rotation_y(-0.4) * Quat::from_rotation_x(1.25);
+    parts.push(tinted(
+        Torus { minor_radius: 0.05, major_radius: 0.42 }
+            .mesh()
+            .minor_resolution(4)
+            .major_resolution(10)
+            .build()
+            .rotated_by(wheel_rot)
+            .translated_by(Vec3::new(-1.55, 0.42, 1.05)),
+        lin(MILL_TIMBER_DK),
+    ));
+    parts.push(box_rot(0.78, 0.055, 0.055, Vec3::new(-1.55, 0.42, 1.05), wheel_rot, MILL_TIMBER_XDK));
+    parts.push(box_rot(0.055, 0.055, 0.78, Vec3::new(-1.55, 0.42, 1.05), wheel_rot, MILL_TIMBER_XDK));
+    for (i, &(x, z)) in [(0.0_f32, 2.5_f32), (0.35, 3.1), (-0.25, 3.65)].iter().enumerate() {
+        parts.push(facet_at(0.34 - i as f32 * 0.03, Vec3::new(x, 0.045, z), 0.16, MILL_STONE));
+    }
+
+    let base = mottle(flat_shaded(merged(parts)), 0.42);
+
+    // ── Animated parts ──────────────────────────────────────────────────────────
+
+    // The sail cross: hub boss + four lattice arms in the part-local XY plane, spinning
+    // about local +Z. Mounted on the cap's +Z face, canted back ~8° like a real smock mill.
+    let mut sail: Vec<Mesh> = Vec::new();
+    sail.push(tinted(
+        Cylinder::new(0.17, 0.5).mesh().resolution(8).build().rotated_by(Quat::from_rotation_x(FRAC_PI_2)),
+        lin(MILL_TIMBER_XDK),
+    ));
+    sail.push(ball(0.12, Vec3::new(0.0, 0.0, 0.26), 1.0, MILL_TIMBER_DK));
+    for k in 0..4 {
+        let rot = Quat::from_rotation_z(k as f32 * FRAC_PI_2);
+        let torn = k == 2; // one sail's canvas hangs short — the mill is OLD.
+        sail.push(tinted(box_at(0.09, SAIL_LEN, 0.07, yv(SAIL_LEN * 0.5)).rotated_by(rot), lin(MILL_TIMBER_XDK)));
+        // Lattice crossbars along the outer half.
+        let bars = if torn { 2 } else { 4 };
+        for b in 0..bars {
+            let y = 0.95 + b as f32 * 0.42;
+            sail.push(tinted(
+                box_at(0.62, 0.055, 0.035, Vec3::new(0.115, y, 0.0)).rotated_by(rot),
+                lin(MILL_TIMBER_DK),
+            ));
+        }
+        // Canvas panel to one side of the spar (short + mildewed on the torn arm).
+        let (len, cc) = if torn { (0.72, MILL_CANVAS_DK) } else { (1.62, MILL_CANVAS) };
+        sail.push(tinted(
+            box_at(0.5, len, 0.028, Vec3::new(0.34, SAIL_LEN - 0.12 - len * 0.5, 0.0)).rotated_by(rot),
+            lin(cc),
+        ));
+        // (No loose "torn flap" — folding a panel off-plane read as a detached floating card;
+        // the short mildewed panel + missing crossbars carry the neglect on their own.)
+    }
+    let sail_mesh = mottle(flat_shaded(merged(sail)), 0.3);
+    // Gentle 6° back-cant; the hub stands proud of the cap so the cross never clips the thatch.
+    let sail_xf = Transform::from_translation(MILL_HUB).with_rotation(Quat::from_rotation_x(0.1));
+
+    // Weathervane: a little iron arrow that hunts back and forth in the wind.
+    let vane = flat_shaded(merged(vec![
+        tbox(0.03, 0.42, 0.03, yv(0.21), MILL_TIMBER_XDK),
+        tbox(0.5, 0.05, 0.03, yv(0.42), MILL_TIMBER_XDK),
+        tinted(
+            Cone { radius: 0.055, height: 0.16 }
+                .mesh()
+                .resolution(4)
+                .build()
+                .rotated_by(Quat::from_rotation_z(-FRAC_PI_2))
+                .translated_by(Vec3::new(0.3, 0.42, 0.0)),
+            lin(MILL_TIMBER_XDK),
+        ),
+        tbox(0.12, 0.16, 0.02, Vec3::new(-0.24, 0.42, 0.0), MILL_TIMBER_DK),
+    ]));
+
+    // The lit window: the miller's ghost keeps a candle burning. Gentle pulse.
+    let window = flat_shaded(tbox(0.26, 0.34, 0.1, Vec3::ZERO, 0xffffff));
+
+    LandmarkModel {
+        base,
+        parts: vec![
+            AnimPart::solid(sail_mesh, sail_xf, Fx::Spin { axis: Vec3::Z, rate: 0.42 }),
+            AnimPart::solid(
+                vane,
+                Transform::from_xyz(0.0, 5.66, 0.0),
+                Fx::Sway { axis: Vec3::Y, amp: 0.55, freq: 0.31, phase: 0.0 },
+            ),
+            AnimPart::glowing(
+                // Pressed into the wall shell (radius ≈1.04 at this height) so it reads as a
+                // casement, not a floating pane.
+                window,
+                Transform::from_xyz(0.57, 3.1, 0.88).with_rotation(Quat::from_rotation_y(0.57)),
+                Fx::None,
+                Glow { color: Color::srgb_u8(0xff, 0xb4, 0x5e), strength: 4.0, pulse: Some((1.1, 0.28, 0.0)) },
+            ),
+        ],
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  THE WITCH'S HUT — swamp. A crooked stilt-cabin with a sagging moss roof, green
+//  witch-light in the windows, smoke curling off the chimney, charms swaying from
+//  the eaves and a cauldron bubbling in the yard, circled by wisps.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const HUT_STILT: u32 = 0x413830; // sodden stilt wood
+const HUT_PLANK: u32 = 0x5d4f3e; // wall boards
+const HUT_PLANK_DK: u32 = 0x453a2c;
+const HUT_ROOF: u32 = 0x4f5a36; // moss-eaten shingles
+const HUT_ROOF_DK: u32 = 0x3c4629;
+const HUT_MOSS: u32 = 0x6a7b3c;
+const HUT_STONE: u32 = 0x5c5a52; // chimney / fire-ring stone
+const HUT_BONE: u32 = 0xd8cfb8; // charms + the yard skull
+const HUT_POT: u32 = 0x232326; // cauldron iron
+const HUT_SHROOM: u32 = 0x9a4a68; // bog-violet toadstools
+const HUT_SMOKE: u32 = 0x9a978e;
+const WITCH_GREEN: Color = Color::srgb(0.49, 1.0, 0.6);
+
+/// Cauldron yard spot (model-local) — the wisps orbit above it.
+const CAULDRON: Vec3 = Vec3::new(1.75, 0.0, 1.3);
+
+pub fn witch_hut() -> LandmarkModel {
+    let mut parts: Vec<Mesh> = Vec::new();
+
+    // ── Stilts: six crooked posts + two diagonal braces, feet splayed in the mire.
+    let feet: [(f32, f32, f32, f32); 6] = [
+        (-1.0, -0.85, 0.1, 0.3),
+        (0.95, -0.9, -0.08, 1.2),
+        (-1.05, 0.8, 0.12, 2.4),
+        (1.0, 0.85, -0.1, 3.6),
+        (0.0, -0.95, 0.06, 4.2),
+        (0.05, 0.9, -0.07, 5.1),
+    ];
+    for &(x, z, tilt, yaw) in &feet {
+        parts.push(tinted(limb(0.105, 1.35, 5, tilt, yaw, Vec3::new(x, -0.05, z)), lin(HUT_STILT)));
+        parts.push(facet_at(0.16, Vec3::new(x, 0.05, z), 0.4, HUT_PLANK_DK));
+    }
+    // Cross-braces actually spanning stilt to stilt (a first pass had free-floating poles).
+    parts.push(box_rot(2.2, 0.07, 0.07, Vec3::new(0.0, 0.62, -0.88), Quat::from_rotation_z(0.46), HUT_STILT));
+    parts.push(box_rot(0.07, 0.07, 1.9, Vec3::new(0.98, 0.62, 0.0), Quat::from_rotation_x(-0.44), HUT_STILT));
+
+    // ── Platform: plank deck with a slight drunken cant; a rickety ladder up the front.
+    let cant = Quat::from_rotation_z(0.035) * Quat::from_rotation_x(-0.02);
+    parts.push(box_rot(2.6, 0.13, 2.2, Vec3::new(0.0, 1.32, 0.0), cant, HUT_PLANK_DK));
+    for i in 0..5 {
+        parts.push(box_rot(
+            2.5,
+            0.035,
+            0.34,
+            Vec3::new(0.0, 1.41, -0.85 + i as f32 * 0.42),
+            cant,
+            if i % 2 == 0 { HUT_PLANK } else { HUT_PLANK_DK },
+        ));
+    }
+    for &x in &[-0.28_f32, 0.28] {
+        parts.push(tinted(limb(0.045, 1.55, 4, 0.32, 0.0, Vec3::new(x, 0.0, 1.55)), lin(HUT_STILT)));
+    }
+    for r in 0..4 {
+        let t = 0.25 + r as f32 * 0.35;
+        parts.push(tbox(0.62, 0.05, 0.07, Vec3::new(0.0, t, 1.55 - t * 0.33), HUT_PLANK));
+    }
+
+    // ── Cabin: a crooked box, corner posts, and a door that never opens.
+    let lean = Quat::from_rotation_z(0.05) * Quat::from_rotation_x(-0.025);
+    parts.push(box_rot(1.9, 1.5, 1.6, Vec3::new(-0.05, 2.15, -0.1), lean, HUT_PLANK));
+    for i in 0..4 {
+        parts.push(box_rot(
+            1.94,
+            0.045,
+            1.64,
+            Vec3::new(-0.05, 1.62 + i as f32 * 0.38, -0.1),
+            lean,
+            HUT_PLANK_DK,
+        ));
+    }
+    for &(x, z) in &[(-1.0_f32, 0.68_f32), (0.9, 0.68), (-1.0, -0.88), (0.9, -0.88)] {
+        parts.push(box_rot(0.14, 1.56, 0.14, Vec3::new(x, 2.15, z), lean, HUT_PLANK_DK));
+    }
+    // Door (+Z) with a crooked lintel and a bone fetish nailed above it.
+    parts.push(box_rot(0.5, 0.95, 0.1, Vec3::new(0.32, 1.95, 0.72), lean, 0x1c1712));
+    parts.push(box_rot(0.6, 0.1, 0.12, Vec3::new(0.32, 2.46, 0.72), lean * Quat::from_rotation_z(0.08), HUT_STILT));
+    parts.push(tbox(0.05, 0.22, 0.05, Vec3::new(0.32, 2.62, 0.78), HUT_BONE));
+
+    // ── Roof: two sagging oversized slabs, moss saddles, a crooked stone chimney.
+    parts.push(box_rot(1.55, 0.09, 2.35, Vec3::new(-0.72, 3.28, -0.1), Quat::from_rotation_z(0.62), HUT_ROOF));
+    parts.push(box_rot(1.5, 0.09, 2.3, Vec3::new(0.58, 3.32, -0.1), Quat::from_rotation_z(-0.55), HUT_ROOF_DK));
+    parts.push(box_rot(0.22, 0.14, 2.4, Vec3::new(-0.06, 3.66, -0.1), Quat::from_rotation_z(0.03), HUT_ROOF_DK));
+    for &(x, y, z, r) in &[
+        (-0.9_f32, 3.15_f32, 0.5_f32, 0.3_f32),
+        (0.75, 3.2, -0.6, 0.26),
+        (-0.5, 3.45, -0.7, 0.22),
+        (0.2, 3.6, 0.3, 0.2),
+    ] {
+        parts.push(ball(r, Vec3::new(x, y, z), 0.45, HUT_MOSS));
+    }
+    for c in 0..4 {
+        let t = c as f32;
+        parts.push(box_rot(
+            0.46 - t * 0.05,
+            0.34,
+            0.46 - t * 0.05,
+            Vec3::new(-0.78 + t * 0.05, 3.0 + t * 0.34, -0.72),
+            Quat::from_rotation_y(t * 0.22) * Quat::from_rotation_z(0.04),
+            if c % 2 == 0 { HUT_STONE } else { HUT_PLANK_DK },
+        ));
+    }
+
+    // ── Yard: cauldron on a stone fire-ring, skull stake, toadstools, firewood.
+    parts.push(ball(0.42, CAULDRON + yv(0.52), 0.85, HUT_POT));
+    parts.push(frustum(0.34, 0.42, 0.14, CAULDRON + yv(0.86), 8, HUT_POT));
+    for i in 0..3 {
+        let a = i as f32 * TAU / 3.0 + 0.5;
+        parts.push(tinted(
+            limb(0.035, 0.42, 4, 0.5, a, CAULDRON + Vec3::new(a.cos() * 0.3, 0.0, a.sin() * 0.3)),
+            lin(HUT_STILT),
+        ));
+    }
+    for i in 0..6 {
+        let a = i as f32 * TAU / 6.0 + 0.2;
+        parts.push(facet_at(0.13, CAULDRON + Vec3::new(a.cos() * 0.5, 0.05, a.sin() * 0.5), 0.5, HUT_STONE));
+    }
+    parts.push(tinted(limb(0.04, 0.95, 4, 0.08, 0.0, Vec3::new(-1.7, 0.0, 1.5)), lin(HUT_STILT)));
+    parts.push(ball(0.14, Vec3::new(-1.7, 1.02, 1.52), 0.9, HUT_BONE));
+    parts.push(tbox(0.1, 0.08, 0.1, Vec3::new(-1.7, 0.93, 1.6), HUT_BONE));
+    for &(x, z, s) in &[(-1.35_f32, -0.5_f32, 1.0_f32), (1.3, 0.4, 0.75), (-0.6, 1.25, 0.6)] {
+        for k in 0..3 {
+            let a = k as f32 * 2.1 + x;
+            let (mx, mz) = (x + a.cos() * 0.14 * s, z + a.sin() * 0.14 * s);
+            let h = (0.14 + k as f32 * 0.06) * s;
+            parts.push(cyl(0.042 * s, h, Vec3::new(mx, h * 0.5, mz), 5, HUT_BONE));
+            parts.push(ball(0.095 * s, Vec3::new(mx, h + 0.02, mz), 0.55, HUT_SHROOM));
+        }
+    }
+    for k in 0..4 {
+        parts.push(cyl_rot(
+            0.07,
+            0.75,
+            5,
+            Vec3::new(0.55 + (k % 2) as f32 * 0.16, 0.08 + (k / 2) as f32 * 0.13, -0.6),
+            Quat::from_rotation_z(FRAC_PI_2) * Quat::from_rotation_y(0.15 * k as f32),
+            HUT_STILT,
+        ));
+    }
+    // The raven that is definitely just a raven.
+    parts.push(ball(0.085, Vec3::new(-0.06, 3.78, 0.75), 0.9, 0x14161a));
+    parts.push(ball(0.06, Vec3::new(-0.06, 3.87, 0.82), 0.9, 0x14161a));
+    parts.push(cone_at(0.02, 0.07, Vec3::new(-0.06, 3.87, 0.9), 4, 0x8a8a3a));
+
+    let base = mottle(flat_shaded(merged(parts)), 0.46);
+
+    // ── Animated parts ──────────────────────────────────────────────────────────
+    let mut anim: Vec<AnimPart> = Vec::new();
+
+    // Two green-lit windows (front + -X side), breathing out of phase.
+    let win = |w: f32, h: f32| flat_shaded(tbox(w, h, 0.1, Vec3::ZERO, 0xffffff));
+    anim.push(AnimPart::glowing(
+        win(0.3, 0.3),
+        Transform::from_xyz(-0.55, 2.3, 0.71).with_rotation(Quat::from_rotation_z(0.05)),
+        Fx::None,
+        Glow { color: WITCH_GREEN, strength: 5.0, pulse: Some((0.7, 0.35, 0.0)) },
+    ));
+    anim.push(AnimPart::glowing(
+        win(0.26, 0.34),
+        Transform::from_xyz(-1.06, 2.2, -0.25).with_rotation(Quat::from_rotation_y(FRAC_PI_2)),
+        Fx::None,
+        Glow { color: WITCH_GREEN, strength: 5.0, pulse: Some((0.55, 0.35, 1.9)) },
+    ));
+
+    // The brew surface — a glowing disc riding just under the cauldron rim.
+    anim.push(AnimPart::glowing(
+        flat_shaded(tinted(Cylinder::new(0.31, 0.05).mesh().resolution(10).build(), lin(0xffffff))),
+        Transform::from_translation(CAULDRON + yv(0.94)),
+        Fx::None,
+        Glow { color: WITCH_GREEN, strength: 7.0, pulse: Some((1.6, 0.3, 0.7)) },
+    ));
+    // Three wisps circling above the brew.
+    for (i, &(r, h, rate)) in [(0.3_f32, 1.15_f32, 1.1_f32), (0.42, 1.4, -0.8), (0.24, 1.65, 1.5)].iter().enumerate() {
+        anim.push(AnimPart::glowing(
+            flat_shaded(tinted(ico(0.05 + i as f32 * 0.012, 0), lin(0xffffff))),
+            Transform::from_translation(CAULDRON + Vec3::new(r, h, 0.0)),
+            Fx::Orbit {
+                centre: CAULDRON + yv(h),
+                rate,
+                bob_amp: 0.1,
+                bob_freq: 1.3 + i as f32 * 0.5,
+                phase: i as f32 * 2.1,
+            },
+            Glow { color: Color::srgb(0.62, 1.0, 0.69), strength: 8.0, pulse: None },
+        ));
+    }
+
+    // Charms swinging from the eaves: bone-and-twig fetishes on cords.
+    let charm = |long: f32| {
+        flat_shaded(merged(vec![
+            tbox(0.022, long, 0.022, yv(-long * 0.5), HUT_STILT),
+            tbox(0.05, 0.16, 0.05, yv(-long - 0.06), HUT_BONE),
+            tbox(0.14, 0.04, 0.04, yv(-long + 0.08), HUT_BONE),
+        ]))
+    };
+    for (i, &(x, z, long)) in
+        [(-1.35_f32, 0.95_f32, 0.5_f32), (1.25, 0.9, 0.38), (1.3, -1.0, 0.55), (-0.2, 1.05, 0.42)].iter().enumerate()
+    {
+        anim.push(AnimPart::solid(
+            charm(long),
+            Transform::from_xyz(x, 3.05, z),
+            Fx::Sway {
+                axis: if i % 2 == 0 { Vec3::X } else { Vec3::Z },
+                amp: 0.16,
+                freq: 1.1 + i as f32 * 0.23,
+                phase: i as f32 * 1.4,
+            },
+        ));
+    }
+    // The door lantern: an amber counterpoint to all that green.
+    anim.push(AnimPart::glowing(
+        flat_shaded(merged(vec![
+            tbox(0.02, 0.18, 0.02, yv(-0.09), HUT_STILT),
+            tbox(0.11, 0.15, 0.11, yv(-0.26), 0xffffff),
+        ])),
+        Transform::from_xyz(0.78, 2.6, 0.78),
+        Fx::Sway { axis: Vec3::Z, amp: 0.12, freq: 1.5, phase: 0.6 },
+        Glow { color: Color::srgb_u8(0xff, 0xb4, 0x5e), strength: 4.0, pulse: Some((1.3, 0.25, 0.3)) },
+    ));
+
+    // Chimney smoke: translucent puffs looping up out of the flue mouth — phases pack them
+    // close so the column reads connected, not as beads on a string.
+    for k in 0..4 {
+        let mut m = AnimPart::solid(
+            flat_shaded(tinted(ico(0.21, 0).scaled_by(Vec3::new(1.0, 0.78, 1.0)), lin(HUT_SMOKE))),
+            Transform::from_xyz(-0.66, 4.02, -0.72),
+            Fx::Rise { rate: 0.36, range: 1.55, drift: Vec2::new(0.34, 0.16), grow: 1.2, phase: k as f32 * 0.39 },
+        );
+        m.alpha = 0.32;
+        anim.push(m);
+    }
+
+    LandmarkModel { base, parts: anim }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  THE FROZEN SPIRE — snow. A great shard of ancient ice erupting from a frost
+//  tor inside a ring of burst floe-slabs; a cyan heart pulses in its throat and
+//  six splinters of ice levitate in slow interleaved orbits around it.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const ICE_BODY: u32 = 0xa9d2f0;
+const ICE_RIME: u32 = 0xc4e3f6;
+const ICE_PALE: u32 = 0xe6f4fc;
+const ICE_DEEP: u32 = 0x5f93cc;
+const ICE_ABYSS: u32 = 0x3c6ca8; // shadowed core faces
+const FROST_ROCK: u32 = 0x66727f;
+const SNOW_CAP: u32 = 0xe8f2fa;
+const SNOW_SHADE: u32 = 0xc8dff0;
+
+pub fn frozen_spire() -> LandmarkModel {
+    let mut parts: Vec<Mesh> = Vec::new();
+
+    // ── Frost tor footing + snow banked against it.
+    parts.push(chunk_at(0.55, yv(0.28), Vec3::new(1.5, 0.75, 1.3), 0.2, 0.08, 1, FROST_ROCK));
+    parts.push(chunk_at(0.4, Vec3::new(0.55, 0.5, -0.3), Vec3::new(1.2, 0.9, 1.0), 0.9, -0.15, 0, FROST_ROCK));
+    parts.push(chunk_at(0.34, Vec3::new(-0.6, 0.42, 0.35), Vec3::new(1.1, 0.85, 1.05), -0.6, 0.12, 0, FROST_ROCK));
+    for &(x, z, r) in &[(0.85_f32, 0.55_f32, 0.5_f32), (-0.8, -0.5, 0.42), (0.1, -0.85, 0.38), (-0.45, 0.9, 0.4)] {
+        parts.push(ball(r, Vec3::new(x, r * 0.35, z), 0.4, SNOW_CAP));
+    }
+    parts.push(ball(0.62, yv(0.5), 0.3, SNOW_SHADE));
+
+    // ── The spire: a BLADE-like central shard (asymmetric cross-section, yawed) + flanking
+    // splinters, all one crystal. A tilted tip splinter + mid-height protrusions break the
+    // smooth "rocket" outline into something wind-carved.
+    parts.push(chunk_at(0.62, yv(2.9), Vec3::new(1.15, 4.6, 0.72), 0.45, 0.03, 1, ICE_BODY));
+    parts.push(chunk_at(0.26, Vec3::new(-0.1, 5.5, -0.08), Vec3::new(0.7, 2.2, 0.6), 1.1, -0.16, 0, ICE_PALE));
+    parts.push(chunk_at(0.34, Vec3::new(0.42, 3.9, -0.28), Vec3::new(1.0, 1.6, 0.8), 0.9, 0.22, 0, ICE_BODY));
+    parts.push(chunk_at(0.3, Vec3::new(-0.5, 3.1, 0.3), Vec3::new(1.0, 1.4, 0.85), -0.5, -0.18, 0, ICE_DEEP));
+    // A darker core shard inside/behind reads as depth through the flat shading.
+    parts.push(chunk_at(0.5, Vec3::new(-0.14, 2.4, -0.12), Vec3::new(0.9, 3.9, 0.8), 0.8, -0.04, 0, ICE_ABYSS));
+    // Rime sliver hugging the sunward edge.
+    parts.push(chunk_at(0.3, Vec3::new(0.4, 3.3, 0.22), Vec3::new(0.55, 3.4, 0.5), 0.35, 0.05, 0, ICE_PALE));
+    parts.push(chunk_at(0.42, Vec3::new(0.95, 1.7, -0.4), Vec3::new(0.85, 2.6, 0.75), 0.5, -0.14, 1, ICE_DEEP));
+    parts.push(chunk_at(0.36, Vec3::new(-0.9, 1.35, 0.5), Vec3::new(0.8, 2.1, 0.7), -0.7, 0.12, 1, ICE_BODY));
+    parts.push(chunk_at(0.22, Vec3::new(-0.55, 0.9, -0.75), Vec3::new(0.75, 1.5, 0.7), 1.6, 0.08, 0, ICE_RIME));
+
+    // ── Burst ring: floe slabs heaved up and outward, as if the spire punched through.
+    for i in 0..8 {
+        let a = i as f32 * TAU / 8.0 + 0.27;
+        let r = 1.75 + hash3(a, 0.0, 1.0) * 0.5;
+        let (sx, sz) = (a.cos() * r, a.sin() * r);
+        let h = 0.5 + hash3(a, 2.0, 0.0) * 0.55;
+        let c = [ICE_BODY, ICE_DEEP, ICE_RIME][i % 3];
+        parts.push(slab_at(
+            0.42,
+            h,
+            0.16,
+            Vec3::new(sx, slab_ground(0.42, h, 0.55) - 0.15, sz),
+            a + FRAC_PI_2,
+            0.55,
+            c,
+        ));
+    }
+    // Shed chips + a couple of leaning icicle spears in the snow.
+    for &(x, z, r) in &[(1.3_f32, 1.15_f32, 0.12_f32), (-1.2, -1.05, 0.1), (1.5, -0.8, 0.09), (-1.5, 0.7, 0.11)] {
+        parts.push(facet_at(r, Vec3::new(x, r * 0.5, z), 0.6, ICE_PALE));
+    }
+    for &(x, z, h, t) in &[(0.9_f32, -1.3_f32, 0.75_f32, 0.35_f32), (-1.05, 1.25, 0.6, -0.3)] {
+        parts.push(tinted(
+            Cone { radius: 0.09, height: h }
+                .mesh()
+                .resolution(5)
+                .build()
+                .rotated_by(Quat::from_rotation_z(t))
+                .translated_by(Vec3::new(x, h * 0.4, z)),
+            lin(ICE_RIME),
+        ));
+    }
+
+    let base = mottle(flat_shaded(merged(parts)), 0.3);
+
+    // ── Animated parts ──────────────────────────────────────────────────────────
+    let mut anim: Vec<AnimPart> = Vec::new();
+
+    // The heart: a cold light lodged in the spire's throat, slow as a sleeping pulse.
+    // Proud of the blade face (cross-section half-depth ≈0.45 at this height) so it reads
+    // as an embedded orb, not a decal.
+    anim.push(AnimPart::glowing(
+        flat_shaded(tinted(ico(0.3, 0), lin(0xffffff))),
+        Transform::from_xyz(0.38, 2.35, 0.52),
+        Fx::None,
+        Glow { color: Color::srgb(0.35, 0.9, 1.0), strength: 9.0, pulse: Some((0.8, 0.4, 0.0)) },
+    ));
+
+    // Six levitating splinters in interleaved orbits — the spire's quiet gravity.
+    for i in 0..6 {
+        let fi = i as f32;
+        let r = 1.45 + (i % 3) as f32 * 0.38;
+        let h = 2.0 + fi * 0.46;
+        let rate = if i % 2 == 0 { 0.28 + fi * 0.03 } else { -(0.34 + fi * 0.025) };
+        let stretch = 1.9 + hash3(fi, 5.0, 2.0) * 1.1;
+        anim.push(AnimPart::glowing(
+            flat_shaded(tinted(
+                ico(0.14, 0).scaled_by(Vec3::new(0.85, stretch, 0.85)).rotated_by(Quat::from_rotation_z(0.18)),
+                lin(0xffffff),
+            )),
+            Transform::from_xyz(r, h, 0.0),
+            Fx::Orbit { centre: yv(h), rate, bob_amp: 0.14, bob_freq: 0.5 + fi * 0.11, phase: fi * 1.05 },
+            Glow { color: Color::srgb(0.62, 0.86, 1.0), strength: 2.4, pulse: None },
+        ));
+    }
+
+    LandmarkModel { base, parts: anim }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  THE SUNKEN PYRAMID — desert. A grand six-tier ziggurat half-swallowed by a
+//  dune, a processional stair to a four-pillar summit shrine, a toppled obelisk,
+//  a colossus head drowning in the sand — and above it all, a gilded sun-disc
+//  relic spinning slowly on nothing at all.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const PYR_BODY: u32 = 0xc9a96b; // sandstone courses
+const PYR_LT: u32 = 0xe2c98f; // sunlit rims
+const PYR_DK: u32 = 0xa8854c;
+const PYR_RUST: u32 = 0x9a6a40; // iron-stained courses / obelisks
+const PYR_PALE: u32 = 0xd7bd8d; // the colossus head (finer stone)
+const PYR_GOLD: u32 = 0xd4a63c; // the altar block
+const PYR_DOOR: u32 = 0x2c2418;
+const SAND: u32 = 0xd9c08a;
+const SAND_DK: u32 = 0xbb9c5e;
+const SUN_GOLD: Color = Color::srgb(1.0, 0.78, 0.3);
+
+/// Half-width of tier `i` of 6 (base 2.35 → top 0.62) and the tier height.
+fn pyr_w(i: usize) -> f32 {
+    2.35 + (0.62 - 2.35) * (i as f32 / 5.0)
+}
+const PYR_TH: f32 = 0.6;
+
+pub fn sunken_pyramid() -> LandmarkModel {
+    let mut parts: Vec<Mesh> = Vec::new();
+
+    // ── Six clean-built tiers with sunlit rims, corner damage and banded colour.
+    let bands = [PYR_RUST, PYR_BODY, PYR_DK, PYR_BODY, PYR_RUST, PYR_DK];
+    for i in 0..6 {
+        let w = pyr_w(i);
+        let y = i as f32 * PYR_TH;
+        let jig = Quat::from_rotation_y((hash3(i as f32, 3.0, 7.0) - 0.5) * 0.05);
+        parts.push(box_rot(w * 2.0, PYR_TH, w * 2.0, yv(y + PYR_TH * 0.5), jig, bands[i]));
+        if i % 2 == 0 {
+            parts.push(box_rot(w * 2.0 + 0.07, 0.06, w * 2.0 + 0.07, yv(y + PYR_TH - 0.03), jig, PYR_LT));
+        }
+        // One chipped corner per tier (hash-picked) — weather bites the arrises first.
+        let hh = hash3(i as f32, 1.0, 11.0);
+        let cx = if hh > 0.5 { w } else { -w };
+        let cz = if hash3(i as f32, 1.0, 23.0) > 0.5 { w } else { -w };
+        parts.push(chunk_at(
+            0.12 + hh * 0.08,
+            Vec3::new(cx, y + PYR_TH * (0.3 + hh * 0.5), cz),
+            Vec3::new(1.0, 0.8, 1.0),
+            hh * TAU,
+            0.2,
+            0,
+            PYR_DK,
+        ));
+    }
+
+    // ── Processional stair up the +Z face (no stringers — a first pass floated two beams
+    // over the treads; the clean stepped run reads better).
+    for s in 0..12 {
+        let y = s as f32 * 0.3;
+        // The face slopes inward as the tiers shrink; keep each tread proud of it.
+        let w_here = 2.35 + (0.62 - 2.35) * (y / 3.6);
+        parts.push(tbox(0.95 - y * 0.04, 0.3, 0.62, Vec3::new(0.0, y + 0.15, w_here + 0.14), PYR_LT));
+    }
+
+    // ── Summit shrine: floor slab, four pillars, two lintels, the gold altar.
+    let top_y = 6.0 * PYR_TH;
+    parts.push(tbox(1.5, 0.12, 1.5, yv(top_y + 0.06), PYR_LT));
+    for &(x, z) in &[(-0.52_f32, -0.52_f32), (0.52, -0.52), (-0.52, 0.52), (0.52, 0.52)] {
+        parts.push(cyl(0.11, 0.78, Vec3::new(x, top_y + 0.51, z), 6, PYR_BODY));
+        parts.push(tbox(0.3, 0.1, 0.3, Vec3::new(x, top_y + 0.94, z), PYR_DK));
+    }
+    for &z in &[-0.52_f32, 0.52] {
+        parts.push(tbox(1.4, 0.15, 0.34, Vec3::new(0.0, top_y + 1.06, z), PYR_RUST));
+    }
+    parts.push(tbox(0.44, 0.34, 0.44, yv(top_y + 0.29), PYR_GOLD));
+    // Dark doorway recess into the top tier's +Z face.
+    parts.push(tbox(0.5, 0.42, 0.12, Vec3::new(0.0, top_y - 0.28, pyr_w(5) + 0.01), PYR_DOOR));
+
+    // ── The dune that is eating the monument (the -X/-Z quarter drowns).
+    for &(x, z, r, sq) in &[
+        (-2.4_f32, -1.4_f32, 1.5_f32, 0.42_f32),
+        (-1.5, -2.4, 1.3, 0.4),
+        (-2.8, 0.2, 1.1, 0.34),
+        (-0.2, -2.75, 1.05, 0.32),
+        (-3.3, -1.2, 0.85, 0.3),
+    ] {
+        parts.push(ball(r, Vec3::new(x, -r * sq * 0.25, z), sq, SAND));
+    }
+    for &(x, z, yaw) in &[(-2.2_f32, -2.1_f32, 0.5_f32), (-3.0, -0.4, -0.6), (-1.0, -2.7, 0.9)] {
+        parts.push(slab_at(1.0, 0.12, 0.6, Vec3::new(x, 0.07, z), yaw, 0.05, SAND_DK));
+    }
+
+    // ── The colossus head, buried to the chin in the +X sand, face turned toward the stair.
+    let head = Vec3::new(3.0, 0.38, 1.9);
+    let head_rot = Quat::from_rotation_y(-2.25) * Quat::from_rotation_z(0.12);
+    parts.push(tinted(
+        ico(0.55, 1).scaled_by(Vec3::new(0.92, 1.0, 0.98)).rotated_by(head_rot).translated_by(head),
+        lin(PYR_PALE),
+    ));
+    // Nemes headdress: crown slab + two side wings hugging the cranium.
+    parts.push(box_rot(0.78, 0.16, 0.58, head + head_rot * Vec3::new(0.0, 0.42, -0.05), head_rot, PYR_RUST));
+    parts.push(box_rot(0.13, 0.52, 0.44, head + head_rot * Vec3::new(-0.5, 0.06, -0.06), head_rot, PYR_RUST));
+    parts.push(box_rot(0.13, 0.52, 0.44, head + head_rot * Vec3::new(0.5, 0.06, -0.06), head_rot, PYR_RUST));
+    // The face (+Z of the head frame): brow ledge, broken nose, lip slab.
+    parts.push(box_rot(0.5, 0.09, 0.13, head + head_rot * Vec3::new(0.0, 0.17, 0.46), head_rot, PYR_PALE));
+    parts.push(box_rot(0.13, 0.24, 0.15, head + head_rot * Vec3::new(0.0, 0.0, 0.52), head_rot * Quat::from_rotation_x(0.14), PYR_DK));
+    parts.push(box_rot(0.3, 0.07, 0.1, head + head_rot * Vec3::new(0.0, -0.2, 0.48), head_rot, PYR_PALE));
+    // Sand lapping the chin.
+    parts.push(ball(0.72, Vec3::new(head.x, 0.02, head.z), 0.26, SAND));
+
+    // ── Obelisks at the stair foot: one standing, one toppled mid-fall centuries ago.
+    let ob = Vec3::new(1.15, 0.0, 3.15);
+    parts.push(frustum(0.17, 0.11, 1.45, ob + yv(0.75), 4, PYR_RUST));
+    parts.push(cone_at(0.12, 0.3, ob + yv(1.62), 4, PYR_GOLD));
+    parts.push(tbox(0.5, 0.18, 0.5, ob + yv(0.06), PYR_DK));
+    let ob2 = Vec3::new(-1.25, 0.0, 3.0);
+    parts.push(tbox(0.48, 0.16, 0.48, ob2 + yv(0.05), PYR_DK));
+    parts.push(frustum(0.17, 0.14, 0.5, ob2 + yv(0.35), 4, PYR_RUST));
+    parts.push(box_rot(
+        0.26,
+        1.15,
+        0.26,
+        ob2 + Vec3::new(-0.55, 0.2, -0.4),
+        Quat::from_rotation_y(0.7) * Quat::from_rotation_z(1.35),
+        PYR_RUST,
+    ));
+    // Fallen column drums + scattered blocks round the base.
+    parts.push(cyl_rot(0.2, 0.55, 7, Vec3::new(2.6, 0.2, -1.4), Quat::from_rotation_z(FRAC_PI_2), PYR_BODY));
+    parts.push(cyl_rot(0.2, 0.5, 7, Vec3::new(3.15, 0.2, -1.15), Quat::from_rotation_z(FRAC_PI_2) * Quat::from_rotation_y(0.5), PYR_DK));
+    parts.push(slab_at(0.4, 0.28, 0.34, Vec3::new(-2.3, 0.2, 2.5), 0.8, 0.15, PYR_BODY));
+
+    let base = mottle(flat_shaded(merged(parts)), 0.5);
+
+    // ── Animated parts ──────────────────────────────────────────────────────────
+    let mut anim: Vec<AnimPart> = Vec::new();
+
+    // The sun-disc relic: a gilded ring + core coin, hovering over the shrine,
+    // turning like a coin that never settles.
+    let mut disc: Vec<Mesh> = Vec::new();
+    disc.push(tinted(
+        Torus { minor_radius: 0.055, major_radius: 0.46 }
+            .mesh()
+            .minor_resolution(4)
+            .major_resolution(12)
+            .build()
+            .rotated_by(Quat::from_rotation_x(FRAC_PI_2)),
+        lin(0xffffff),
+    ));
+    disc.push(tinted(
+        Cylinder::new(0.28, 0.045).mesh().resolution(12).build().rotated_by(Quat::from_rotation_x(FRAC_PI_2)),
+        lin(0xffffff),
+    ));
+    for i in 0..8 {
+        let a = i as f32 * TAU / 8.0;
+        disc.push(tinted(
+            box_at(0.05, 0.16, 0.03, Vec3::new(a.cos() * 0.62, a.sin() * 0.62, 0.0))
+                .rotated_by(Quat::from_rotation_z(a + FRAC_PI_2)),
+            lin(0xffffff),
+        ));
+    }
+    anim.push(AnimPart::glowing(
+        flat_shaded(merged(disc)),
+        Transform::from_xyz(0.0, 5.15, 0.0),
+        Fx::Hover { bob_amp: 0.12, bob_freq: 0.55, spin_rate: 0.65, phase: 0.0 },
+        Glow { color: SUN_GOLD, strength: 5.0, pulse: Some((0.9, 0.22, 0.0)) },
+    ));
+
+    // Gold glyph strips flanking the stair on the bottom tier, smouldering out of phase.
+    for (i, &x) in [-1.05_f32, 1.05].iter().enumerate() {
+        let glyphs = merged(
+            (0..4)
+                .map(|g| tbox(0.1, 0.09 + (g % 2) as f32 * 0.05, 0.05, Vec3::new(0.0, g as f32 * 0.17, 0.0), 0xffffff))
+                .collect(),
+        );
+        anim.push(AnimPart::glowing(
+            flat_shaded(glyphs),
+            Transform::from_xyz(x, 0.28, 2.36),
+            Fx::None,
+            Glow { color: SUN_GOLD, strength: 2.6, pulse: Some((0.5, 0.4, i as f32 * 2.4)) },
+        ));
+    }
+
+    LandmarkModel { base, parts: anim }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+//  THE STANDING STONES — rocky. A full walkable circle: six rune-cut monoliths
+//  (two forming a gate arch), a seventh fallen and broken, a low altar at the
+//  centre — and above the altar, a cracked keystone that never quite lands.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const MEG_A: u32 = 0x9a9aa3; // cool light grey
+const MEG_B: u32 = 0x8a8f98; // mid grey
+const MEG_C: u32 = 0xaab0b2; // pale warm grey
+const MEG_DK: u32 = 0x6b6862; // shadowed feet / underside
+const MEG_PALE: u32 = 0xb3a692; // sun-bleached caps
+const LICHEN_ORANGE: u32 = 0xc88a3a;
+const LICHEN_SAGE: u32 = 0x9aa56b;
+const RUNE_AMBER: Color = Color::srgb(1.0, 0.72, 0.28);
+
+/// Ring radius and the six standing stones as `(angle, height)`. The first two are the
+/// gate pair (+Z side, where the road spur arrives); the gap near angle ~0.2 is where
+/// the fallen seventh lies. KEEP IN SYNC with [`stone_blockers`].
+const RING_R: f32 = 2.9;
+const STONES: [(f32, f32); 6] =
+    [(1.19, 3.25), (1.95, 3.25), (2.85, 2.6), (3.75, 2.4), (4.65, 2.8), (5.5, 2.55)];
+/// Where the broken seventh monolith lies (angle, radius).
+const FALLEN: (f32, f32) = (0.22, 3.35);
+
+/// Blocker boxes (model-local `(dx, dz, hw, hd)`) — one per stone + the altar + the fallen
+/// monolith, so the circle interior stays WALKABLE (the rune trial plays out inside it).
+pub fn stone_blockers() -> Vec<(f32, f32, f32, f32)> {
+    let mut v: Vec<(f32, f32, f32, f32)> =
+        STONES.iter().map(|&(a, _)| (a.cos() * RING_R, a.sin() * RING_R, 0.52, 0.4)).collect();
+    v.push((0.0, 0.0, 0.62, 0.62)); // altar
+    v.push((FALLEN.0.cos() * FALLEN.1, FALLEN.0.sin() * FALLEN.1, 1.0, 0.5));
+    v
+}
+
+pub fn standing_stones() -> LandmarkModel {
+    let mut parts: Vec<Mesh> = Vec::new();
+
+    // ── The six monoliths: worked, tapered, each leaning its own way.
+    for (i, &(a, h)) in STONES.iter().enumerate() {
+        let (x, z) = (a.cos() * RING_R, a.sin() * RING_R);
+        let yaw = -(a + FRAC_PI_2); // broad face toward the circle centre
+        let lean = (hash3(a, 9.0, 1.0) - 0.5) * 0.09;
+        let body = [MEG_A, MEG_B, MEG_C][i % 3];
+        let spin = Quat::from_rotation_y(yaw) * Quat::from_rotation_z(lean);
+        // Foot rubble + the shadowed base wedge.
+        parts.push(facet_at(0.34, Vec3::new(x, 0.14, z), 0.5, MEG_DK));
+        // Two worked courses — strongly tapered, the upper twisted a touch off true so the
+        // silhouette reads hand-raised, not machined.
+        parts.push(box_rot(0.74, h * 0.6, 0.48, Vec3::new(x, h * 0.3, z), spin, body));
+        parts.push(box_rot(
+            0.52,
+            h * 0.48,
+            0.36,
+            Vec3::new(x + lean * h * 0.4, h * 0.72, z),
+            spin * Quat::from_rotation_y(0.09) * Quat::from_rotation_z(lean * 0.7),
+            body,
+        ));
+        // Bleached cap chunk + two weather bites out of the arrises.
+        parts.push(chunk_at(0.3, Vec3::new(x, h * 0.97, z), Vec3::new(1.15, 0.55, 0.9), a, 0.1, 0, MEG_PALE));
+        for k in 0..2 {
+            let hb = hash3(a, k as f32, 31.0);
+            let side = if hb > 0.5 { 0.36 } else { -0.36 };
+            parts.push(chunk_at(
+                0.13 + hb * 0.07,
+                Vec3::new(x + a.cos() * side, h * (0.25 + hb * 0.45), z + a.sin() * side),
+                Vec3::new(1.0, 0.75, 0.9),
+                hb * TAU,
+                0.15,
+                0,
+                MEG_DK,
+            ));
+        }
+        // Lichen on the weather side.
+        parts.push(lichen_at(0.15, Vec3::new(x + a.cos() * 0.36, h * 0.35, z + a.sin() * 0.36), if i % 2 == 0 { LICHEN_ORANGE } else { LICHEN_SAGE }));
+    }
+
+    // ── The gate lintel bridging the first pair (+Z, facing the road spur).
+    let (a1, h1) = STONES[0];
+    let (a2, _) = STONES[1];
+    let mid = (a1 + a2) * 0.5;
+    let lx = (a1.cos() + a2.cos()) * 0.5 * RING_R;
+    let lz = (a1.sin() + a2.sin()) * 0.5 * RING_R;
+    let lintel_yaw = -(mid + FRAC_PI_2);
+    parts.push(box_rot(
+        2.5,
+        0.44,
+        0.55,
+        Vec3::new(lx, h1 + 0.2, lz),
+        Quat::from_rotation_y(lintel_yaw) * Quat::from_rotation_z(0.015),
+        MEG_B,
+    ));
+    parts.push(box_rot(0.9, 0.3, 0.42, Vec3::new(lx, h1 + 0.5, lz), Quat::from_rotation_y(lintel_yaw), MEG_PALE));
+
+    // ── The fallen seventh, snapped in two where it landed.
+    let (fx, fz) = (FALLEN.0.cos() * FALLEN.1, FALLEN.0.sin() * FALLEN.1);
+    let f_yaw = -(FALLEN.0 + FRAC_PI_2);
+    parts.push(box_rot(
+        0.62,
+        1.5,
+        0.4,
+        Vec3::new(fx - 0.35, 0.3, fz - 0.2),
+        Quat::from_rotation_y(f_yaw + 0.15) * Quat::from_rotation_z(FRAC_PI_2 * 0.94),
+        MEG_B,
+    ));
+    parts.push(box_rot(
+        0.58,
+        0.9,
+        0.38,
+        Vec3::new(fx + 0.85, 0.26, fz + 0.35),
+        Quat::from_rotation_y(f_yaw - 0.35) * Quat::from_rotation_z(FRAC_PI_2 * 1.06),
+        MEG_A,
+    ));
+    parts.push(chunk_at(0.2, Vec3::new(fx + 0.25, 0.12, fz + 0.1), Vec3::new(1.0, 0.7, 1.0), 0.5, 0.0, 0, MEG_DK));
+
+    // ── The altar: three squat legs, two stacked slabs, a dark offering bowl.
+    for i in 0..3 {
+        let a = i as f32 * TAU / 3.0 + 0.4;
+        parts.push(tbox(0.3, 0.42, 0.3, Vec3::new(a.cos() * 0.42, 0.21, a.sin() * 0.42), MEG_DK));
+    }
+    parts.push(box_rot(1.3, 0.18, 1.0, yv(0.52), Quat::from_rotation_y(0.2), MEG_B));
+    parts.push(box_rot(1.05, 0.14, 0.8, yv(0.68), Quat::from_rotation_y(0.32), MEG_PALE));
+    parts.push(cyl(0.16, 0.1, yv(0.78), 8, MEG_DK));
+
+    // ── Ring dressing: flat waystones between the monoliths, two cairns, talus.
+    for i in 0..6 {
+        let a = STONES[i].0 + 0.45;
+        parts.push(facet_at(0.24, Vec3::new(a.cos() * RING_R * 0.97, 0.05, a.sin() * RING_R * 0.97), 0.2, MEG_DK));
+    }
+    for &(a, r) in &[(2.4_f32, 4.3_f32), (5.1, 4.1)] {
+        let (cx, cz) = (a.cos() * r, a.sin() * r);
+        for s in 0..3 {
+            parts.push(flat_stone(
+                0.5 - s as f32 * 0.12,
+                0.13,
+                0.4 - s as f32 * 0.08,
+                Vec3::new(cx, 0.07 + s as f32 * 0.13, cz),
+                a + s as f32 * 0.5,
+                if s % 2 == 0 { MEG_B } else { MEG_C },
+            ));
+        }
+    }
+    for &(x, z, r) in &[(1.6_f32, -0.9_f32, 0.14_f32), (-1.8, 0.6, 0.12), (0.4, 1.9, 0.11), (-0.9, -1.7, 0.13)] {
+        parts.push(facet_at(r, Vec3::new(x, r * 0.55, z), 0.6, MEG_DK));
+    }
+
+    let base = mottle(flat_shaded(merged(parts)), 0.58);
+
+    // ── Animated parts ──────────────────────────────────────────────────────────
+    let mut anim: Vec<AnimPart> = Vec::new();
+
+    // Rune strips down each monolith's inner face, smouldering in a slow stagger. Pressed
+    // half-proud INTO the face (course half-depth 0.24 → face at RING_R−0.24; glyph depth
+    // 0.12 straddles it) so they read carved, not floating.
+    for (i, &(a, h)) in STONES.iter().enumerate() {
+        let inner = RING_R - 0.27;
+        let (x, z) = (a.cos() * inner, a.sin() * inner);
+        let yaw = -(a + FRAC_PI_2);
+        // Same lean as the monolith's lower course (same hash) — the strip rides the face
+        // instead of peeling off a leaning stone; kept low where the lean displaces least.
+        let lean = (hash3(a, 9.0, 1.0) - 0.5) * 0.09;
+        let glyphs = merged(
+            (0..4)
+                .map(|g| {
+                    tbox(
+                        0.1 + (g % 2) as f32 * 0.04,
+                        0.1 + ((g + i) % 3) as f32 * 0.03,
+                        0.12,
+                        Vec3::new(0.0, g as f32 * 0.22, 0.0),
+                        0xffffff,
+                    )
+                })
+                .collect(),
+        );
+        anim.push(AnimPart::glowing(
+            flat_shaded(glyphs),
+            Transform::from_xyz(x, h * 0.22, z)
+                .with_rotation(Quat::from_rotation_y(yaw) * Quat::from_rotation_z(lean)),
+            Fx::None,
+            Glow { color: RUNE_AMBER, strength: 3.4, pulse: Some((0.55, 0.4, i as f32 * 1.05)) },
+        ));
+    }
+
+    // The keystone: a cracked block hovering over the altar…
+    let keystone = flat_shaded(merged(vec![
+        tinted(ico(0.4, 0).scaled_by(Vec3::new(1.0, 0.85, 0.9)), lin(MEG_B)),
+        facet_at(0.15, Vec3::new(0.34, 0.16, 0.1), 0.8, MEG_PALE),
+        facet_at(0.12, Vec3::new(-0.3, -0.14, -0.12), 0.8, MEG_A),
+    ]));
+    let hover = Fx::Hover { bob_amp: 0.15, bob_freq: 0.45, spin_rate: 0.3, phase: 0.0 };
+    anim.push(AnimPart::solid(keystone, Transform::from_xyz(0.0, 2.3, 0.0), hover));
+    // …and the amber light leaking from its cracks (same hover parameters → locked in step).
+    let seams = flat_shaded(merged(vec![
+        tinted(ico(0.07, 0).translated_by(Vec3::new(0.3, 0.08, 0.22)), lin(0xffffff)),
+        tinted(ico(0.06, 0).translated_by(Vec3::new(-0.26, 0.2, -0.14)), lin(0xffffff)),
+        tinted(ico(0.065, 0).translated_by(Vec3::new(0.05, -0.2, 0.3)), lin(0xffffff)),
+    ]));
+    anim.push(AnimPart::glowing(
+        seams,
+        Transform::from_xyz(0.0, 2.3, 0.0),
+        Fx::Hover { bob_amp: 0.15, bob_freq: 0.45, spin_rate: 0.3, phase: 0.0 },
+        Glow { color: RUNE_AMBER, strength: 6.0, pulse: Some((0.7, 0.35, 0.5)) },
+    ));
+
+    LandmarkModel { base, parts: anim }
+}

--- a/src/landmarks.rs
+++ b/src/landmarks.rs
@@ -185,21 +185,24 @@ fn meta(b: Biome) -> Meta {
             beacon: Color::srgb(1.0, 0.76, 0.23), // gold over grey rock
             gear: "stone_maul", // Stone Maul (+18) — the circle's own heft
         },
+        // NB (July 2026 map-character overhaul): the forest/swamp landmarks were re-identified —
+        // Hollow Oak → the Old Mill, Mire Sentinel → the Witch's Hut. Saves round-trip discovery
+        // by NAME, so a pre-overhaul save simply shows the new places undiscovered (harmless).
         Biome::Forest => Meta {
-            name: "The Hollow Oak",
-            lore: "Roots drink deep; so shall you strike.",
+            name: "The Old Mill",
+            lore: "Its sails still turn, though no wind asks them to.",
             buff: BuffKind::Power,
             buff_mag: 1.4,
             beacon: Color::srgb(1.0, 0.68, 0.18), // amber over green forest
-            gear: "sword_gold", // Golden Blade (+21)
+            gear: "sword_gold", // Golden Blade (+21) — the miller's hidden pay
         },
         Biome::Swamp => Meta {
-            name: "The Mire Sentinel",
-            lore: "Bog-iron bark shrugs off the worst.",
+            name: "The Witch's Hut",
+            lore: "The brew never cools. The door never opens.",
             buff: BuffKind::Resist,
             buff_mag: 0.6,
             beacon: Color::srgb(0.31, 0.94, 0.90), // bright cyan over murk
-            gear: "dragon_plate", // Dragonscale Plate (42%) — the worst the mire endured
+            gear: "dragon_plate", // Dragonscale Plate (42%) — payment the witch never collected
         },
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ mod hints;
 mod hud;
 mod interaction;
 mod inventory;
+mod landmark_models;
 mod landmarks;
 mod loading;
 mod lumberjack;
@@ -293,6 +294,9 @@ fn main() {
         // Rival AI stronghold: a second castle in the desert (Stronghold-Crusader-style opponent).
         // Standalone: the tuples above are at the `Plugins` arity-15 cap.
         .add_plugins(rival::RivalPlugin)
+        // Landmark set-piece animators (mill sails, orbiting shards, glow pulses). Standalone —
+        // the tuples above are at the `Plugins` arity-15 cap.
+        .add_plugins(ruins::RuinsFxPlugin)
         // Ambush snowmen: static snow-biome decor that wakes + slams when the hero nears or strikes
         // it. Standalone — the tuples above are at the `Plugins` arity-15 cap.
         .add_plugins(snowman::SnowmanPlugin)

--- a/src/navgrid.rs
+++ b/src/navgrid.rs
@@ -14,12 +14,13 @@ use crate::blockers;
 use crate::worldmap::{ground_at_world, COLS, GROUND_STEP, GX, GZ, ROWS};
 
 /// A* node budget for the invader keep-march. The spawn ring is 30 tiles out, but on the enlarged
-/// (259×295) map an invader spawned across one of the four rivers must detour to a bridge, so the
-/// explored set can far exceed the straight-line tile count. 1400 truncated those detours to an
-/// *empty* path (idle invader); 6000 covers the worst river detour. Since the keep is always
-/// reachable, A* terminates as soon as it's found — the larger budget only costs on a (never-
-/// occurring for invaders) unreachable goal, where the open set drains to the cap.
-pub const NAV_MAX_NODES: u32 = 6000;
+/// map an invader spawned across one of the four rivers must detour to a bridge, so the explored
+/// set can far exceed the straight-line tile count. 1400 truncated those detours to an *empty*
+/// path (idle invader); 6000 covered the worst river detour at MAP_SCALE 2.2, re-sized to 8400
+/// for the 2.6 bump (budget ∝ tile count ∝ MAP_SCALE²). Since the keep is always reachable, A*
+/// terminates as soon as it's found — the larger budget only costs on a (never-occurring for
+/// invaders) unreachable goal, where the open set drains to the cap.
+pub const NAV_MAX_NODES: u32 = 8400;
 
 /// World centre of tile `(ix, iz)` in forest world-space (castle at origin).
 #[inline]

--- a/src/ruins.rs
+++ b/src/ruins.rs
@@ -606,6 +606,8 @@ pub fn populate_landmarks(
             continue; // `landmark_sites` already logged the miss.
         };
         let (x, y, z, yaw) = (s.pos.x, s.y, s.pos.y, s.yaw);
+        // Greppable placement line — capture/debug sessions frame landmark close-ups from this.
+        info!("landmark {:?} placed at ({:.1}, {:.1})", biome, x, z);
         let xf = Transform::from_xyz(x, y, z)
             .with_rotation(Quat::from_rotation_y(yaw))
             .with_scale(Vec3::splat(scale));

--- a/src/ruins.rs
+++ b/src/ruins.rs
@@ -1,80 +1,43 @@
-//! Landmark props — the five signature biome set-pieces (sunken pyramid, frozen spire,
-//! standing-stone circle, giant dead tree, swamp sentinel) the world map plants one of in
-//! each biome region. Built as single merged vertex-coloured meshes (one per landmark) so
-//! they batch against the scene's shared white material; each model's BASE sits at y=0 and
-//! the placement pass scales/seats it on FLAT ground.
+//! Landmark machinery — placement + the animated-set-piece spawn API. The five signature
+//! biome set-pieces themselves (old mill, witch's hut, frozen spire, sunken pyramid, standing
+//! stones) are authored in [`crate::landmark_models`]; this module owns:
 //!
-//! Build contract (per the verified-APIs doc §9): every part is a primitive
-//! `tinted` with a flat linear `ATTRIBUTE_COLOR` BEFORE the merge (the scene's one white
-//! `StandardMaterial` reads colour straight off the vertices), merged via `Mesh::merge`, then
-//! `flat_shaded` (`duplicate_vertices` → `compute_flat_normals`) for the crisp low-poly facets
-//! the rest of the scene uses. `duplicate_vertices` MUST precede `compute_flat_normals`.
+//!  * the shared low-poly mesh helpers (`tinted`/`merged`/`flat_shaded`/`mottle` + primitive
+//!    builders) every landmark builder composes from,
+//!  * the [`LandmarkModel`]/[`AnimPart`] spawn API — one merged static base mesh on the scene's
+//!    shared white vertex-colour material (batches like everything else), plus child entities
+//!    for the ANIMATED / glowing sub-parts (mill sails, orbiting ice shards, pulsing windows…),
+//!  * [`RuinsFxPlugin`] — the cosmetic part animators (spin / sway / orbit / hover / rise /
+//!    glow-pulse). Render-side dressing like `banner.rs`, so the systems stay UNGATED and the
+//!    sails keep turning while a panel freezes the sim,
+//!  * the flat-spot site picker + `populate_landmarks` world placement.
+//!
+//! Build contract (verified-APIs doc §9): every part is a primitive `tinted` with a flat linear
+//! `ATTRIBUTE_COLOR` BEFORE the merge (the shared white `StandardMaterial` reads colour straight
+//! off the vertices), merged via `Mesh::merge`, then `flat_shaded` (`duplicate_vertices` →
+//! `compute_flat_normals` — in that order; the latter panics on an indexed mesh).
 
-use bevy::prelude::*;
+use bevy::light::NotShadowCaster;
 use bevy::mesh::VertexAttributeValues;
-use std::f32::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
+use bevy::prelude::*;
+use std::f32::consts::{FRAC_PI_4, TAU};
 use std::sync::OnceLock;
 
-use crate::palette::{lin, lin_scaled, DEAD_WOOD, DEAD_WOOD_DARK};
+use crate::palette::lin;
 
-// ── Trilithon / rocky landmark (baked shadow → pale cap, like biome_rocky) ───
-const STONE_DARK: u32 = 0x6b6358; // shadowed foot / crevice wedge
-const STONE_BODY: u32 = 0x8a7f70; // mid grey-brown body
-const STONE_PALE: u32 = 0xb3a692; // sun-bleached top facet
-const STONE_COOL: u32 = 0x7d7a72; // cooler accent lump
-const STONE_A: u32 = 0x9a9aa3; // left upright — cool light grey
-const STONE_B: u32 = 0x8a8f98; // lintel — mid grey
-const STONE_C: u32 = 0xaab0b2; // right upright — pale warm grey
-const STONE_CAP: u32 = 0x6b6862; // shaded underside
-const LICHEN_ORANGE: u32 = 0xc88a3a;
-const LICHEN_SAGE: u32 = 0x9aa56b;
-const PEBBLE_WARM: u32 = 0x8a7a64;
-
-// ── Frozen spire (angular ice chunks, biome_snow family) ─────────────────────
-const ICE_BODY: u32 = 0xa9d2f0;
-const ICE_RIME: u32 = 0xc4e3f6;
-const ICE_PALE: u32 = 0xe6f4fc;
-const ICE_DEEP: u32 = 0x5f93cc;
-const ICE_RIM: u32 = 0x9cc3e0;
-const FROST_ROCK: u32 = 0x66727f; // blue-grey rubble the crystals erupt from
-
-// ── Sunken pyramid (banded sandstone facets, biome_desert family) ─────────────
-const SAND_BODY: u32 = 0xd9c08a;
-const SAND_LT: u32 = 0xe9d4a2;
-const SAND_DK: u32 = 0xbb9c5e;
-const SAND_SHADOW: u32 = 0x8c7340;
-const SAND_DOOR: u32 = 0x2c2418;
-const HOODOO_BASE: u32 = 0x9c7d59; // warm ochre sandstone (desert tiers)
-const HOODOO_RUST: u32 = 0x8a5c3c;
-const HOODOO_PALE: u32 = 0xc6a978;
-const SNOW_CAP: u32 = 0xe8f2fa; // frost dusting on the ice-footing rocks
-const SNOW_SHADE: u32 = 0xc8dff0;
-
-// ── Dead-tree wood tints ─────────────────────────────────────────────────────
-const TREE_BARK: u32 = DEAD_WOOD; // 0x6e6258 weathered grey-brown
-const TREE_BARK_DARK: u32 = DEAD_WOOD_DARK; // 0x4a4238 lower trunk / collar
-const TREE_ROOT: u32 = 0x2f2418; // near-black wet root wood at the base
-
-// ── Swamp sentinel tints (mossy grey-green, water-stained) ─────────────────────
-const SWAMP_BARK: u32 = 0x5d6150; // grey-green mossy bark
-const SWAMP_BARK_DARK: u32 = 0x3a3c30; // water-stained lower trunk
-const SWAMP_ROOT: u32 = 0x241f16; // black sodden root wood
-const SWAMP_MOSS: u32 = 0x6a7b3c; // hanging moss / knee caps
-
-// ── Mesh helpers (verified 0.18 forms) ───────────────────────────────────────
+// ── Mesh helpers (verified API forms; shared with `landmark_models`) ─────────
 
 /// Tag every vertex of a part with one flat linear colour. REQUIRED before merge —
 /// all merged parts must carry the same attribute set, and the scene's shared white
 /// `StandardMaterial` reads colour straight off `ATTRIBUTE_COLOR`.
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
+pub(crate) fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
     let n = m.count_vertices();
     m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
     m
 }
 
-/// Merge a list of already-tinted parts into one mesh. `Mesh::merge` returns a
-/// `Result` in 0.18 (all parts share POSITION/NORMAL/UV_0/COLOR, so it never fails).
-fn merged(parts: Vec<Mesh>) -> Mesh {
+/// Merge a list of already-tinted parts into one mesh.
+pub(crate) fn merged(parts: Vec<Mesh>) -> Mesh {
     let mut it = parts.into_iter();
     let mut base = it.next().expect("at least one part");
     for p in it {
@@ -84,25 +47,29 @@ fn merged(parts: Vec<Mesh>) -> Mesh {
 }
 
 /// Un-index + recompute per-face normals → crisp flat-shaded low-poly facets.
-/// `duplicate_vertices()` MUST run before `compute_flat_normals()` (the latter panics
-/// on an indexed mesh). Call LAST, on the merged mesh.
-fn flat_shaded(mut m: Mesh) -> Mesh {
+/// `duplicate_vertices()` MUST run before `compute_flat_normals()`. Call LAST, on the merge.
+pub(crate) fn flat_shaded(mut m: Mesh) -> Mesh {
     m.duplicate_vertices();
     m.compute_flat_normals();
     m
 }
 
-fn yv(v: f32) -> Vec3 {
+pub(crate) fn yv(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)
 }
 
 /// A box primitive, positioned so its CENTER lands at `center`.
-fn box_at(x: f32, y: f32, z: f32, center: Vec3) -> Mesh {
+pub(crate) fn box_at(x: f32, y: f32, z: f32, center: Vec3) -> Mesh {
     Cuboid::new(x, y, z).mesh().build().translated_by(center)
 }
 
+/// A box rotated by an arbitrary quaternion about its own centre, then translated.
+pub(crate) fn box_rot(x: f32, y: f32, z: f32, center: Vec3, rot: Quat, c: u32) -> Mesh {
+    tinted(Cuboid::new(x, y, z).mesh().build().rotated_by(rot).translated_by(center), lin(c))
+}
+
 /// A faceted icosphere blob (ico detail 1), squashed on Y, centred at `center`.
-fn ball(r: f32, center: Vec3, squash: f32, c: u32) -> Mesh {
+pub(crate) fn ball(r: f32, center: Vec3, squash: f32, c: u32) -> Mesh {
     tinted(
         Sphere::new(r)
             .mesh()
@@ -115,12 +82,37 @@ fn ball(r: f32, center: Vec3, squash: f32, c: u32) -> Mesh {
 }
 
 /// An upright cylinder centred at `center`. `res` keeps the low-poly facet look.
-fn cyl(r: f32, h: f32, center: Vec3, res: u32, c: u32) -> Mesh {
+pub(crate) fn cyl(r: f32, h: f32, center: Vec3, res: u32, c: u32) -> Mesh {
     tinted(Cylinder::new(r, h).mesh().resolution(res).build().translated_by(center), lin(c))
 }
 
-/// Deterministic [0,1) value noise from a world position (same sin-hash family as the scatter).
-fn hash3(x: f32, y: f32, z: f32) -> f32 {
+/// A cylinder rotated about its centre, then translated (fallen column drums, leaning discs).
+pub(crate) fn cyl_rot(r: f32, h: f32, res: u32, center: Vec3, rot: Quat, c: u32) -> Mesh {
+    tinted(
+        Cylinder::new(r, h).mesh().resolution(res).build().rotated_by(rot).translated_by(center),
+        lin(c),
+    )
+}
+
+/// A truncated-cone shell (tower bodies, thatch caps). `res` low keeps it faceted.
+pub(crate) fn frustum(r_bottom: f32, r_top: f32, h: f32, center: Vec3, res: u32, c: u32) -> Mesh {
+    tinted(
+        ConicalFrustum { radius_top: r_top, radius_bottom: r_bottom, height: h }
+            .mesh()
+            .resolution(res)
+            .build()
+            .translated_by(center),
+        lin(c),
+    )
+}
+
+/// An upright cone whose CENTRE sits at `center` (roof peaks, stakes).
+pub(crate) fn cone_at(r: f32, h: f32, center: Vec3, res: u32, c: u32) -> Mesh {
+    tinted(Cone { radius: r, height: h }.mesh().resolution(res).build().translated_by(center), lin(c))
+}
+
+/// Deterministic [0,1) value noise from a position (same sin-hash family as the scatter).
+pub(crate) fn hash3(x: f32, y: f32, z: f32) -> f32 {
     let v = (x * 127.1 + y * 311.7 + z * 74.7).sin() * 43758.5453;
     v - v.floor()
 }
@@ -130,7 +122,7 @@ fn hash3(x: f32, y: f32, z: f32) -> f32 {
 /// by a position-seeded noise so big stone/sand faces read mottled and grainy rather than as
 /// flat plastic — the project's stand-in for a texture, staying pure vertex-colour so the
 /// landmark still batches against the shared white material. `amount` ≈ peak ± fraction.
-fn mottle(mut m: Mesh, amount: f32) -> Mesh {
+pub(crate) fn mottle(mut m: Mesh, amount: f32) -> Mesh {
     let pos: Vec<[f32; 3]> = match m.attribute(Mesh::ATTRIBUTE_POSITION) {
         Some(VertexAttributeValues::Float32x3(p)) => p.clone(),
         _ => return m,
@@ -159,12 +151,12 @@ fn mottle(mut m: Mesh, amount: f32) -> Mesh {
 }
 
 /// A low-poly faceted lump (ico detail 0) — the angular chipped-stone look.
-fn facet_at(r: f32, off: Vec3, squash: f32, c: u32) -> Mesh {
+pub(crate) fn facet_at(r: f32, off: Vec3, squash: f32, c: u32) -> Mesh {
     facet_tinted(r, off, squash, lin(c))
 }
 
 /// Like [`facet_at`] but with an explicit linear RGBA (for baked shadow/highlight scales).
-fn facet_tinted(r: f32, off: Vec3, squash: f32, c: [f32; 4]) -> Mesh {
+pub(crate) fn facet_tinted(r: f32, off: Vec3, squash: f32, c: [f32; 4]) -> Mesh {
     tinted(
         Sphere::new(r)
             .mesh()
@@ -177,7 +169,8 @@ fn facet_tinted(r: f32, off: Vec3, squash: f32, c: [f32; 4]) -> Mesh {
 }
 
 /// A faceted lump stretched on X/Y/Z and Z-tilted into a jagged block.
-fn block_at(rx: f32, ry: f32, rz: f32, off: Vec3, tilt: f32, c: u32) -> Mesh {
+#[allow(dead_code)] // part of the landmark-builder toolkit; not every model uses every primitive
+pub(crate) fn block_at(rx: f32, ry: f32, rz: f32, off: Vec3, tilt: f32, c: u32) -> Mesh {
     tinted(
         Sphere::new(1.0)
             .mesh()
@@ -191,7 +184,7 @@ fn block_at(rx: f32, ry: f32, rz: f32, off: Vec3, tilt: f32, c: u32) -> Mesh {
 }
 
 /// `block_at` with an extra yaw so fracture slabs can lean in any direction.
-fn slab_at(rx: f32, ry: f32, rz: f32, off: Vec3, yaw: f32, tilt: f32, c: u32) -> Mesh {
+pub(crate) fn slab_at(rx: f32, ry: f32, rz: f32, off: Vec3, yaw: f32, tilt: f32, c: u32) -> Mesh {
     tinted(
         Sphere::new(1.0)
             .mesh()
@@ -205,22 +198,17 @@ fn slab_at(rx: f32, ry: f32, rz: f32, off: Vec3, yaw: f32, tilt: f32, c: u32) ->
 }
 
 /// Centre height that grounds a Z-tilted slab's lowest point at y=0.
-fn slab_ground(rx: f32, ry: f32, tilt: f32) -> f32 {
+pub(crate) fn slab_ground(rx: f32, ry: f32, tilt: f32) -> f32 {
     ((rx * tilt.sin()).powi(2) + (ry * tilt.cos()).powi(2)).sqrt()
 }
 
 /// A flat lichen splotch pressed onto a stone surface.
-fn lichen_at(r: f32, off: Vec3, c: u32) -> Mesh {
+pub(crate) fn lichen_at(r: f32, off: Vec3, c: u32) -> Mesh {
     facet_at(r, off, 0.24, c)
 }
 
-/// An upright cylinder whose centre sits at `cy` (a part rooted at y=0 uses `cy = h/2`).
-fn cyl_up(r: f32, h: f32, cy: f32, res: u32, c: u32) -> Mesh {
-    tinted(Cylinder::new(r, h).mesh().resolution(res).build().translated_by(yv(cy)), lin(c))
-}
-
 /// An angular rock chunk: squashed icosphere, yawed + pitched (biome_snow `chunk_at`).
-fn chunk_at(r: f32, off: Vec3, scale: Vec3, yaw: f32, pitch: f32, detail: u32, c: u32) -> Mesh {
+pub(crate) fn chunk_at(r: f32, off: Vec3, scale: Vec3, yaw: f32, pitch: f32, detail: u32, c: u32) -> Mesh {
     tinted(
         Sphere::new(r)
             .mesh()
@@ -234,7 +222,7 @@ fn chunk_at(r: f32, off: Vec3, scale: Vec3, yaw: f32, pitch: f32, detail: u32, c
 }
 
 /// A flat cairn stone — thin cuboid slab yawed about Y.
-fn flat_stone(w: f32, h: f32, d: f32, off: Vec3, yaw: f32, c: u32) -> Mesh {
+pub(crate) fn flat_stone(w: f32, h: f32, d: f32, off: Vec3, yaw: f32, c: u32) -> Mesh {
     tinted(
         Cuboid::new(w, h, d)
             .mesh()
@@ -249,7 +237,7 @@ fn flat_stone(w: f32, h: f32, d: f32, off: Vec3, yaw: f32, c: u32) -> Mesh {
 /// about Z and yawed about Y, then translated to its attach point. Order: lift the
 /// base-centred cylinder so its base is at origin → rotate (so it swings about its
 /// base) → translate to where it attaches. `resolution` keeps the low-poly facet look.
-fn limb(radius: f32, height: f32, resolution: u32, pitch_z: f32, yaw_y: f32, attach: Vec3) -> Mesh {
+pub(crate) fn limb(radius: f32, height: f32, resolution: u32, pitch_z: f32, yaw_y: f32, attach: Vec3) -> Mesh {
     let rot = Quat::from_rotation_y(yaw_y) * Quat::from_rotation_z(pitch_z);
     Cylinder::new(radius, height)
         .mesh()
@@ -260,369 +248,266 @@ fn limb(radius: f32, height: f32, resolution: u32, pitch_z: f32, yaw_y: f32, att
         .translated_by(attach)
 }
 
-// ── Standing stones (rocky landmark) ──────────────────────────────────────────
+// ── The animated-set-piece API ─────────────────────────────────────────────────
 
-/// One arch upright: two counter-leaning fracture slabs + stacked blocks + pale crown
-/// (the `biome_rocky` leaning-slab crag recipe, not smooth cylinders).
-fn crag_pillar(x: f32, total_h: f32) -> Vec<Mesh> {
-    let r = 0.48;
-    let (mx, my, mt) = (r * 1.22, total_h * 0.56, 0.28);
-    let (cx, cy, ct) = (r * 1.02, total_h * 0.52, -0.34);
-    vec![
-        facet_at(r * 0.55, Vec3::new(x, r * 0.24, 0.06), 0.84, STONE_DARK),
-        slab_at(
-            mx,
-            my,
-            r * 0.92,
-            Vec3::new(x - r * 0.12, slab_ground(mx, my, mt) + total_h * 0.20, 0.02),
-            0.12,
-            mt,
-            STONE_BODY,
-        ),
-        slab_at(
-            cx,
-            cy,
-            r * 0.85,
-            Vec3::new(x + r * 0.22, slab_ground(cx, cy, ct) + total_h * 0.22, -r * 0.08),
-            -0.18,
-            ct,
-            STONE_COOL,
-        ),
-        facet_tinted(r * 0.40, Vec3::new(x + r * 0.06, total_h * 0.50, r * 0.12), 0.86, lin_scaled(STONE_DARK, 0.85)),
-        block_at(r * 0.76, total_h * 0.30, r * 0.68, Vec3::new(x + r * 0.06, total_h * 0.66, -0.04), -0.10, STONE_A),
-        block_at(r * 0.68, total_h * 0.42, r * 0.62, Vec3::new(x, total_h * 0.48, 0.02), 0.03, STONE_BODY),
-        block_at(r * 0.60, total_h * 0.26, r * 0.54, Vec3::new(x - r * 0.04, total_h * 0.90, 0.05), 0.08, STONE_C),
-        facet_at(r * 0.44, Vec3::new(x + r * 0.05, total_h * 1.02, -0.02), 0.46, STONE_PALE),
-        facet_tinted(r * 0.30, Vec3::new(x - r * 0.22, total_h * 0.76, r * 0.26), 0.48, lin_scaled(STONE_PALE, 0.94)),
-        lichen_at(0.16, Vec3::new(x - r * 0.78, total_h * 0.30, r * 0.32), LICHEN_ORANGE),
-        lichen_at(0.13, Vec3::new(x + r * 0.68, total_h * 0.56, -r * 0.18), LICHEN_SAGE),
-    ]
+/// A glowing sub-part: gets its OWN unlit emissive material (the beacon recipe) instead of the
+/// shared white one. `pulse = Some((freq rad/s, ±fraction, phase))` breathes the emissive.
+pub struct Glow {
+    pub color: Color,
+    /// Emissive multiplier (the landmark beacons run ~16; set-piece accents want 3–9).
+    pub strength: f32,
+    pub pulse: Option<(f32, f32, f32)>,
 }
 
-/// A small loose crag cluster (two leaning slabs + cobbles) for the outer ring / talus.
-fn mini_crag(cx: f32, cz: f32, scale: f32, yaw: f32) -> Vec<Mesh> {
-    let r = 0.38 * scale;
-    let (sx, sy, st) = (r * 1.15, r * 0.72, 0.32);
-    vec![
-        slab_at(
-            sx,
-            sy,
-            r * 0.88,
-            Vec3::new(cx - r * 0.08, slab_ground(sx, sy, st), cz),
-            yaw,
-            st,
-            STONE_BODY,
-        ),
-        slab_at(
-            r * 0.92,
-            r * 0.58,
-            r * 0.75,
-            Vec3::new(cx + r * 0.42, slab_ground(r * 0.92, r * 0.58, -0.28), cz - r * 0.06),
-            yaw + 0.6,
-            -0.28,
-            STONE_COOL,
-        ),
-        facet_at(r * 0.34, Vec3::new(cx + r * 0.12, r * 1.18, cz + 0.04), 0.44, STONE_PALE),
-        facet_at(r * 0.22, Vec3::new(cx - r * 0.55, r * 0.20, cz + r * 0.35), 0.66, PEBBLE_WARM),
-        facet_tinted(r * 0.18, Vec3::new(cx + r * 0.48, r * 0.16, cz - r * 0.32), 0.66, lin_scaled(STONE_DARK, 1.05)),
-    ]
+/// The cosmetic motions a landmark sub-part can carry. All are pure `Transform` drives off
+/// wall-clock time — deterministic, no state, safe to run ungated.
+pub enum Fx {
+    /// Static part (used for glow-only parts like lit windows).
+    None,
+    /// Continuous rotation about a LOCAL axis (mill sails, coin-spinning relics).
+    Spin { axis: Vec3, rate: f32 },
+    /// Pendulum sway about a local axis through the part's origin (charms, lanterns, vanes).
+    Sway { axis: Vec3, amp: f32, freq: f32, phase: f32 },
+    /// Circle a model-local centre (the part's rest offset from `centre` sets the radius),
+    /// with an optional vertical bob (orbiting ice shards, cauldron wisps).
+    Orbit { centre: Vec3, rate: f32, bob_amp: f32, bob_freq: f32, phase: f32 },
+    /// Levitate in place: vertical bob + slow yaw spin (hovering keystones, sun-disc relics).
+    Hover { bob_amp: f32, bob_freq: f32, spin_rate: f32, phase: f32 },
+    /// Loop upward over `range` then wrap, drifting sideways and swelling as it climbs
+    /// (chimney smoke). `grow` = extra scale at the top of the run.
+    Rise { rate: f32, range: f32, drift: Vec2, grow: f32, phase: f32 },
 }
 
-/// **The Standing Stones** — a natural rock arch: two fractured crag pillars bridged by a
-/// thick faceted lintel (ported from `biome_rocky::landmarks`), three outer crag clusters,
-/// and a talus skirt. No plinth. Base at y=0, ~3.2u to the lintel crown; opening faces ±Z.
-pub fn build_trilithon_mesh() -> Mesh {
-    const GAP: f32 = 2.0;
-    const HALF: f32 = GAP * 0.5;
-    const POST_H: f32 = 2.65;
+/// One animated / glowing sub-part of a landmark: its own child entity with its own mesh.
+/// Everything static belongs in the merged base mesh instead (one draw, batches).
+pub struct AnimPart {
+    pub mesh: Mesh,
+    pub xf: Transform,
+    pub fx: Fx,
+    pub glow: Option<Glow>,
+    /// < 1.0 → translucent unlit part (smoke); ignored when `glow` is set.
+    pub alpha: f32,
+}
 
-    let mut parts: Vec<Mesh> = Vec::new();
-    for p in crag_pillar(-HALF, POST_H) {
-        parts.push(p);
+impl AnimPart {
+    /// A solid vertex-coloured part on the shared white material.
+    pub fn solid(mesh: Mesh, xf: Transform, fx: Fx) -> Self {
+        Self { mesh, xf, fx, glow: None, alpha: 1.0 }
     }
-    for p in crag_pillar(HALF, POST_H) {
-        parts.push(p);
+    /// A glowing part (own unlit emissive material).
+    pub fn glowing(mesh: Mesh, xf: Transform, fx: Fx, glow: Glow) -> Self {
+        Self { mesh, xf, fx, glow: Some(glow), alpha: 1.0 }
     }
+}
 
-    // Lintel span — same layered block recipe as the rocky biome's rock arch.
-    let span = GAP;
-    let lintel_y = POST_H + 0.16;
-    parts.push(block_at(
-        span * 0.34,
-        0.55,
-        0.40,
-        Vec3::new(-span * 0.28, lintel_y, 0.0),
-        -0.10,
-        STONE_B,
-    ));
-    parts.push(block_at(
-        span * 0.34,
-        0.55,
-        0.40,
-        Vec3::new(span * 0.28, lintel_y, 0.0),
-        0.10,
-        STONE_B,
-    ));
-    parts.push(block_at(span * 0.16, 0.50, 0.38, Vec3::new(0.0, lintel_y + 0.30, 0.0), 0.0, STONE_PALE));
-    parts.push(block_at(span * 0.50, 0.22, 0.34, Vec3::new(0.0, lintel_y - 0.05, 0.0), 0.0, STONE_CAP));
-    parts.push(facet_tinted(0.48, Vec3::new(-0.68, lintel_y - 0.42, 0.10), 0.76, lin_scaled(STONE_DARK, 0.9)));
-    parts.push(facet_tinted(0.40, Vec3::new(0.88, lintel_y - 0.38, -0.08), 0.76, lin_scaled(STONE_BODY, 0.88)));
-    parts.push(slab_at(0.52, 0.28, 0.42, Vec3::new(-0.35, 0.28, 0.55), 0.65, 0.16, STONE_COOL));
-    parts.push(facet_at(0.34, Vec3::new(0.65, 0.22, -0.48), 0.62, PEBBLE_WARM));
-    parts.push(facet_tinted(0.20, Vec3::new(0.08, 0.13, 0.82), 0.58, lin_scaled(STONE_BODY, 0.95)));
+/// A complete landmark: one merged static base mesh + the animated sub-parts.
+pub struct LandmarkModel {
+    pub base: Mesh,
+    pub parts: Vec<AnimPart>,
+}
 
-    // Three big outer crags (not five skinny duplicates).
-    for (i, &(sc, yaw_off)) in [(1.0_f32, 0.0), (1.15, 1.1), (0.92, -0.8)].iter().enumerate() {
-        let a = i as f32 * (TAU / 3.0) + 0.65;
-        let (rx, rz) = (a.cos() * 2.85, a.sin() * 2.85);
-        for p in mini_crag(rx, rz, sc, a + yaw_off) {
-            parts.push(p);
+/// Rest transform captured at spawn — the FX systems pose relative to this every frame.
+#[derive(Component)]
+struct RestXf(Transform);
+
+#[derive(Component)]
+struct FxSpin {
+    axis: Vec3,
+    rate: f32,
+}
+
+#[derive(Component)]
+struct FxSway {
+    axis: Vec3,
+    amp: f32,
+    freq: f32,
+    phase: f32,
+}
+
+#[derive(Component)]
+struct FxOrbit {
+    centre: Vec3,
+    rate: f32,
+    bob_amp: f32,
+    bob_freq: f32,
+    phase: f32,
+}
+
+#[derive(Component)]
+struct FxHover {
+    bob_amp: f32,
+    bob_freq: f32,
+    spin_rate: f32,
+    phase: f32,
+}
+
+#[derive(Component)]
+struct FxRise {
+    rate: f32,
+    range: f32,
+    drift: Vec2,
+    grow: f32,
+    phase: f32,
+}
+
+/// Breathes a glow part's emissive. Each pulsing part owns a UNIQUE material instance,
+/// so mutating it here can't bleed into other parts.
+#[derive(Component)]
+struct FxPulse {
+    mat: Handle<StandardMaterial>,
+    emissive: LinearRgba,
+    freq: f32,
+    amp: f32,
+    phase: f32,
+}
+
+/// Spawn a [`LandmarkModel`] at `xf`: the base mesh on `white` (the scene's shared
+/// vertex-colour material) with each [`AnimPart`] as a child (children inherit the root
+/// scale/yaw, so parts are authored in the same model-local space as the base). Returns the
+/// root entity — callers add their own tags (`BiomeEntity`, the POI attach, …).
+pub fn spawn_landmark_model(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    materials: &mut Assets<StandardMaterial>,
+    white: &Handle<StandardMaterial>,
+    model: LandmarkModel,
+    xf: Transform,
+) -> Entity {
+    let root = commands
+        .spawn((Mesh3d(meshes.add(model.base)), MeshMaterial3d(white.clone()), xf, Visibility::Inherited))
+        .id();
+    for part in model.parts {
+        // Material: glow → own unlit emissive (beacon recipe); translucent → own blend
+        // material; otherwise the shared white.
+        let mut pulse = None;
+        let (mat, shadowless) = if let Some(g) = &part.glow {
+            let emissive = LinearRgba::from(g.color) * g.strength;
+            let handle = materials.add(StandardMaterial {
+                base_color: g.color,
+                emissive,
+                unlit: true,
+                ..default()
+            });
+            if let Some((freq, amp, phase)) = g.pulse {
+                pulse = Some(FxPulse { mat: handle.clone(), emissive, freq, amp, phase });
+            }
+            (handle, true)
+        } else if part.alpha < 1.0 {
+            let handle = materials.add(StandardMaterial {
+                base_color: Color::srgba(1.0, 1.0, 1.0, part.alpha),
+                alpha_mode: AlphaMode::Blend,
+                unlit: true,
+                cull_mode: None,
+                ..default()
+            });
+            (handle, true)
+        } else {
+            (white.clone(), false)
+        };
+        let mesh = meshes.add(part.mesh);
+        commands.entity(root).with_children(|p| {
+            let mut e = p.spawn((Mesh3d(mesh), MeshMaterial3d(mat), part.xf, RestXf(part.xf)));
+            if shadowless {
+                e.insert(NotShadowCaster);
+            }
+            match part.fx {
+                Fx::None => {}
+                Fx::Spin { axis, rate } => {
+                    e.insert(FxSpin { axis, rate });
+                }
+                Fx::Sway { axis, amp, freq, phase } => {
+                    e.insert(FxSway { axis, amp, freq, phase });
+                }
+                Fx::Orbit { centre, rate, bob_amp, bob_freq, phase } => {
+                    e.insert(FxOrbit { centre, rate, bob_amp, bob_freq, phase });
+                }
+                Fx::Hover { bob_amp, bob_freq, spin_rate, phase } => {
+                    e.insert(FxHover { bob_amp, bob_freq, spin_rate, phase });
+                }
+                Fx::Rise { rate, range, drift, grow, phase } => {
+                    e.insert(FxRise { rate, range, drift, grow, phase });
+                }
+            }
+            if let Some(p) = pulse {
+                e.insert(p);
+            }
+        });
+    }
+    root
+}
+
+// ── The cosmetic animators ─────────────────────────────────────────────────────
+
+fn fx_spin(time: Res<Time>, mut q: Query<(&FxSpin, &RestXf, &mut Transform)>) {
+    let t = time.elapsed_secs();
+    for (s, rest, mut xf) in &mut q {
+        xf.rotation = rest.0.rotation * Quat::from_axis_angle(s.axis, (t * s.rate) % TAU);
+    }
+}
+
+fn fx_sway(time: Res<Time>, mut q: Query<(&FxSway, &RestXf, &mut Transform)>) {
+    let t = time.elapsed_secs();
+    for (s, rest, mut xf) in &mut q {
+        // A touch of second-harmonic so the pendulum reads hand-touched, not metronomic.
+        let a = (t * s.freq + s.phase).sin() + 0.25 * (t * s.freq * 2.7 + s.phase).sin();
+        xf.rotation = rest.0.rotation * Quat::from_axis_angle(s.axis, a * s.amp);
+    }
+}
+
+fn fx_orbit(time: Res<Time>, mut q: Query<(&FxOrbit, &RestXf, &mut Transform)>) {
+    let t = time.elapsed_secs();
+    for (o, rest, mut xf) in &mut q {
+        let rel = rest.0.translation - o.centre;
+        let swing = Quat::from_rotation_y(t * o.rate + o.phase);
+        let bob = o.bob_amp * (t * o.bob_freq + o.phase * 1.7).sin();
+        xf.translation = o.centre + swing * rel + Vec3::Y * bob;
+        // Shards tumble gently as they circle.
+        xf.rotation = rest.0.rotation * Quat::from_rotation_y(t * o.rate * 0.6);
+    }
+}
+
+fn fx_hover(time: Res<Time>, mut q: Query<(&FxHover, &RestXf, &mut Transform)>) {
+    let t = time.elapsed_secs();
+    for (h, rest, mut xf) in &mut q {
+        xf.translation = rest.0.translation + Vec3::Y * (h.bob_amp * (t * h.bob_freq + h.phase).sin());
+        xf.rotation = rest.0.rotation * Quat::from_rotation_y((t * h.spin_rate + h.phase) % TAU);
+    }
+}
+
+fn fx_rise(time: Res<Time>, mut q: Query<(&FxRise, &RestXf, &mut Transform)>) {
+    let t = time.elapsed_secs();
+    for (r, rest, mut xf) in &mut q {
+        let p = (t * r.rate + r.phase).rem_euclid(r.range);
+        let f = p / r.range;
+        xf.translation =
+            rest.0.translation + Vec3::new(r.drift.x * f, p, r.drift.y * f);
+        xf.scale = rest.0.scale * (0.55 + r.grow * f);
+    }
+}
+
+fn fx_pulse(time: Res<Time>, mut mats: ResMut<Assets<StandardMaterial>>, q: Query<&FxPulse>) {
+    let t = time.elapsed_secs();
+    for p in &q {
+        if let Some(mut m) = mats.get_mut(&p.mat) {
+            m.emissive = p.emissive * (1.0 + (t * p.freq + p.phase).sin() * p.amp);
         }
     }
-
-    // Talus skirt under the arch.
-    for (i, &(dx, dz)) in [
-        (-1.35_f32, 0.70),
-        (1.30, -0.60),
-        (0.10, 0.95),
-        (-0.85, -0.88),
-        (1.55, 0.30),
-        (-1.55, -0.25),
-    ]
-    .iter()
-    .enumerate()
-    {
-        let r = 0.16 + (i % 3) as f32 * 0.05;
-        parts.push(facet_at(
-            r,
-            Vec3::new(dx, r * 0.58, dz),
-            0.66,
-            if i % 2 == 0 { STONE_COOL } else { PEBBLE_WARM },
-        ));
-    }
-
-    mottle(flat_shaded(merged(parts)), 0.62)
 }
 
-// ── Frozen spire (snow landmark) ──────────────────────────────────────────────
+/// Registers the landmark part animators. Added by the game AND the standalone model viewer,
+/// so `FOREST_VIEW=landmark:mill` previews the same motion the island renders.
+pub struct RuinsFxPlugin;
 
-/// A slim hanging icicle rooted at `root` (tip stays above y=0).
-fn icicle(r: f32, len: f32, root: Vec3) -> Mesh {
-    tinted(
-        Cone { radius: r, height: len }
-            .mesh()
-            .resolution(4)
-            .build()
-            .rotated_by(Quat::from_rotation_x(PI))
-            .translated_by(root - yv(len * 0.5)),
-        lin(ICE_PALE),
-    )
-}
-
-/// **The Frozen Spire** — a banded ice hoodoo (wind-carved drums + protruding pale ledges)
-/// erupting from a frost-boulder footing with snow dusting and icicles. No snow-dome plinth.
-/// ~3.8u tall, base at y=0.
-pub fn build_frozen_spire_mesh() -> Mesh {
-    let mut parts: Vec<Mesh> = Vec::new();
-
-    // Frost-boulder footing — split tor + snow dusting (biome_snow boulder recipe).
-    parts.push(chunk_at(0.32, yv(0.16), Vec3::new(1.2, 0.72, 1.05), 0.12, 0.08, 0, FROST_ROCK));
-    parts.push(chunk_at(0.24, Vec3::new(0.10, 0.52, -0.05), Vec3::new(1.15, 0.88, 0.95), 0.75, -0.20, 0, FROST_ROCK));
-    parts.push(facet_tinted(0.14, Vec3::new(-0.18, 0.50, 0.12), 0.48, lin_scaled(FROST_ROCK, 1.08)));
-    parts.push(ball(0.24, yv(0.46), 0.44, SNOW_CAP));
-    parts.push(ball(0.16, Vec3::new(0.18, 0.38, 0.14), 0.45, SNOW_CAP));
-    parts.push(ball(0.13, Vec3::new(-0.20, 0.34, -0.14), 0.48, SNOW_SHADE));
-
-    // Central spire — stacked angular ice chunks (detail 1) tapering to a crown shard.
-    let bands: [(f32, f32, u32, f32); 6] = [
-        (0.40, 0.48, ICE_DEEP, 0.00),
-        (0.34, 0.44, ICE_BODY, 0.06),
-        (0.28, 0.40, ICE_RIME, 0.12),
-        (0.22, 0.36, ICE_BODY, 0.20),
-        (0.17, 0.32, ICE_RIME, 0.28),
-        (0.12, 0.28, ICE_PALE, 0.34),
-    ];
-    let mut cy = 0.10;
-    for (i, &(r, h, c, drift)) in bands.iter().enumerate() {
-        parts.push(chunk_at(
-            r,
-            Vec3::new(drift * 0.06, cy + h * 0.5, drift * 0.04),
-            Vec3::new(1.0, h * 2.2, 0.92),
-            drift,
-            0.06,
-            1,
-            c,
-        ));
-        cy += h;
-        if i == 1 || i == 3 {
-            parts.push(facet_at(r * 0.62, Vec3::new(drift * 0.08, cy, drift * 0.05), 0.38, ICE_PALE));
-        }
+impl Plugin for RuinsFxPlugin {
+    fn build(&self, app: &mut App) {
+        // Ungated (render-side dressing, like banner flutter): the mill keeps turning and the
+        // witch-lights keep breathing while a shop panel freezes the sim.
+        app.add_systems(Update, (fx_spin, fx_sway, fx_orbit, fx_hover, fx_rise, fx_pulse));
     }
-    parts.push(chunk_at(
-        0.14,
-        Vec3::new(0.14, cy + 0.28, 0.05),
-        Vec3::new(0.8, 1.5, 0.8),
-        0.55,
-        -0.14,
-        1,
-        ICE_PALE,
-    ));
-    // Bright sunlit facets on the windward flanks.
-    for i in 0..3 {
-        let a = i as f32 * (TAU / 3.0) + 0.25;
-        parts.push(facet_at(0.14, Vec3::new(a.cos() * 0.34, cy * 0.55, a.sin() * 0.34), 0.42, ICE_PALE));
-    }
-    parts.push(icicle(0.022, 0.14, Vec3::new(0.34, 0.38, 0.06)));
-    parts.push(icicle(0.016, 0.10, Vec3::new(-0.28, 0.34, -0.08)));
-
-    // Flanking shards — leaning ice slabs + tip splinters.
-    for i in 0..5 {
-        let a = i as f32 * (TAU / 5.0) + 0.35;
-        let (sx, sz) = (a.cos() * 0.82, a.sin() * 0.82);
-        let h = 0.90 + (i % 3) as f32 * 0.30;
-        let c = if i % 2 == 0 { ICE_BODY } else { ICE_DEEP };
-        parts.push(slab_at(
-            0.22,
-            h,
-            0.18,
-            Vec3::new(sx, slab_ground(0.22, h, 0.30) + 0.02, sz),
-            a,
-            0.30,
-            c,
-        ));
-        parts.push(chunk_at(
-            0.10,
-            Vec3::new(sx + a.cos() * 0.06, h * 0.92, sz + a.sin() * 0.06),
-            Vec3::new(0.75, 1.15, 0.75),
-            a + 0.35,
-            -0.18,
-            0,
-            ICE_PALE,
-        ));
-    }
-
-    // Shed ice chips at the foot.
-    for &(dx, dz) in &[(0.55_f32, 0.42), (-0.48, -0.38), (0.62, -0.52), (-0.58, 0.45)] {
-        parts.push(facet_at(0.08, Vec3::new(dx, 0.05, dz), 0.62, ICE_RIM));
-    }
-
-    mottle(flat_shaded(merged(parts)), 0.34)
-}
-
-// ── Sunken pyramid (desert landmark) ──────────────────────────────────────────
-
-/// One complete ziggurat step: 8 perimeter slabs + centre fill + sunlit rim facets + front tread.
-fn pyramid_tier(y: f32, w: f32, th: f32, body: u32, lit: u32) -> Vec<Mesh> {
-    let mut p = Vec::new();
-    if y > 0.01 {
-        p.push(facet_at(w * 0.50, yv(y + 0.035), 0.28, SAND_SHADOW));
-    }
-    for i in 0..8 {
-        let a = i as f32 * (TAU / 8.0) + 0.18;
-        let (cx, cz) = (a.cos() * w * 0.36, a.sin() * w * 0.36);
-        let tilt = if i % 2 == 0 { 0.05 } else { -0.04 };
-        p.push(slab_at(w * 0.26, th, w * 0.22, Vec3::new(cx, y + th * 0.5, cz), a, tilt, body));
-    }
-    p.push(block_at(w * 0.40, th * 0.94, w * 0.38, yv(y + th * 0.48), 0.02, body));
-    for i in 0..4 {
-        let a = i as f32 * FRAC_PI_2 + FRAC_PI_4;
-        let (cx, cz) = (a.cos() * w * 0.20, a.sin() * w * 0.20);
-        p.push(block_at(w * 0.18, th * 0.82, w * 0.16, Vec3::new(cx, y + th * 0.46, cz), 0.04, body));
-    }
-    for i in 0..4 {
-        let a = i as f32 * FRAC_PI_2 + 0.35;
-        p.push(facet_at(
-            w * 0.20,
-            Vec3::new(a.cos() * w * 0.38, y + th - 0.025, a.sin() * w * 0.38),
-            0.22,
-            lit,
-        ));
-    }
-    // Front staircase — three flat treads climbing the +Z face.
-    for k in 0..3 {
-        let t = k as f32 / 2.0;
-        p.push(flat_stone(
-            0.58 - t * 0.08,
-            th * 0.07,
-            0.38,
-            Vec3::new(0.0, y + th * (0.32 + t * 0.22), w * 0.46 + k as f32 * 0.04),
-            0.0,
-            lit,
-        ));
-    }
-    p
-}
-
-/// **The Sunken Pyramid** — a weathered stepped sandstone ziggurat: five solid tiers (8-slab
-/// rings + infill per step), banded ochre/rust courses, a doorwayed summit cluster, half-buried
-/// sand pebbles at the foot, and a toppled obelisk. No blank platform. ~3.7u tall, base at y=0.
-pub fn build_sunken_pyramid_mesh() -> Mesh {
-    let mut parts: Vec<Mesh> = Vec::new();
-
-    // Half-buried sand — scattered pebbles + low drifts hugging the lowest course.
-    for &(dx, dz, r, c) in &[
-        (1.55_f32, 1.40, 0.30, SAND_DK),
-        (-1.65, 1.25, 0.26, SAND_BODY),
-        (-1.35, -1.55, 0.28, SAND_DK),
-        (1.45, -1.30, 0.24, SAND_BODY),
-        (0.85, 1.65, 0.20, SAND_DK),
-        (-1.75, -0.55, 0.22, SAND_BODY),
-    ] {
-        parts.push(facet_at(r, Vec3::new(dx, r * 0.48, dz), 0.54, c));
-    }
-    for &(dx, dz, yaw) in &[(1.4_f32, 1.2, 0.5), (-1.5, -1.1, -0.7)] {
-        parts.push(slab_at(0.85, 0.10, 0.55, Vec3::new(dx, 0.06, dz), yaw, 0.06, SAND_DK));
-    }
-
-    let tiers = 5;
-    let (w0, w1, th) = (3.15_f32, 0.95_f32, 0.38_f32);
-    let bodies = [HOODOO_RUST, SAND_BODY, HOODOO_BASE, SAND_DK, HOODOO_PALE];
-    let mut y_base = 0.0_f32;
-    let mut top_w = w0;
-    for i in 0..tiers {
-        let t = i as f32 / (tiers - 1) as f32;
-        let w = w0 + (w1 - w0) * t;
-        for p in pyramid_tier(y_base, w, th, bodies[i], SAND_LT) {
-            parts.push(p);
-        }
-        y_base += th;
-        top_w = w;
-    }
-
-    // Summit temple — layered cap blocks + dark doorway recess on the +Z face.
-    let tw = top_w * 0.88;
-    let tht = 0.52;
-    parts.push(block_at(tw * 0.44, tht, tw * 0.40, yv(y_base + tht * 0.5), 0.03, HOODOO_BASE));
-    parts.push(slab_at(tw * 0.52, 0.14, tw * 0.48, yv(y_base + tht + 0.06), 0.25, 0.02, HOODOO_RUST));
-    parts.push(facet_at(tw * 0.18, Vec3::new(0.0, y_base + tht * 0.40, tw * 0.47), 0.52, SAND_DOOR));
-    parts.push(facet_at(tw * 0.14, Vec3::new(tw * 0.32, y_base + tht * 0.72, 0.0), 0.24, SAND_LT));
-    parts.push(facet_at(tw * 0.12, Vec3::new(-tw * 0.30, y_base + tht * 0.68, -0.02), 0.24, SAND_LT));
-
-    // Toppled obelisk — fallen slab shaft + pyramidion chip half-buried in sand.
-    parts.push(slab_at(0.28, 1.50, 0.24, Vec3::new(2.15, 0.85, 0.48), 0.45, 1.18, HOODOO_RUST));
-    parts.push(chunk_at(
-        0.20,
-        Vec3::new(2.58, 0.24, 0.55),
-        Vec3::new(0.9, 0.75, 0.9),
-        -0.6,
-        0.2,
-        0,
-        HOODOO_PALE,
-    ));
-    parts.push(facet_at(0.26, Vec3::new(-2.15, 0.14, 0.92), 0.64, SAND_BODY));
-    parts.push(facet_at(0.20, Vec3::new(-2.40, 0.11, -0.62), 0.64, SAND_DK));
-    parts.push(facet_at(0.16, Vec3::new(0.80, 0.09, -1.48), 0.58, SAND_DK));
-
-    mottle(flat_shaded(merged(parts)), 0.60)
 }
 
 // ── Per-biome placement (combined world map) ─────────────────────────────────────
 
-/// Plant one signature landmark in each biome region of the combined map. Reject-samples a
-/// clear, on-land tile of the target biome (away from camps/castle) and — crucially — seats
-/// it on the FLATTEST footprint it can find, never on a slope or with an edge over the sea, so
-/// the set-piece sits cleanly on the ground instead of clipping through a terrace. Mirrors the
-/// wildlife/ore placement; called from `worldmap::build`.
 /// A chosen landmark spot, picked once from the TERRAIN (before scatter) so both the landmark
 /// placement here and the road network (`roads::build_curves`) can route to the same point.
 #[derive(Clone, Copy)]
@@ -637,23 +522,23 @@ pub struct LandmarkSite {
     pub spread: f32,
 }
 
-/// (biome, scale, footprint_radius) for each landmark. KEEP IN SYNC with the `specs` mesh table in
-/// [`populate_landmarks`] — same scale/foot_r per biome (that table also carries the mesh + box).
-// Scales bumped ~+20% (map-character overhaul pass 4): each landmark is its biome's skyline
-// FLAG — it has to break the treeline from the road, or the spur leading to it pulls nobody.
+/// (biome, scale, footprint_radius) for each landmark. KEEP IN SYNC with the `specs` table in
+/// [`populate_landmarks`] — same scale per biome (that table carries the model + blockers).
+/// Each landmark is its biome's skyline FLAG — it has to break the treeline from the road, or
+/// the spur leading to it pulls nobody.
 const SITE_PARAMS: [(crate::biome::Biome, f32, f32); 5] = [
-    (crate::biome::Biome::Snow, 1.7, 1.0),
-    (crate::biome::Biome::Desert, 1.55, 2.0),
-    (crate::biome::Biome::Rocky, 1.55, 2.0),
-    (crate::biome::Biome::Forest, 1.5, 0.7),
-    (crate::biome::Biome::Swamp, 1.35, 0.8),
+    (crate::biome::Biome::Snow, 1.5, 1.4),
+    (crate::biome::Biome::Desert, 1.5, 2.4),
+    (crate::biome::Biome::Rocky, 1.45, 2.4),
+    (crate::biome::Biome::Forest, 1.45, 1.5),
+    (crate::biome::Biome::Swamp, 1.4, 1.5),
 ];
 
 /// The five landmark spots, chosen once (flattest valid candidate per biome) and cached. Decoupled
 /// from `blockers` — those aren't populated this early (the road field bakes at the ground pass,
 /// long before scatter) — so spots shifted slightly vs. the old post-scatter search; the
 /// `LANDMARK_CLEAR_R` sweep fells any scatter that ends up under a landmark anyway. The fortress
-/// blob is excluded by radius (its forced-flat plateau would otherwise lure the swamp sentinel).
+/// blob is excluded by radius (its forced-flat plateau would otherwise lure the swamp landmark).
 pub fn landmark_sites() -> &'static [LandmarkSite] {
     static SITES: OnceLock<Vec<LandmarkSite>> = OnceLock::new();
     SITES.get_or_init(|| {
@@ -703,38 +588,35 @@ pub fn populate_landmarks(
     materials: &mut Assets<StandardMaterial>,
 ) {
     use crate::biome::{Biome, BiomeEntity};
-    let mat = materials.add(StandardMaterial { base_color: Color::WHITE, perceptual_roughness: 0.92, ..default() });
-    // (biome, mesh, scale, (box_hw, box_hd), footprint_radius) — one landmark each. The solid is an
-    // oriented BOX (not a ≤1.0 circle) so wide set-pieces — the trilithon's standing stones, the
-    // pyramid's broad base — actually block instead of letting you walk through their edges. The
-    // half-extents (mesh-local, world-scaled below) hug each silhouette; footprint_radius is the
-    // flatness-probe reach (now lives in `SITE_PARAMS` — keep both in sync).
-    let specs: [(Biome, Mesh, f32, (f32, f32)); 5] = [
-        (Biome::Snow, build_frozen_spire_mesh(), 1.7, (0.7, 0.7)),
-        (Biome::Desert, build_sunken_pyramid_mesh(), 1.55, (1.15, 1.15)),
-        (Biome::Rocky, build_trilithon_mesh(), 1.55, (1.25, 0.55)), // wide arch, thin depth
-        (Biome::Forest, build_giant_dead_tree_mesh(), 1.5, (0.55, 0.55)),
-        (Biome::Swamp, build_swamp_sentinel_mesh(), 1.35, (0.65, 0.65)),
+    let white = materials.add(StandardMaterial { base_color: Color::WHITE, perceptual_roughness: 0.92, ..default() });
+    // (biome, model, scale, blocker OBBs) — one landmark each. Blockers are `(dx, dz, hw, hd)` in
+    // MODEL-LOCAL units (rotated into place with the placed yaw, scaled to world): most landmarks
+    // block one box hugging the built mass, but the standing stones block PER-STONE so the circle
+    // itself stays walkable (the rune trial plays out inside it).
+    let specs: [(Biome, LandmarkModel, f32, Vec<(f32, f32, f32, f32)>); 5] = [
+        (Biome::Snow, crate::landmark_models::frozen_spire(), 1.5, vec![(0.0, 0.0, 1.0, 1.0)]),
+        (Biome::Desert, crate::landmark_models::sunken_pyramid(), 1.5, vec![(0.0, 0.0, 2.1, 2.1)]),
+        (Biome::Rocky, crate::landmark_models::standing_stones(), 1.45, crate::landmark_models::stone_blockers()),
+        (Biome::Forest, crate::landmark_models::old_mill(), 1.45, vec![(0.0, 0.0, 1.5, 1.5)]),
+        (Biome::Swamp, crate::landmark_models::witch_hut(), 1.4, vec![(0.0, 0.3, 1.25, 1.1), (1.7, 1.2, 0.55, 0.55)]),
     ];
-    // Spots are pre-chosen from the terrain (see `landmark_sites`); here we just plant the mesh.
-    for (biome, mesh, scale, (box_hw, box_hd)) in specs {
-        let handle = meshes.add(mesh);
+    // Spots are pre-chosen from the terrain (see `landmark_sites`); here we just plant the model.
+    for (biome, model, scale, obbs) in specs {
         let Some(s) = landmark_sites().iter().find(|s| s.biome == biome) else {
             continue; // `landmark_sites` already logged the miss.
         };
         let (x, y, z, yaw) = (s.pos.x, s.y, s.pos.y, s.yaw);
-        let id = commands
-            .spawn((
-                Mesh3d(handle.clone()),
-                MeshMaterial3d(mat.clone()),
-                Transform::from_xyz(x, y, z)
-                    .with_rotation(Quat::from_rotation_y(yaw))
-                    .with_scale(Vec3::splat(scale)),
-                BiomeEntity,
-            ))
-            .id();
-        // Solid oriented box, scaled into world units + turned to match the placed mesh yaw.
-        crate::blockers::add_obb(x, z, box_hw * scale, box_hd * scale, yaw);
+        let xf = Transform::from_xyz(x, y, z)
+            .with_rotation(Quat::from_rotation_y(yaw))
+            .with_scale(Vec3::splat(scale));
+        let id = spawn_landmark_model(commands, meshes, materials, &white, model, xf);
+        commands.entity(id).insert(BiomeEntity);
+        // Solid oriented boxes, offsets rotated by the placed yaw + scaled into world units.
+        let (sin, cos) = yaw.sin_cos();
+        for (dx, dz, hw, hd) in obbs {
+            let (wx, wz) = ((dx * cos + dz * sin) * scale, (-dx * sin + dz * cos) * scale);
+            crate::blockers::add_obb(x + wx, z + wz, hw * scale, hd * scale, yaw);
+        }
         crate::landmarks::attach(commands, id, biome, Vec3::new(x, y, z), meshes, materials);
         if s.spread > crate::worldmap::GROUND_STEP {
             info!("landmark {:?}: best spot still uneven (spread {:.2})", biome, s.spread);
@@ -759,103 +641,4 @@ fn footprint_spread(x: f32, z: f32, radius: f32) -> Option<f32> {
         }
     }
     Some(hi - lo)
-}
-
-// ── Dead trees (forest + swamp landmarks) ─────────────────────────────────────────
-
-/// **The Hollow Oak** — a tall bare gnarled dead tree, ~5u to the branch tips, base at y=0.
-pub fn build_giant_dead_tree_mesh() -> Mesh {
-    mottle(flat_shaded(merged(dead_tree_parts(TREE_BARK, TREE_BARK_DARK, TREE_ROOT, None))), 0.4)
-}
-
-/// **The Mire Sentinel** — the swamp's drowned cousin of the dead tree: mossy grey-green,
-/// water-stained bark, hanging moss strands off the limbs and a ring of knob-tipped cypress
-/// "knees" round its sodden base. Base at y=0.
-pub fn build_swamp_sentinel_mesh() -> Mesh {
-    mottle(flat_shaded(merged(dead_tree_parts(SWAMP_BARK, SWAMP_BARK_DARK, SWAMP_ROOT, Some(SWAMP_MOSS)))), 0.44)
-}
-
-/// Shared dead-tree build: a dark flared root collar grounding a tapered three-segment
-/// gnarled trunk, shallow flared roots, and four thick bare branches (each sprouting a
-/// forked twig) high up, plus a dark hollow knot. `moss = Some(c)` makes it the swamp
-/// sentinel — hanging moss strands off each branch, a moss saddle on the trunk, and a ring
-/// of cypress knees at the base.
-fn dead_tree_parts(bark: u32, bark_dark: u32, root: u32, moss: Option<u32>) -> Vec<Mesh> {
-    let mut parts: Vec<Mesh> = Vec::new();
-
-    // Dark flared root collar / stump the trunk grows out of (base at y=0).
-    parts.push(tinted(limb(0.46, 0.55, 8, 0.0, 0.0, Vec3::ZERO), lin(bark_dark)));
-
-    // Shallow flared roots splaying from the base — five around the trunk, laid nearly flat.
-    for i in 0..5 {
-        let yaw = i as f32 * TAU / 5.0 + 0.3;
-        let len = 0.55 + (i as f32 * 0.07);
-        parts.push(tinted(limb(0.13, len, 5, FRAC_PI_2 * 1.05, yaw, Vec3::new(0.0, 0.16, 0.0)), lin(root)));
-    }
-
-    // ── Trunk: three stacked tapered segments, each leaning a touch more for a gnarl.
-    let seg_specs: [(f32, f32, f32, f32); 3] = [
-        (1.5, 0.31, 0.05, 0.0),  // lower (darker)
-        (1.4, 0.23, -0.08, 0.5), // mid
-        (1.2, 0.15, 0.13, 0.3),  // upper (thinnest)
-    ];
-    let trunk_base_y = 0.4;
-    let mut tip = Vec3::new(0.0, trunk_base_y, 0.0);
-    let mut accum = Quat::IDENTITY;
-    for (idx, &(h, r, lean_z, lean_yaw)) in seg_specs.iter().enumerate() {
-        accum = accum * Quat::from_rotation_y(lean_yaw) * Quat::from_rotation_z(lean_z);
-        let seg = Cylinder::new(r, h)
-            .mesh()
-            .resolution(6)
-            .build()
-            .translated_by(Vec3::new(0.0, h * 0.5, 0.0))
-            .rotated_by(accum)
-            .translated_by(tip);
-        let hex = if idx == 0 { bark_dark } else { bark };
-        parts.push(tinted(seg, lin(hex)));
-        tip += accum * Vec3::new(0.0, h, 0.0);
-    }
-
-    // Dark hollow knot on the lower trunk (a recessed eye in the bark).
-    parts.push(ball(0.16, Vec3::new(0.18, 1.4, 0.18), 0.85, root));
-
-    // ── Branches: thick bare limbs forking outward/upward high on the trunk.
-    let branches: [(f32, f32, f32, f32, f32); 4] = [
-        (2.4, 0.4, 0.85, 1.05, 0.115),
-        (2.9, 2.5, 0.75, 0.95, 0.10),
-        (3.3, 4.4, 0.95, 0.90, 0.09),
-        (3.6, 1.4, 0.6, 0.75, 0.075),
-    ];
-    for &(ay, yaw, pitch, len, r) in branches.iter() {
-        let attach = Vec3::new(0.0, ay, 0.0);
-        parts.push(tinted(limb(r, len, 5, -pitch, yaw, attach), lin(bark)));
-        let branch_rot = Quat::from_rotation_y(yaw) * Quat::from_rotation_z(-pitch);
-        let tip_pt = attach + branch_rot * Vec3::new(0.0, len, 0.0);
-        let twig_rot = branch_rot * Quat::from_rotation_z(0.7);
-        let twig = Cylinder::new(r * 0.5, len * 0.5)
-            .mesh()
-            .resolution(5)
-            .build()
-            .translated_by(Vec3::new(0.0, len * 0.25, 0.0))
-            .rotated_by(twig_rot)
-            .translated_by(tip_pt);
-        parts.push(tinted(twig, lin(bark)));
-        // Swamp: a strand of moss hanging straight down off the branch tip.
-        if let Some(mc) = moss {
-            parts.push(tinted(box_at(0.05, 0.55, 0.05, tip_pt + yv(-0.28)), lin(mc)));
-        }
-    }
-
-    // ── Swamp extras: a moss saddle on the trunk + a ring of cypress knees at the base.
-    if let Some(mc) = moss {
-        parts.push(ball(0.34, yv(1.0), 0.5, mc));
-        for i in 0..5 {
-            let a = i as f32 * TAU / 5.0 + 0.7;
-            let (kx, kz) = (a.cos() * 0.78, a.sin() * 0.78);
-            parts.push(cyl(0.09, 0.32, Vec3::new(kx, 0.16, kz), 5, bark_dark));
-            parts.push(ball(0.1, Vec3::new(kx, 0.34, kz), 0.8, mc));
-        }
-    }
-
-    parts
 }

--- a/src/savegame.rs
+++ b/src/savegame.rs
@@ -567,8 +567,8 @@ mod tests {
             blight_captives_freed: vec![false, true],
             discoveries_found: 3,
             discoveries_completed: false,
-            discovered_landmarks: vec!["The Hollow Oak".into()],
-            claimed_landmark_gear: vec!["The Hollow Oak".into()],
+            discovered_landmarks: vec!["The Old Mill".into()],
+            claimed_landmark_gear: vec!["The Old Mill".into()],
             opened_chests: vec![false, true, false],
             quest: Some(QuestLog { active: 3, progress: 2.0 }),
             rival_gold: 142.5,
@@ -593,7 +593,7 @@ mod tests {
         assert_eq!(back.upgrades, data.upgrades);
         assert!(back.defenses.walls);
         assert_eq!(back.rescued_camps, vec![true, false, true]);
-        assert_eq!(back.discovered_landmarks, vec!["The Hollow Oak".to_string()]);
+        assert_eq!(back.discovered_landmarks, vec!["The Old Mill".to_string()]);
         assert_eq!(back.opened_chests, vec![false, true, false]);
         assert_eq!(back.quest, Some(QuestLog { active: 3, progress: 2.0 }));
         assert!(back.bag.has_item("potion"));

--- a/src/snowman.rs
+++ b/src/snowman.rs
@@ -51,9 +51,12 @@ const RESPAWN: f32 = 150.0;
 /// Waddle leg-swing frequency while shambling.
 const GAIT: f32 = 5.5;
 
-/// Snow biome region centre (world XZ) — snowmen scatter around here (see CLAUDE.md biome table).
-const SNOW_CENTRE: Vec2 = Vec2::new(-69.0, -45.0);
-/// How far from [`SNOW_CENTRE`] a snowman may be placed.
+/// Snow biome region centre — snowmen scatter around here (see CLAUDE.md biome table).
+/// Authored at MAP_SCALE 2.2; `world22` rescales it to the current map size.
+fn snow_centre() -> Vec2 {
+    crate::worldmap::world22(-69.0, -45.0)
+}
+/// How far from [`snow_centre`] a snowman may be placed.
 const SCATTER_R: f32 = 30.0;
 /// Target number of ambush snowmen on the island.
 const COUNT: usize = 10;
@@ -174,7 +177,7 @@ fn seed_snowmen(
         // Uniform-ish point in the scatter disc around the snow centre.
         let ang = frand(&mut rng) * std::f32::consts::TAU;
         let rad = SCATTER_R * frand(&mut rng).sqrt();
-        let p = SNOW_CENTRE + Vec2::new(ang.cos(), ang.sin()) * rad;
+        let p = snow_centre() + Vec2::new(ang.cos(), ang.sin()) * rad;
         // Must be walkable snow, off any build plot, and spaced from its siblings.
         if footing(p.x, p.y).is_none()
             || crate::worldmap::biome_at_world(p.x, p.y) != Some(crate::biome::Biome::Snow)

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -9,11 +9,15 @@
 //! turntable). `main()` calls [`run`] and returns early when `FOREST_VIEW` is set.
 //!
 //! Models: `FOREST_VIEW=hero` (default) renders the knight in rest pose; honours
-//! `FOREST_EQUIP="weapon,armor"`. `FOREST_VIEW=landmark:trilithon|spire|pyramid`
-//! previews a biome landmark prop on the white vertex-colour material.
+//! `FOREST_EQUIP="weapon,armor"`. `FOREST_VIEW=landmark:mill|hut|spire|pyramid|stones`
+//! previews a biome landmark SET-PIECE — the full `LandmarkModel` (merged base + animated
+//! parts) on the white vertex-colour material, with the real `RuinsFxPlugin` animators
+//! running, auto-framed from the mesh bounds (big props need a far camera, not the
+//! character default). `FOREST_CAM` still overrides the framing.
 
 use std::f32::consts::FRAC_PI_2;
 
+use bevy::mesh::VertexAttributeValues;
 use bevy::prelude::*;
 use bevy::window::WindowResolution;
 
@@ -36,6 +40,7 @@ pub fn run() {
         .add_plugins(crate::quadruped::QuadrupedPlugin) // poses any previewed quadruped from its QuadDrive
         .add_plugins(crate::biped::BipedPlugin) // poses any previewed ork/peasant biped from its BipedDrive
         .add_plugins(crate::capture::CapturePlugin) // FOREST_SHOT / FOREST_CLIP (+ _ORBIT turntable)
+        .add_plugins(crate::ruins::RuinsFxPlugin) // landmark part animators (sails/orbits/pulses)
         .insert_resource(GlobalAmbientLight { brightness: 160.0, ..default() })
         .insert_resource(ClearColor(Color::srgb(0.16, 0.17, 0.20)))
         .add_systems(Startup, setup);
@@ -209,6 +214,31 @@ fn parse_cam() -> Option<(Vec3, Vec3)> {
     (n.len() == 6).then(|| (Vec3::new(n[0], n[1], n[2]), Vec3::new(n[3], n[4], n[5])))
 }
 
+/// Min/max corners of a mesh's vertices — the auto-framing input for big props.
+fn mesh_bounds(m: &Mesh) -> (Vec3, Vec3) {
+    let (mut lo, mut hi) = (Vec3::splat(f32::MAX), Vec3::splat(f32::MIN));
+    if let Some(VertexAttributeValues::Float32x3(p)) = m.attribute(Mesh::ATTRIBUTE_POSITION) {
+        for v in p {
+            lo = lo.min(Vec3::from(*v));
+            hi = hi.max(Vec3::from(*v));
+        }
+    }
+    (lo, hi)
+}
+
+/// The landmark set-piece named by `landmark:<name>` (biome aliases accepted).
+fn landmark_model(name: &str) -> crate::ruins::LandmarkModel {
+    use crate::landmark_models as lm;
+    match name {
+        "hut" | "witch" | "swamp" => lm::witch_hut(),
+        "spire" | "snow" | "ice" => lm::frozen_spire(),
+        "pyramid" | "desert" => lm::sunken_pyramid(),
+        "stones" | "rocky" | "trilithon" | "circle" => lm::standing_stones(),
+        // `mill` / `forest` / anything else → the old mill.
+        _ => lm::old_mill(),
+    }
+}
+
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -216,34 +246,46 @@ fn setup(
     mut creature_mats: ResMut<Assets<crate::creature::CreatureMaterial>>,
 ) {
     // Camera — framed on a ~1.8u-tall model standing at the origin (chest-height look-at).
-    let (eye, target) = parse_cam().unwrap_or((Vec3::new(0.0, 1.0, 3.0), Vec3::new(0.0, 0.85, 0.0)));
+    // The landmark path below re-frames from the model's real bounds instead.
+    let (mut eye, mut target) = parse_cam().unwrap_or((Vec3::new(0.0, 1.0, 3.0), Vec3::new(0.0, 0.85, 0.0)));
+
+    // `FOREST_VIEW=landmark:<name>` — a full landmark set-piece: merged base on the white
+    // vertex-colour material + its animated parts (RuinsFxPlugin drives them here too).
+    let view_env = std::env::var("FOREST_VIEW").unwrap_or_default();
+    if let Some(name) = view_env.strip_prefix("landmark:") {
+        let model = landmark_model(name);
+        if parse_cam().is_none() {
+            // Auto-fit: pull back proportionally to the model's bounding radius, from a
+            // low front-right three-quarter angle (shows silhouette + ground dressing).
+            let (lo, hi) = mesh_bounds(&model.base);
+            let centre = (lo + hi) * 0.5;
+            let radius = ((hi - lo) * 0.5).length().max(1.0);
+            target = Vec3::new(centre.x, centre.y * 0.9, centre.z);
+            eye = centre + Vec3::new(0.62, 0.38, 1.0).normalize() * radius * 2.1;
+        }
+        commands.spawn((Camera3d::default(), Transform::from_translation(eye).looking_at(target, Vec3::Y)));
+        spawn_stage_lights(&mut commands);
+        spawn_ground(&mut commands, &mut meshes, &mut std_mats, 14.0);
+        let white = std_mats.add(StandardMaterial {
+            base_color: Color::WHITE,
+            perceptual_roughness: 0.92,
+            ..default()
+        });
+        crate::ruins::spawn_landmark_model(
+            &mut commands,
+            &mut meshes,
+            &mut std_mats,
+            &white,
+            model,
+            Transform::default(),
+        );
+        return;
+    }
+
     commands.spawn((Camera3d::default(), Transform::from_translation(eye).looking_at(target, Vec3::Y)));
 
-    // Three-point-ish lighting: a shadowed key, a soft fill from the opposite side, a back rim.
-    commands.spawn((
-        DirectionalLight { illuminance: 10_000.0, shadow_maps_enabled: true, ..default() },
-        Transform::from_xyz(4.0, 7.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-    ));
-    commands.spawn((
-        DirectionalLight { illuminance: 3_500.0, shadow_maps_enabled: false, ..default() },
-        Transform::from_xyz(-5.0, 4.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
-    ));
-    commands.spawn((
-        DirectionalLight { illuminance: 2_500.0, shadow_maps_enabled: false, ..default() },
-        Transform::from_xyz(0.0, 3.0, -6.0).looking_at(Vec3::ZERO, Vec3::Y),
-    ));
-
-    // Neutral ground disk so the model casts a shadow and isn't floating in void.
-    let ground = std_mats.add(StandardMaterial {
-        base_color: Color::srgb(0.22, 0.24, 0.27),
-        perceptual_roughness: 0.96,
-        ..default()
-    });
-    commands.spawn((
-        Mesh3d(meshes.add(Circle::new(6.0))),
-        MeshMaterial3d(ground),
-        Transform::from_rotation(Quat::from_rotation_x(-FRAC_PI_2)),
-    ));
+    spawn_stage_lights(&mut commands);
+    spawn_ground(&mut commands, &mut meshes, &mut std_mats, 6.0);
 
     // `FOREST_VIEW=trees` — the harvestable "chop these for wood" resources on the clean stage
     // (quest-card art): a few tree kinds + a desert saguaro, no world scene around them. These use
@@ -285,27 +327,7 @@ fn setup(
             crate::player::HeroHealth::default(),
         ))
         .id();
-    let view = std::env::var("FOREST_VIEW").unwrap_or_default();
-    if view.starts_with("landmark:") {
-        let mesh = match view.rsplit(':').next() {
-            Some("trilithon") | Some("rocky") | Some("stones") => crate::ruins::build_trilithon_mesh(),
-            Some("spire") | Some("snow") | Some("ice") => crate::ruins::build_frozen_spire_mesh(),
-            Some("pyramid") | Some("desert") => crate::ruins::build_sunken_pyramid_mesh(),
-            _ => crate::ruins::build_trilithon_mesh(),
-        };
-        let white = std_mats.add(StandardMaterial {
-            base_color: Color::WHITE,
-            perceptual_roughness: 0.92,
-            ..default()
-        });
-        commands.entity(root).insert((
-            Mesh3d(meshes.add(mesh)),
-            MeshMaterial3d(white),
-            Transform::from_scale(Vec3::splat(1.3)),
-        ));
-    } else {
-        spawn_model(&mut commands, root, &mut meshes, &mat);
-    }
+    spawn_model(&mut commands, root, &mut meshes, &mat);
 }
 
 /// Spawn the model named by `FOREST_VIEW` under `root`. Add new models as `match` arms.
@@ -444,6 +466,42 @@ fn spawn_model(
             crate::player::spawn_hero_meshes(commands, root, m, meshes, mat);
         }
     }
+}
+
+/// Three-point-ish lighting: a shadowed key, a soft fill from the opposite side, a back rim.
+fn spawn_stage_lights(commands: &mut Commands) {
+    commands.spawn((
+        DirectionalLight { illuminance: 10_000.0, shadow_maps_enabled: true, ..default() },
+        Transform::from_xyz(4.0, 7.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+    commands.spawn((
+        DirectionalLight { illuminance: 3_500.0, shadow_maps_enabled: false, ..default() },
+        Transform::from_xyz(-5.0, 4.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+    commands.spawn((
+        DirectionalLight { illuminance: 2_500.0, shadow_maps_enabled: false, ..default() },
+        Transform::from_xyz(0.0, 3.0, -6.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+}
+
+/// Neutral ground disk so the model casts a shadow and isn't floating in void.
+/// `r` scales with the subject (6u suits a character; landmarks want more).
+fn spawn_ground(
+    commands: &mut Commands,
+    meshes: &mut Assets<Mesh>,
+    std_mats: &mut Assets<StandardMaterial>,
+    r: f32,
+) {
+    let ground = std_mats.add(StandardMaterial {
+        base_color: Color::srgb(0.22, 0.24, 0.27),
+        perceptual_roughness: 0.96,
+        ..default()
+    });
+    commands.spawn((
+        Mesh3d(meshes.add(Circle::new(r))),
+        MeshMaterial3d(ground),
+        Transform::from_rotation(Quat::from_rotation_x(-FRAC_PI_2)),
+    ));
 }
 
 /// `FOREST_EQUIP="weapon_id,armor_id"` → `(weapon, armor)`; either side may be empty.

--- a/src/worldmap.rs
+++ b/src/worldmap.rs
@@ -41,12 +41,23 @@ use crate::water::{WaterExt, WaterMaterial, WaterParams};
 /// Bumped 1.5 → 1.8 (a clean +20% on every axis), then 1.8 → 2.0 to give the strongholds (esp.
 /// the desert rival, jammed against the north coast) more room, then 2.0 → 2.2 (map-character
 /// overhaul pass 0) so the biomes keep real interior once the fixed-world-size claims (warden
-/// glade r16, rival plateau r30, fortress apron) are subtracted. The two world-coord-authored
-/// landmarks scale with it automatically: `ork_fortress::BLIGHT_DZ` and `rival::RIVAL_CENTRE` are
-/// both derived from `MAP_SCALE`, so bumping it keeps the ork gate on the south coast and the
-/// rival fort in the desert with no hand-tuning. (The warden `boss::region_center` world coords
-/// are hand-authored but sit well inside their biomes at 2.2 — verified.)
-pub const MAP_SCALE: f32 = 2.2;
+/// glade r16, rival plateau r30, fortress apron) are subtracted, then 2.2 → 2.6 (landmark
+/// overhaul, July 2026 — paid for by the terrain far-LOD, see `build_terrain_chunk_coarse`).
+/// The world-coord-authored landmarks scale with it automatically: `ork_fortress::BLIGHT_DZ` and
+/// `rival::RIVAL_CENTRE` are derived from `MAP_SCALE`, and the remaining hand-authored world
+/// coords (warden `boss::region_center`, chest hoards, snowman field, the swamp pool keep-out)
+/// route through [`world22`] so they track scale bumps too. Per-bump manual checklist: trim
+/// `SAFE_R` (base-space, so it silently over-grows), re-size `navgrid::NAV_MAX_NODES` (A* budget
+/// ∝ tiles), and re-check CLAUDE.md's biome-centre table for capture framing.
+pub const MAP_SCALE: f32 = 2.6;
+
+/// Rescale a world-XZ coordinate that was hand-authored (and playtested) at `MAP_SCALE` 2.2 to
+/// the CURRENT scale. Generation runs in base space, so a point that sat inside a biome at 2.2
+/// maps to the same base-space spot — same biome, same relative position — at any other scale.
+/// Every hand-authored world coordinate should pass through here rather than bake the scale in.
+pub fn world22(x: f32, z: f32) -> Vec2 {
+    Vec2::new(x, z) * (MAP_SCALE / 2.2)
+}
 // The GRID is the enlarged resolution; GENERATION still runs in *base* space — the grid
 // loop samples `classify(ix / MAP_SCALE, …)`, so the island shape is identical, just
 // drawn over more tiles. `CX/CZ` stay the BASE centre used by all the generation math;
@@ -70,12 +81,12 @@ const ISLAND_RX: f32 = 71.0;
 const ISLAND_RZ: f32 = 53.0;
 const ISLAND_EXP: f32 = 2.6;
 // Castle safe-zone radius in BASE space (forced flat grass, no biome scatter). `classify` runs in
-// base space, so the WORLD radius is `SAFE_R * MAP_SCALE` (≈32.4 at MAP_SCALE 2.2). Trimmed from
-// 18.0 → 16.2 → 14.7 across the 1.8 → 2.0 → 2.2 scale bumps: this is base-space, so each bump
-// silently grows the *world* safe-zone ~10%; the trims keep the biome-free ring round the castle
-// at its tuned ~32.4-unit world size. Town build plots flatten themselves (`near_build_plot`),
-// so this doesn't gate their footing.
-pub const SAFE_R: f32 = 14.7;
+// base space, so the WORLD radius is `SAFE_R * MAP_SCALE` (≈32.4 at MAP_SCALE 2.6). Trimmed from
+// 18.0 → 16.2 → 14.7 → 12.45 across the 1.8 → 2.0 → 2.2 → 2.6 scale bumps: this is base-space, so
+// each bump silently grows the *world* safe-zone; the trims keep the biome-free ring round the
+// castle at its tuned ~32.4-unit world size. Town build plots flatten themselves
+// (`near_build_plot`), so this doesn't gate their footing.
+pub const SAFE_R: f32 = 12.45;
 pub const GROUND_STEP: f32 = 0.5; // world-Y per height class
 pub const SEA_Y: f32 = -0.4;
 /// Colour-blend half-width (tiles) at biome edges.
@@ -765,10 +776,11 @@ fn pool_sd(x: f32, z: f32) -> f32 {
     if best == f32::INFINITY {
         return best;
     }
-    // Swamp warden arena keep-out (world → base).
+    // Swamp warden arena keep-out (world → base). The glade coord is authored at scale 2.2.
     let wx = x * MAP_SCALE - GX;
     let wz = z * MAP_SCALE - GZ;
-    if (wx - 0.0).hypot(wz - 57.0) < POOL_WARDEN_KEEPOUT {
+    let swamp_glade = world22(0.0, 57.0);
+    if (wx - swamp_glade.x).hypot(wz - swamp_glade.y) < POOL_WARDEN_KEEPOUT {
         return f32::INFINITY;
     }
     // The Blight owns its own ground (checked before regions in `classify`) — keep pools out.
@@ -2377,29 +2389,195 @@ fn spawn_terrain_sheet(
     mat: Handle<TerrainMaterial>,
     keep: impl Fn(TB) -> bool + Copy,
 ) {
+    let lod = terrain_lod_enabled();
     let mut cz = 0;
     while cz < ROWS {
         let mut cx = 0;
         while cx < COLS {
-            let mesh = build_terrain_chunk(
-                keep,
-                cx,
-                (cx + TERRAIN_CHUNK).min(COLS),
-                cz,
-                (cz + TERRAIN_CHUNK).min(ROWS),
-            );
+            let (x1, z1) = ((cx + TERRAIN_CHUNK).min(COLS), (cz + TERRAIN_CHUNK).min(ROWS));
+            let mesh = build_terrain_chunk(keep, cx, x1, cz, z1);
             if mesh.count_vertices() > 0 {
-                commands.spawn((
+                let mut e = commands.spawn((
                     Mesh3d(meshes.add(mesh)),
                     MeshMaterial3d(mat.clone()),
                     Transform::default(),
                     crate::biome::BiomeEntity,
                 ));
+                // Terrain LOD: past TERRAIN_LOD the full-res chunk (1 quad/tile + walls +
+                // marching-squares banks) hands off to a stride-4 coarse drape — ~1/16th the
+                // vertices for the distant majority of the island. The band is a dithered
+                // crossfade (only the ring of chunks currently inside it pays the discard
+                // cost) so the swap doesn't pop; skirts on the coarse mesh hide the seam.
+                if lod {
+                    if let Some(coarse) = build_terrain_chunk_coarse(keep, cx, x1, cz, z1) {
+                        e.insert(bevy::camera::visibility::VisibilityRange {
+                            start_margin: 0.0..0.0,
+                            end_margin: TERRAIN_LOD..TERRAIN_LOD + TERRAIN_LOD_BAND,
+                            use_aabb: true,
+                        });
+                        commands.spawn((
+                            Mesh3d(meshes.add(coarse)),
+                            MeshMaterial3d(mat.clone()),
+                            Transform::default(),
+                            crate::biome::BiomeEntity,
+                            // Shadow cascades stop at ~150 and the fog is thick out there —
+                            // the coarse drape is pure fill, never a shadow caster.
+                            bevy::light::NotShadowCaster,
+                            bevy::camera::visibility::VisibilityRange {
+                                start_margin: TERRAIN_LOD..TERRAIN_LOD + TERRAIN_LOD_BAND,
+                                end_margin: 1.0e30..1.0e30, // no far cutoff — terrain always draws
+                                use_aabb: true,
+                            },
+                        ));
+                    }
+                }
             }
             cx += TERRAIN_CHUNK;
         }
         cz += TERRAIN_CHUNK;
     }
+}
+
+/// Where the full-res terrain chunk hands off to its coarse LOD (world units, camera→chunk-AABB
+/// distance), and the width of the dithered crossfade band. 110 sits past the base fog start
+/// (≈56) and the prop/cover culls (62/75), well before trees vanish (180) — so the geometry
+/// swap happens under haze, on chunks the eye reads mostly by silhouette.
+const TERRAIN_LOD: f32 = 110.0;
+const TERRAIN_LOD_BAND: f32 = 26.0;
+/// Coarse-LOD sampling stride, in tiles (one quad per 4×4 tiles ≈ 1/16th the vertices).
+/// Must divide `TERRAIN_CHUNK` so coarse cell corners line up across chunk seams.
+const LOD_STRIDE: i32 = 4;
+
+/// Whether terrain LOD is on. Shares the scatter culling's `FOREST_NOCULL=1` escape hatch —
+/// the whole-island map-shot recipe and perf A/B runs want EVERYTHING at full res.
+fn terrain_lod_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("FOREST_NOCULL").is_err())
+}
+
+/// Build the coarse far-LOD drape for one terrain chunk: the smoothed ground surface sampled
+/// every `LOD_STRIDE` tiles, no terrace walls, no marching-squares river cuts (the channel just
+/// drapes toward `SEA_Y` and the always-drawn water plane reads as the river), plus a short
+/// downward SKIRT around the chunk perimeter so LOD seams against neighbouring full-res chunks
+/// can't open see-through cracks. Cell→sheet routing matches the full-res pass (centre tile's
+/// class through `keep`), so each sheet's coarse drape wears its own material grain.
+fn build_terrain_chunk_coarse(
+    keep: impl Fn(TB) -> bool,
+    ix0: i32,
+    ix1: i32,
+    iz0: i32,
+    iz1: i32,
+) -> Option<Mesh> {
+    let mut positions: Vec<[f32; 3]> = Vec::new();
+    let mut normals: Vec<[f32; 3]> = Vec::new();
+    let mut colors: Vec<[f32; 4]> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+
+    // Ground height at a stride-grid corner (world Y), `None` over water / off the island.
+    let corner_y = |cx: i32, cz: i32| -> Option<f32> { smooth_surface_y(cx as f32 - GX, cz as f32 - GZ) };
+    // Sea-tucked height for a wet corner: just under the water plane so the drape dips beneath.
+    const WET_Y: f32 = SEA_Y - 0.12;
+    let nrm3 = |v: [f32; 3]| {
+        let l = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt().max(1e-4);
+        [v[0] / l, v[1] / l, v[2] / l]
+    };
+
+    let mut push_quad = |p: [[f32; 3]; 4], n: [[f32; 3]; 4], c: [[f32; 4]; 4]| {
+        let b = positions.len() as u32;
+        for k in 0..4 {
+            positions.push(p[k]);
+            normals.push(n[k]);
+            colors.push(c[k]);
+        }
+        indices.extend_from_slice(&[b, b + 1, b + 2, b, b + 2, b + 3]);
+    };
+
+    let mut cz = iz0;
+    while cz < iz1 {
+        let z1 = (cz + LOD_STRIDE).min(iz1);
+        let mut cx = ix0;
+        while cx < ix1 {
+            let x1 = (cx + LOD_STRIDE).min(ix1);
+            // Route the cell to a sheet by its centre tile (or any land corner on the coast).
+            let centre = tile_at((cx + x1) / 2, (cz + z1) / 2);
+            let class = centre.or_else(|| {
+                [(cx, cz), (x1, cz), (x1, z1), (cx, z1)].iter().find_map(|&(gx, gz)| tile_at(gx, gz))
+            });
+            let Some((tb, _)) = class else {
+                cx += LOD_STRIDE;
+                continue; // open sea cell
+            };
+            if !keep(tb) {
+                cx += LOD_STRIDE;
+                continue;
+            }
+            let corners = [(cx, cz), (x1, cz), (x1, z1), (cx, z1)];
+            let ys = corners.map(|(gx, gz)| corner_y(gx, gz));
+            if ys.iter().all(|y| y.is_none()) {
+                cx += LOD_STRIDE;
+                continue;
+            }
+            let y = ys.map(|y| y.unwrap_or(WET_Y));
+            // Central-difference normals over the stride grid (wet samples clamp to WET_Y).
+            let cn = |gx: i32, gz: i32| {
+                let s = LOD_STRIDE;
+                let e = corner_y(gx + s, gz).unwrap_or(WET_Y);
+                let w = corner_y(gx - s, gz).unwrap_or(WET_Y);
+                let so = corner_y(gx, gz + s).unwrap_or(WET_Y);
+                let no = corner_y(gx, gz - s).unwrap_or(WET_Y);
+                nrm3([w - e, 2.0 * s as f32, no - so])
+            };
+            let p = corners.map(|(gx, gz)| [gx as f32 - GX, 0.0, gz as f32 - GZ]);
+            let p = [
+                [p[0][0], y[0], p[0][2]],
+                [p[1][0], y[1], p[1][2]],
+                [p[2][0], y[2], p[2][2]],
+                [p[3][0], y[3], p[3][2]],
+            ];
+            let n = [cn(cx, cz), cn(x1, cz), cn(x1, z1), cn(cx, z1)];
+            let c = corners.map(|(gx, gz)| ground_color(gx as f32 / MAP_SCALE, gz as f32 / MAP_SCALE));
+            push_quad(p, n, c);
+
+            // Perimeter skirt: cell edges lying on the CHUNK boundary drop a short apron so a
+            // height mismatch against the neighbouring chunk's LOD state can't open a crack.
+            const SKIRT: f32 = 1.1;
+            let edges: [(usize, usize, bool); 4] = [
+                (0, 1, cz == iz0),
+                (1, 2, x1 == ix1),
+                (2, 3, z1 == iz1),
+                (3, 0, cx == ix0),
+            ];
+            for (a, b, on_boundary) in edges {
+                if !on_boundary {
+                    continue;
+                }
+                let dark = |col: [f32; 4]| [col[0] * 0.72, col[1] * 0.70, col[2] * 0.68, col[3]];
+                push_quad(
+                    [
+                        p[a],
+                        p[b],
+                        [p[b][0], p[b][1] - SKIRT, p[b][2]],
+                        [p[a][0], p[a][1] - SKIRT, p[a][2]],
+                    ],
+                    [n[a], n[b], n[b], n[a]],
+                    [c[a], c[b], dark(c[b]), dark(c[a])],
+                );
+            }
+            cx += LOD_STRIDE;
+        }
+        cz += LOD_STRIDE;
+    }
+
+    if positions.is_empty() {
+        return None;
+    }
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList, RenderAssetUsages::default());
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+    mesh.insert_indices(Indices::U32(indices));
+    Some(mesh)
 }
 
 /// Build one terrain CHUNK — the tiles in `[ix0,ix1) × [iz0,iz1)` that pass `keep`. Walls still


### PR DESCRIPTION
## Summary

Replaces the static landmark system with five fully-realized animated set-pieces — one per biome. Each landmark is a merged vertex-coloured base mesh (batching against the shared white material) plus child entities for animated/glowing sub-parts (spinning sails, orbiting ice shards, pulsing windows, etc.). Authored in `landmark_models.rs` and spawned via the new `LandmarkModel`/`AnimPart` API in `ruins.rs`.

## Key Changes

- **New module `landmark_models.rs`** (963 lines): Five landmark builders
  - **Old Mill** (forest): weathered smock windmill with rotating sails, lit window, yard props
  - **Witch's Hut** (swamp): crooked stilt-cabin with green-lit windows, bubbling cauldron, orbiting wisps
  - **Frozen Spire** (snow): angular ice tower with glowing heart and levitating crystal shards
  - **Sunken Pyramid** (desert): half-buried ziggurat with spinning sun-disc relic and hoodoo tiers
  - **Standing Stones** (rocky): natural arch with fractured pillars, lintel, and talus skirt

- **Refactored `ruins.rs`**: Extracted shared mesh primitives and animation API
  - Moved low-poly helpers (`tinted`, `merged`, `flat_shaded`, `mottle`, `ball`, `cyl`, `frustum`, `cone_at`, `limb`, etc.) to public scope for landmark builders
  - New `Glow` struct: emissive material + optional pulse animation
  - New `Fx` enum: `None`, `Spin`, `Sway`, `Orbit`, `Hover`, `Rise` — pure Transform drivers off wall-clock time
  - New `AnimPart` struct: wraps a mesh + transform + FX + optional glow
  - New `LandmarkModel` struct: base mesh + vec of `AnimPart` children
  - `RuinsFxPlugin`: cosmetic animators (ungated, runs during sim freeze)
  - `populate_landmarks()`: flat-spot picker + world placement

- **Updated `viewer.rs`**: Landmark preview support
  - `FOREST_VIEW=landmark:<name>` (aliases: `mill|hut|spire|pyramid|stones|forest|swamp|snow|desert|rocky|trilithon|circle`)
  - Auto-frames big props from mesh bounds (not the character default camera)
  - Runs real `RuinsFxPlugin` so animations preview correctly

- **World scale bump**: `MAP_SCALE` 2.2 → 2.6 (funded by terrain far-LOD)
  - New `world22()` helper: rescales hand-authored world coords from the old scale
  - Updated `SAFE_R` (14.7 → 12.45) to maintain castle biome-free ring
  - Updated swamp warden keep-out, snowman field, chest hoards, and other hand-authored coords to use `world22()`

- **Minor updates**:
  - `biome_forest.rs`: removed unused `BiomeEntity` import
  - `landmarks.rs`: updated metadata comments for July 2026 overhaul
  - `boss/mod.rs`, `navgrid.rs`, `snowman.rs`, `chest.rs`: scale-aware coordinate rescaling
  - `CLAUDE.md`: documented terrain far-LOD perf notes
  - `main.rs`: added `mod landmark_models`

## Implementation Notes

- Each landmark is authored in model-local units with base at y=0; `populate_landmarks()` scales ~1.4–1.5× into the world
- All static geometry is one merged flat-shaded mesh (vertex-coloured, batches like everything else)
- Animated parts (sails, orbits, glows) are child entities with deterministic Transform drives — safe to run ungated
- The `Glow` struct uses an unlit emissive material (beacon recipe) instead of the shared white one
- Pulse animations are optional and parameterized by (frequency rad/s, ±fraction,

https://claude.ai/code/session_01J3Xo8a55tQLDAdAjhX5GWz