### PR TITLE
Codebase cleanup from review: meshkit + sim-gate helper, plus DoF torch-blur tweak

### DIFF
--- a/src/aftermath.rs
+++ b/src/aftermath.rs
@@ -19,6 +19,7 @@ use crate::dying::Dying;
 use crate::orks::Ork;
 use crate::palette::lin;
 use crate::siege::{GamePhase, Siege};
+use crate::meshkit::merged_flat;
 
 /// Most aftermath entities allowed at once (oldest reaped first).
 const MAX_MARKS: usize = 160;
@@ -286,17 +287,6 @@ fn tint_a(mut m: Mesh, hex: u32, alpha: f32) -> Mesh {
     let n = m.count_vertices();
     m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
     m
-}
-
-fn merged_flat(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("aftermath parts share attributes");
-    }
-    base.duplicate_vertices();
-    base.compute_flat_normals();
-    base
 }
 
 /// Flat ground disc (lying in XZ, normal up) — the stain / scorch base shape.

--- a/src/biome_desert.rs
+++ b/src/biome_desert.rs
@@ -24,6 +24,7 @@ use bevy::prelude::*;
 
 use crate::biome::{Backdrop, Biome, BiomeConfig, BiomeEntity, GroundDetail, ParticleKind, PropClass};
 use crate::palette::lin;
+use crate::meshkit::{flat_shaded, merged, tinted};
 
 const TAU: f32 = std::f32::consts::TAU;
 const FRAC_PI_2: f32 = std::f32::consts::FRAC_PI_2;
@@ -82,34 +83,6 @@ const CACTUS_SCALE: f32 = 1.6;
 
 fn y(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)
-}
-
-/// Tag every vertex of `m` with one flat linear colour (REQUIRED before merge — every
-/// merged part must carry the same attribute set, incl. `ATTRIBUTE_COLOR`).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge several pre-`tinted` parts into ONE mesh so identical props batch into one
-/// draw call. `Mesh::merge` returns `Result` in 0.18 — `.expect` on a mismatch.
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("desert parts share attributes");
-    }
-    base
-}
-
-/// Un-index + recompute per-face normals → crisp flat-shaded low-poly facets.
-/// `duplicate_vertices()` MUST run before `compute_flat_normals()` (the latter panics
-/// on an indexed mesh). Call LAST, on the merged mesh.
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
 }
 
 /// A faceted icosphere blob (ico detail 0), optionally squashed, centred at `off`.

--- a/src/biome_rocky.rs
+++ b/src/biome_rocky.rs
@@ -34,6 +34,7 @@ use bevy::prelude::*;
 
 use crate::biome::{Backdrop, Biome, BiomeConfig, BiomeEntity, GroundDetail, ParticleKind, PropClass};
 use crate::palette::{lin, lin_scaled};
+use crate::meshkit::{flat_shaded, merged, tinted};
 
 // ── Rocky palette ─────────────────────────────────────────────────────────────────
 // Stone body tones: a cool-warm grey-brown stack so a crag reads lit (dark foot →
@@ -78,34 +79,6 @@ const FLOWER_GOLD: u32 = 0xd9b84e;
 const STEM_GREEN: u32 = 0x6f7a44;
 
 // ── Mesh helpers (mirror trees.rs / props.rs / decor.rs verbatim) ──────────────────
-
-/// Tag every vertex of `m` with one flat linear colour (REQUIRED before merge — all
-/// merged parts must carry the same attribute set, incl. ATTRIBUTE_COLOR).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge several pre-`tinted` parts into ONE mesh (so identical props batch into one
-/// draw call). `Mesh::merge` returns `Result` in 0.18 — `.expect` on a mismatch.
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("rocky parts share attributes");
-    }
-    base
-}
-
-/// Un-index + recompute per-face normals → crisp flat-shaded low-poly facets.
-/// `duplicate_vertices()` MUST run before `compute_flat_normals()` (the latter panics
-/// on an indexed mesh). Call LAST, on the merged mesh.
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
-}
 
 fn y(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)

--- a/src/biome_snow.rs
+++ b/src/biome_snow.rs
@@ -33,6 +33,7 @@
 use bevy::prelude::*;
 
 use crate::biome::{Backdrop, Biome, BiomeConfig, BiomeEntity, GroundDetail, ParticleKind, PropClass};
+use crate::meshkit::{flat_shaded, merged, tinted};
 
 // ── Snow palette (hex lifted from the TS game's snow biome) ─────────────────────
 // Ground: snow `#eef3f8` / `#eaf1f7`, fog `#cdd8e8` — kept blue-grey, NOT pure white.
@@ -94,32 +95,6 @@ const FRAC_PI_2: f32 = std::f32::consts::FRAC_PI_2;
 
 fn lin(c: u32) -> [f32; 4] {
     crate::palette::lin(c)
-}
-
-/// Tag every vertex of `m` with a flat linear colour (REQUIRED before merge — all parts
-/// must carry the same attribute set incl. `ATTRIBUTE_COLOR`).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge a non-empty list of pre-`tinted` parts into ONE mesh (renderer batches them).
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut b = it.next().expect("part");
-    for p in it {
-        b.merge(&p).expect("attrs");
-    }
-    b
-}
-
-/// Un-index + recompute per-face normals → crisp flat-shaded facets. MUST be called LAST
-/// on the merged mesh (`compute_flat_normals` panics on an indexed mesh).
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
 }
 
 /// Bake painterly facet shading into the vertex colours (call AFTER `flat_shaded`, so the

--- a/src/biome_swamp.rs
+++ b/src/biome_swamp.rs
@@ -47,6 +47,7 @@ use crate::biome::{
     Backdrop, Biome, BiomeConfig, BiomeEntity, GroundDetail, ParticleKind, PropClass,
 };
 use crate::palette::{lin, lin_scaled};
+use crate::meshkit::{flat_shaded, merged, tinted};
 
 const TAU: f32 = std::f32::consts::TAU;
 const PI: f32 = std::f32::consts::PI;
@@ -117,33 +118,6 @@ const GLOWMUSH_SPOTS: [(f32, f32, f32); 6] = [
 
 fn y(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)
-}
-
-/// Tag every vertex with one flat linear colour (REQUIRED before merge — all merged
-/// parts must carry the same attribute set, incl. `ATTRIBUTE_COLOR`).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge pre-`tinted` parts into ONE mesh so identical props batch into one draw call.
-/// `Mesh::merge` returns `Result` in 0.18 — `.expect` on an attribute mismatch.
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("swamp parts share attributes");
-    }
-    base
-}
-
-/// Un-index + recompute per-face normals → crisp flat-shaded facets. MUST be called LAST,
-/// on the merged mesh (`compute_flat_normals` panics on an indexed mesh, so dup first).
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
 }
 
 /// A faceted icosphere blob (ico detail 0), optionally squashed (or stretched, > 1),

--- a/src/boats.rs
+++ b/src/boats.rs
@@ -19,6 +19,7 @@ use bevy::prelude::*;
 
 use crate::biome::BiomeEntity;
 use crate::palette::lin;
+use crate::meshkit::{flat_shaded, merged, tinted};
 
 const TAU: f32 = std::f32::consts::TAU;
 const SEED: u32 = 0xb0a7;
@@ -316,27 +317,5 @@ fn raw_tris(positions: Vec<[f32; 3]>) -> Mesh {
     m.insert_attribute(Mesh::ATTRIBUTE_NORMAL, vec![[0.0, 1.0, 0.0]; n]);
     m.insert_attribute(Mesh::ATTRIBUTE_UV_0, vec![[0.0, 0.0]; n]);
     m.insert_indices(Indices::U32(indices));
-    m
-}
-
-/// Tag every vertex with one flat linear colour (REQUIRED before merge).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("boat parts share attributes");
-    }
-    base
-}
-
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
     m
 }

--- a/src/boss/mod.rs
+++ b/src/boss/mod.rs
@@ -30,6 +30,7 @@ use crate::{steer, worldmap};
 use crate::audio::director::{Speak, VoiceManager};
 use crate::audio::lines::Concept;
 use crate::audio::MusicState;
+use crate::game_state::SimAppExt;
 
 // ── Tuning (all forest-side; not parity-gated) ────────────────────────────────────────
 /// Warden HP at level 1, ×`HP_GROWTH` per level. Out-stats a bare hero on purpose (mid-game) —
@@ -250,10 +251,9 @@ impl Plugin for BossPlugin {
             .add_systems(Update, warden_music_flag) // ungated: boss music holds through a panel-freeze
             .add_systems(Update, sync_boss_bar.run_if(in_state(AppState::Playing)))
             .add_systems(OnExit(AppState::Playing), despawn_boss_bar)
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (boss_brain, boss_proximity, boss_levelup, tick_status, reward_on_death)
-                    .run_if(in_state(Modal::None)),
+                    ,
             )
             // Reward dialog: spawns frozen over the world, dismissed with Continue / Enter / Esc.
             .add_systems(OnEnter(Modal::BossReward), spawn_reward_ui)

--- a/src/boss/models.rs
+++ b/src/boss/models.rs
@@ -20,6 +20,7 @@ use crate::biome::Biome;
 use crate::creature::{surf, Surf};
 use crate::critters::PartKind;
 use crate::palette::lin;
+use crate::meshkit::tinted;
 
 /// One articulated boss part (pivot local to the root; mesh built in part-local space).
 pub struct BossPart {
@@ -35,11 +36,6 @@ pub struct BossSpec {
 }
 
 // ── Mesh helpers (the knight-model contract: raw primitive → place → tint → merge) ─────
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
 fn group(parts: Vec<Mesh>) -> Mesh {
     let mut it = parts.into_iter();
     let mut base = it.next().expect("at least one part");

--- a/src/bridges.rs
+++ b/src/bridges.rs
@@ -12,6 +12,7 @@ use bevy::prelude::*;
 use crate::biome::BiomeEntity;
 use crate::palette::{lin, lin_scaled};
 use crate::worldmap::is_river_world;
+use crate::meshkit::tinted;
 
 /// Half-width along the bank (the deck's SHORT axis) of a deck.
 const DECK_HALF_Z: f32 = 1.2;
@@ -392,11 +393,6 @@ fn hash01(mut s: u32) -> f32 {
     s = s.wrapping_mul(0x846c_a68b);
     s ^= s >> 16;
     (s & 0x00ff_ffff) as f32 / 16_777_216.0
-}
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
 }
 /// A tinted cuboid taking a linear colour directly (so callers can pass jittered tones).
 fn bx(w: f32, h: f32, d: f32, off: Vec3, c: [f32; 4]) -> Mesh {

--- a/src/camps.rs
+++ b/src/camps.rs
@@ -25,6 +25,7 @@ use crate::biome::{Biome, BiomeEntity};
 use crate::orks::{self, Faction, VARIANTS};
 use crate::palette::lin;
 use crate::worldmap::{self, GX, GZ};
+use crate::meshkit::tinted;
 
 // ── Plugin (campfire flicker + smoke) ────────────────────────────────────────────────
 
@@ -708,11 +709,6 @@ fn ry(a: f32) -> Quat {
 }
 fn xyz(x: f32, y: f32, z: f32) -> Quat {
     Quat::from_euler(EulerRot::XYZ, x, y, z)
-}
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
 }
 fn group(parts: Vec<Mesh>) -> Mesh {
     let mut it = parts.into_iter();

--- a/src/chest.rs
+++ b/src/chest.rs
@@ -14,12 +14,12 @@ use tileworld_core::inventory::{item_def, Bag, ItemKind};
 
 use crate::audio::{AudioCue, Concept, Speak};
 use crate::combat_fx::{col_kill, FloatQueue, FloatReq, HitFeedback};
-use crate::game_state::Modal;
 use crate::inventory::{try_grant, Inventory, Toasts};
 use crate::palette::lin;
 use crate::player::{HeroState, PlayerRes};
 use crate::verbs::forest_frontier;
 use crate::worldmap;
+use crate::game_state::SimAppExt;
 
 pub struct ChestPlugin;
 
@@ -35,7 +35,7 @@ impl Plugin for ChestPlugin {
         // Sim systems freeze behind panels/pauses; the lid swing is pure animation (a lid keeps
         // falling open behind a panel), so it stays ungated like the other impact-juice drivers.
         app.add_message::<OpenChest>()
-            .add_systems(Update, (chest_interact, chest_respawn).run_if(in_state(Modal::None)))
+            .add_sim_systems((chest_interact, chest_respawn))
             .add_systems(Update, drive_lid_swing);
     }
 }

--- a/src/critters.rs
+++ b/src/critters.rs
@@ -14,6 +14,7 @@ use bevy::mesh::MeshBuilder;
 use bevy::prelude::*;
 
 use crate::palette::lin;
+use crate::meshkit::{merged, tinted};
 
 /// The wildlife species. Includes the three TS "monsters" (Scorpion/BogCroc/Golem) — biome
 /// menaces that hunt/charge the hero (their HP/bounty/drops come from `core::animal_config`).
@@ -62,19 +63,6 @@ pub struct CreatureSpec {
 
 // ─── Mesh helpers (local copies of the props.rs contract) ────────────────────────
 
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("creature parts share attributes");
-    }
-    base
-}
 /// Merge + hard flat-shade — the crisp low-poly facets the TS models use.
 fn group(parts: Vec<Mesh>) -> Mesh {
     let mut m = merged(parts);

--- a/src/decor.rs
+++ b/src/decor.rs
@@ -32,6 +32,7 @@ use bevy::prelude::*;
 
 use crate::palette::lin;
 use crate::terrain::HALF;
+use crate::meshkit::{flat_shaded, merged, tinted};
 
 // ── Decor palette (extends palette.rs; kept local since these tones are decor-only) ──
 const LOG_BARK: u32 = 0x4f3320; // damp brown fallen-log bark
@@ -89,34 +90,6 @@ impl Rng {
 
 fn y(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)
-}
-
-/// Tag every vertex of `m` with one flat linear colour (REQUIRED before merge — all
-/// merged parts must carry the same attribute set, incl. `ATTRIBUTE_COLOR`).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge several pre-`tinted` parts into ONE mesh (so identical props batch into one
-/// draw call). `Mesh::merge` returns `Result` in 0.18 — `.expect` on a mismatch.
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("decor parts share attributes");
-    }
-    base
-}
-
-/// Un-index + recompute per-face normals → crisp flat-shaded low-poly facets.
-/// `duplicate_vertices()` MUST run before `compute_flat_normals()` (the latter panics
-/// on an indexed mesh — see the verified-APIs doc §9).
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
 }
 
 /// A faceted icosphere blob (ico detail 0), optionally squashed, centred at `off`.

--- a/src/defenses.rs
+++ b/src/defenses.rs
@@ -24,11 +24,11 @@ use tileworld_core::defense::{
 
 use crate::economy::Defenses;
 use crate::palette::lin;
-use crate::game_state::Modal;
 use crate::orks::WaveInvader;
 use crate::player::{spawn_burst, CombatFx, Health, HeroState, PlayerRes};
 use crate::projectile::{advance_bolt, BoltStep};
 use crate::siege::{GamePhase, Siege};
+use crate::game_state::SimAppExt;
 
 /// Scale defender damage from core's TS-anchored values so towers/archers *support* the defense
 /// rather than auto-clearing the wave. Re-derived 2026-06 from the old 0.236 (tuned for ~0.35×-HP
@@ -128,8 +128,7 @@ impl Plugin for DefensePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<DefenderBolts>()
             .add_systems(Startup, (setup_bolt_gfx, debug_enable_defenses))
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (
                     defenders_fire,
                     spawn_defender_bolts,
@@ -140,7 +139,7 @@ impl Plugin for DefensePlugin {
                     shrine_heal,
                     sync_keep_archers,
                 )
-                    .run_if(in_state(Modal::None)),
+                    ,
             );
     }
 }

--- a/src/dof.rs
+++ b/src/dof.rs
@@ -54,7 +54,10 @@ pub fn default_dof() -> Dof {
     // the fully-sharp band so everything the player actually fights/loots reads crisp, far_ramp
     // 90→130 makes the distance melt come on later and more gradually, and max_radius 20→13
     // keeps the far bokeh a gentle cinematic soften instead of a smear.
-    Dof { focal: 28.0, range: 42.0, far_ramp: 130.0, max_radius: 13.0, near: NEAR, debug_view: 0.0 }
+    // 2026-07 follow-up (user: torches blur too soon / too hard): range 42→60 pushes the far-blur
+    // ONSET out from focal+42 (~70 tiles) to focal+60 (~88), so mid-distance torches/braziers stay
+    // sharp; max_radius 13→9 softens the remaining far bokeh so lit points read as flames, not smears.
+    Dof { focal: 28.0, range: 60.0, far_ramp: 130.0, max_radius: 9.0, near: NEAR, debug_view: 0.0 }
 }
 
 pub struct DofPlugin;

--- a/src/economy.rs
+++ b/src/economy.rs
@@ -19,6 +19,7 @@ use crate::ui::fonts::{label, UiFonts};
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
 use crate::ui::IconAtlas;
+use crate::game_state::SimAppExt;
 
 /// The crafting-resource bank — currently just stone. Wraps the parity-tested core store.
 #[derive(Resource, Default)]
@@ -84,7 +85,7 @@ impl Plugin for EconomyPlugin {
             // reset already covers it; Load restores over it.
             // (The War Table tree panel itself lives in `tree_ui.rs` — TreeUiPlugin.)
             // Merchant shop (open with T; buys land in the bag).
-            .add_systems(Update, open_shop.run_if(in_state(Modal::None)))
+            .add_sim_systems(open_shop)
             .add_systems(OnEnter(Modal::Shop), spawn_shop)
             .add_systems(OnExit(Modal::Shop), despawn_shop)
             .add_systems(Update, (shop_interact, shop_close).run_if(in_state(Modal::Shop)));

--- a/src/fish.rs
+++ b/src/fish.rs
@@ -21,6 +21,7 @@
 use bevy::prelude::*;
 
 use crate::player::HeroState;
+use crate::meshkit::tinted;
 
 /// How many fish haunt the water near the hero. Kept low — a few flickers, not a shoal.
 const FISH_COUNT: usize = 3;
@@ -105,11 +106,6 @@ impl Plugin for FishPlugin {
 }
 
 // ── Mesh helpers (local copies of the props.rs / critters.rs contract) ───────────────
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
 /// Merge + hard flat-shade for the crisp low-poly facet look (duplicate BEFORE flat-normals —
 /// `compute_flat_normals` panics on an indexed mesh).
 fn group(parts: Vec<Mesh>) -> Mesh {

--- a/src/footstep_fx.rs
+++ b/src/footstep_fx.rs
@@ -12,9 +12,9 @@ use bevy::light::NotShadowCaster;
 use bevy::prelude::*;
 
 use crate::biome::Biome;
-use crate::game_state::Modal;
 use crate::player::Hero;
 use crate::worldmap;
+use crate::game_state::SimAppExt;
 
 /// Downward pull on settling dust motes.
 const GRAV: f32 = 6.0;
@@ -63,7 +63,7 @@ pub struct FootstepFxPlugin;
 impl Plugin for FootstepFxPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup)
-            .add_systems(Update, emit.run_if(in_state(Modal::None)))
+            .add_sim_systems(emit)
             // Fades are visual — keep settling even while frozen.
             .add_systems(Update, (fade_puffs, fade_ripples));
     }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -15,6 +15,8 @@
 //! opening one does NOT fire `OnExit(Playing)`/`OnEnter(Playing)`, so it never wipes the run.
 
 use bevy::ecs::relationship::RelatedSpawnerCommands;
+use bevy::ecs::schedule::IntoScheduleConfigs;
+use bevy::ecs::system::ScheduleSystem;
 use bevy::prelude::*;
 
 use crate::ui::anim::{anim, anim_btn, AnimKind};
@@ -49,6 +51,28 @@ pub enum Modal {
     Quest,
     /// "Warden slain" reward dialog (freezes the world; opened by `boss::reward_on_death`).
     BossReward,
+}
+
+/// Register `Update` systems that belong to the world-sim — the ones that MUST freeze when a panel
+/// opens or `Playing` is left. Exactly equivalent to
+/// `app.add_systems(Update, systems.run_if(in_state(Modal::None)))`, but it names the intent and
+/// makes the freeze-gate impossible to forget: CLAUDE.md requires every new sim system to carry
+/// that gate or it silently runs through pauses/panels. Keep plain `add_systems` for the ungated
+/// render / VFX / HUD systems that must keep drawing while the world is frozen.
+pub trait SimAppExt {
+    fn add_sim_systems<M>(
+        &mut self,
+        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+    ) -> &mut Self;
+}
+
+impl SimAppExt for App {
+    fn add_sim_systems<M>(
+        &mut self,
+        systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
+    ) -> &mut Self {
+        self.add_systems(Update, systems.run_if(in_state(Modal::None)))
+    }
 }
 
 /// Set by the fresh-run buttons (New Game / Play Again / pause Restart) to request a **full

--- a/src/groundcover.rs
+++ b/src/groundcover.rs
@@ -25,6 +25,7 @@ use bevy::prelude::*;
 use std::f32::consts::{FRAC_PI_2, TAU};
 
 use crate::palette::lin;
+use crate::meshkit::{merged, tinted};
 
 // ── Grass palette ───────────────────────────────────────────────────────────────
 // FADED + low-contrast: desaturated, sun-bleached greens so tufts read as soft washed-out foliage
@@ -109,29 +110,9 @@ fn y(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)
 }
 
-/// Tag every vertex of `m` with one flat linear colour (REQUIRED before merge — all
-/// merged parts must carry the same attribute set, incl. `ATTRIBUTE_COLOR`).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
 /// Linear-colour lerp (component-wise, alpha kept at `a`'s).
 fn mix(a: [f32; 4], b: [f32; 4], t: f32) -> [f32; 4] {
     [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t, a[3]]
-}
-
-/// Merge several tinted parts into ONE mesh (so identical props still batch into one
-/// draw call). `Mesh::merge` returns `Result` in 0.18 — unwrap it. All parts must share
-/// indexed-ness + attribute set (see module doc).
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("ground-cover parts share attributes");
-    }
-    base
 }
 
 /// A cylinder whose centre sits at `cy` (so a stem of height `h` rooted at y=0 uses

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -17,7 +17,6 @@ use tileworld_core::shop_catalog::{build_shop_items, discounted_price};
 use tileworld_core::upgrade_store::{UpgradeState, UPGRADE_NODES};
 
 use crate::economy::{Bank, EconomyState, Upgrades};
-use crate::game_state::Modal;
 use crate::inventory::Inventory;
 use crate::player::PlayerRes;
 use crate::siege::{GamePhase, Siege};
@@ -25,6 +24,7 @@ use crate::ui::fonts::{label, UiFonts};
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
 use crate::ui::IconAtlas;
+use crate::game_state::SimAppExt;
 
 /// Seconds the condition must hold before the toast appears (rides out loot churn).
 const PROMOTE_DELAY: f64 = 3.0;
@@ -38,7 +38,7 @@ pub struct HintsPlugin;
 impl Plugin for HintsPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup_hint_root)
-            .add_systems(Update, drive_hints.run_if(in_state(Modal::None)));
+            .add_sim_systems(drive_hints);
     }
 }
 

--- a/src/interaction.rs
+++ b/src/interaction.rs
@@ -22,6 +22,7 @@ use crate::siege::{GamePhase, Siege};
 use crate::ui::fonts::{label, UiFonts};
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
+use crate::game_state::SimAppExt;
 
 /// Interaction ranges (world units), from the 3js `cityPlan`/`Shop` constants.
 const KEEP_DIST: f32 = 4.2;
@@ -128,7 +129,7 @@ impl Plugin for InteractionPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ActiveInteraction>()
             .add_systems(Startup, setup_prompt)
-            .add_systems(Update, drive_interaction.run_if(in_state(Modal::None)))
+            .add_sim_systems(drive_interaction)
             .add_systems(Update, update_prompt);
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -27,6 +27,7 @@ use crate::ui::fonts::{label, UiFonts};
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
 use crate::ui::IconAtlas;
+use crate::game_state::SimAppExt;
 
 /// A quick-slot fired this frame — HUD reads it to pop the matching cell. Index is the
 /// quick-bar order: 0 = Q (food), 1 = Y, 2 = T.
@@ -147,7 +148,7 @@ impl Plugin for InventoryPlugin {
             // (Pause-menu Restart resets in-process via StartScreen → Playing — see
             // game_state::drive_fresh_run — so this OnExit(StartScreen) reset covers it; Load restores.)
             // Quick-bar (Q/Y/T) + open the satchel (Tab/I): only while playing with no panel up.
-            .add_systems(Update, (quickbar_input, open_inventory).run_if(in_state(Modal::None)))
+            .add_sim_systems((quickbar_input, open_inventory))
             // The satchel modal (freezes the world like the tree).
             .add_systems(OnEnter(Modal::Inventory), spawn_inventory_panel)
             .add_systems(OnExit(Modal::Inventory), despawn_inventory_panel)

--- a/src/landmarks.rs
+++ b/src/landmarks.rs
@@ -29,10 +29,11 @@ use tileworld_core::buff_store::BuffKind;
 use crate::audio::AudioCue;
 use crate::biome::{Biome, BiomeEntity};
 use crate::combat_fx::{col_kill, FloatQueue, FloatReq};
-use crate::game_state::{AppState, Modal};
+use crate::game_state::AppState;
 use crate::inventory::{try_grant, Buffs, Inventory, Toasts};
 use crate::player::{HeroState, PlayerRes};
 use crate::ui::fonts::{label, FONT_LABEL, UiFonts};
+use crate::game_state::SimAppExt;
 
 /// Walk this close to an unfound landmark → it's discovered.
 const DISCOVER_R: f32 = 6.0;
@@ -335,10 +336,9 @@ impl Plugin for LandmarksPlugin {
             .add_systems(Update, (sync_rune_hud, sync_rune_ring))
             // Fell trees crowding the landmarks once they've spawned (runs once, then idles).
             .add_systems(Update, clear_around_landmarks)
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (track_total, discover, shrine, start_rune_trial, drive_rune_trial)
-                    .run_if(in_state(Modal::None)),
+                    ,
             );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod ambient_life;
 mod atmospherics;
 mod meadow;
 mod melee_ring;
+mod meshkit; // shared low-poly mesh helpers (tinted/merged/flat_shaded) — see the module doc
 mod audio;
 mod banner;
 mod biped;

--- a/src/meadow.rs
+++ b/src/meadow.rs
@@ -26,6 +26,7 @@ use bevy::prelude::*;
 
 use crate::biome::BiomeEntity;
 use crate::palette::lin;
+use crate::meshkit::{merged_flat as merged, tinted};
 
 /// Radius around the campfire within which the hero rests (heals) during Prep.
 const REST_R: f32 = 3.2;
@@ -452,21 +453,6 @@ fn flame_mesh() -> Mesh {
 
 // ── tiny local mesh helpers (the props.rs contract) ────────────────────────────────
 
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("≥1 part");
-    for p in it {
-        base.merge(&p).expect("meadow parts share attributes");
-    }
-    base.duplicate_vertices();
-    base.compute_flat_normals();
-    base
-}
 fn bx(w: f32, h: f32, d: f32, off: Vec3, c: u32) -> Mesh {
     tinted(Cuboid::new(w, h, d).mesh().build().translated_by(off), lin(c))
 }

--- a/src/meshkit.rs
+++ b/src/meshkit.rs
@@ -1,0 +1,50 @@
+//! Shared low-poly mesh helpers — the "tint → merge → flat-shade" trio every prop/model builder
+//! composes from. These were copy-pasted (byte-identical) into ~30 modules; consolidated here so
+//! there is one home for the mesh-building contract.
+//!
+//! Build contract (verified-APIs doc §9): each part is a primitive [`tinted`] with a flat linear
+//! `ATTRIBUTE_COLOR` BEFORE the merge (the scene's shared white `StandardMaterial` reads colour
+//! straight off the vertices, so thousands of props auto-batch), merged via `Mesh::merge`, then
+//! [`flat_shaded`] (`duplicate_vertices` → `compute_flat_normals`, in that order — the latter
+//! panics on an indexed mesh). [`merged_flat`] is the common merge-then-flat-shade combo.
+
+use crate::palette::lin;
+use bevy::prelude::*;
+
+/// Tag every vertex of a part with one flat linear RGBA colour. REQUIRED before a merge — all
+/// merged parts must carry the same attribute set, and the shared white material reads colour
+/// straight off `ATTRIBUTE_COLOR`.
+pub fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
+    let n = m.count_vertices();
+    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
+    m
+}
+
+/// [`tinted`] from a packed `0xRRGGBB` hex, converted to linear via [`crate::palette::lin`].
+pub fn tinted_hex(m: Mesh, hex: u32) -> Mesh {
+    tinted(m, lin(hex))
+}
+
+/// Merge already-tinted parts into one mesh. Does NOT re-shade — call [`flat_shaded`] after, or
+/// use [`merged_flat`] for the common combine-and-facet.
+pub fn merged(parts: Vec<Mesh>) -> Mesh {
+    let mut it = parts.into_iter();
+    let mut base = it.next().expect("at least one part");
+    for p in it {
+        base.merge(&p).expect("parts share attributes");
+    }
+    base
+}
+
+/// Un-index + recompute per-face normals → crisp flat-shaded low-poly facets.
+/// `duplicate_vertices()` MUST run before `compute_flat_normals()`. Call LAST, on the merge.
+pub fn flat_shaded(mut m: Mesh) -> Mesh {
+    m.duplicate_vertices();
+    m.compute_flat_normals();
+    m
+}
+
+/// [`merged`] followed by [`flat_shaded`] — the common combine-and-facet combo.
+pub fn merged_flat(parts: Vec<Mesh>) -> Mesh {
+    flat_shaded(merged(parts))
+}

--- a/src/orbs.rs
+++ b/src/orbs.rs
@@ -6,8 +6,9 @@
 use bevy::prelude::*;
 use tileworld_core::orb::{self, Orb, OrbKind, OrbStep, PlayerPose};
 
-use crate::game_state::{AppState, Modal};
+use crate::game_state::AppState;
 use crate::player::{HeroState, PlayerRes};
+use crate::game_state::SimAppExt;
 
 /// A reward queued by combat on a kill — split into gold + xp orbs by [`spawn_queued_orbs`].
 pub struct RewardBurst {
@@ -60,11 +61,10 @@ impl Plugin for OrbsPlugin {
             // home onto the reset hero and bank last run's gold/xp into the new run.
             .add_systems(OnExit(AppState::StartScreen), reset_orbs)
             .add_systems(OnExit(AppState::GameOver), reset_orbs)
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (spawn_queued_orbs, step_reward_orbs)
                     .chain()
-                    .run_if(in_state(Modal::None)),
+                    ,
             );
     }
 }

--- a/src/ork_fortress.rs
+++ b/src/ork_fortress.rs
@@ -28,13 +28,15 @@ use bevy::prelude::*;
 use crate::biome::{AtmoSample, BiomeAmbience, BiomeEntity, GroundDetail, ParticleKind};
 use crate::critters::PartKind;
 use crate::firelight::{self, FireLight};
-use crate::game_state::{AppState, Modal};
+use crate::game_state::AppState;
 use crate::orks::{Armory, Faction, OrkPart, OrkVariant};
 use crate::palette::lin;
 use crate::player::{HeroState, PendingHeroDamage};
 use crate::projectile::{advance_bolt, BoltStep};
 use crate::quality::GraphicsQuality;
 use crate::worldmap::{self, GX, GZ, MAP_SCALE};
+use crate::meshkit::tinted;
+use crate::game_state::SimAppExt;
 
 // ── Layout (world space; the OLD grid's south edge was z = +81 — the Blight extends it) ──
 
@@ -220,8 +222,7 @@ impl Plugin for OrkFortressPlugin {
             )
             .add_systems(OnExit(AppState::GameOver), reset_fortress_on_new_run)
             // Sim carries the freeze gate, per the game_state contract.
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (
                     denizen_brain,
                     tower_fire,
@@ -237,7 +238,7 @@ impl Plugin for OrkFortressPlugin {
                     garrison_reinforce,
                     stage_breach,
                 )
-                    .run_if(in_state(Modal::None)),
+                    ,
             );
     }
 }
@@ -3084,11 +3085,6 @@ fn ry(a: f32) -> Quat {
 }
 fn rz(a: f32) -> Quat {
     Quat::from_rotation_z(a)
-}
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
 }
 fn group(parts: Vec<Mesh>) -> Mesh {
     let mut it = parts.into_iter();

--- a/src/orks.rs
+++ b/src/orks.rs
@@ -25,6 +25,7 @@ use crate::critters::PartKind;
 use crate::palette::{lin, lin_scaled};
 use crate::steer;
 use crate::worldmap;
+use crate::meshkit::tinted;
 
 /// Base root scale (the TS group scale before the per-variant `cfg.scale`). Was 0.7, bumped ×1.35
 /// with the hero/house rescale, then cut 15% (×0.85) so orks read a touch shorter than the hero.
@@ -988,11 +989,6 @@ fn rz(a: f32) -> Quat {
 }
 fn xyz(x: f32, y: f32, z: f32) -> Quat {
     Quat::from_euler(EulerRot::XYZ, x, y, z)
-}
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
 }
 fn group(parts: Vec<Mesh>) -> Mesh {
     let mut it = parts.into_iter();

--- a/src/props.rs
+++ b/src/props.rs
@@ -15,6 +15,7 @@
 use bevy::prelude::*;
 
 use crate::palette::{lin, lin_scaled};
+use crate::meshkit::{flat_shaded, merged, tinted};
 
 // Bush greens (TS BUSH_MATS, forest-props spec lines 125-127 / 433-441):
 //   dark #3a8a3a, mid #4aa84a, light #65bb55. Used as the three bush variants' base
@@ -38,24 +39,6 @@ pub const NUM_BUSH_VARIANTS: u32 = 3;
 
 // ─── Mesh helpers (verified 0.18 API, mirrors the working reference in
 // D:/tileworld-bevy/crates/game/src/map_props.rs) ───────────────────────────────
-
-/// Tag every vertex of `m` with a uniform linear RGBA colour (REQUIRED before merge —
-/// all merged parts must share the same attribute set, incl. ATTRIBUTE_COLOR).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge several tinted parts into one mesh (all parts share POSITION/NORMAL/UV/COLOR).
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("prop parts share attributes");
-    }
-    base
-}
 
 fn y(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)
@@ -250,12 +233,4 @@ pub fn build_bush_mesh(variant: u32) -> Mesh {
     // Flat-shaded so the bush reads as crisp low-poly facets (like the TS game), not a
     // soft blob.
     flat_shaded(merged(parts))
-}
-
-/// Un-index + recompute per-face normals so a merged mesh shows hard, flat-shaded
-/// facets (the crisp low-poly look) instead of soft smooth shading.
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
 }

--- a/src/quadruped.rs
+++ b/src/quadruped.rs
@@ -17,7 +17,7 @@ use std::f32::consts::PI;
 use bevy::prelude::*;
 
 use crate::creature::{surf, CreatureMaterial, Surf};
-use crate::palette::lin;
+use crate::meshkit::tinted_hex as tinted;
 
 // ── Species + config (port of `quadrupedSpecies.ts`) ──────────────────────────────────
 
@@ -578,11 +578,6 @@ const EYE: u32 = 0x141414;
 
 fn v(x: f32, y: f32, z: f32) -> Vec3 {
     Vec3::new(x, y, z)
-}
-fn tinted(mut m: Mesh, c: u32) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![lin(c); n]);
-    m
 }
 /// A bevelled box (24 verts + 12 edge bevels + 8 corner tris), origin-centred — the same softened
 /// low-poly silhouette the hero uses (`player::model::chamfer_box`), kept local here so animals read

--- a/src/quest.rs
+++ b/src/quest.rs
@@ -34,6 +34,7 @@ use crate::ui::texture::UiTextures;
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
 use crate::ui::IconAtlas;
+use crate::game_state::SimAppExt;
 
 /// The per-run quest state (wraps the parity-tested core log). Rides the save.
 #[derive(Resource, Default)]
@@ -71,13 +72,12 @@ impl Plugin for QuestPlugin {
             .add_systems(OnExit(Modal::Quest), despawn_quest_panel)
             .add_systems(Update, quest_panel_input.run_if(in_state(Modal::Quest)))
             // Detection (world running only).
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (detect_gather, detect_builds, detect_hunt, detect_survive)
-                    .run_if(in_state(Modal::None)),
+                    ,
             )
             // Open the explainer (world running only).
-            .add_systems(Update, quest_open_input.run_if(in_state(Modal::None)))
+            .add_sim_systems(quest_open_input)
             // Resolution + restore run ungated: a signal emitted while a panel is open (the War
             // Table) must be processed before the 2-frame message buffer drops it.
             .add_systems(Update, (apply_quest_signals, restore_quest_log))

--- a/src/ruins.rs
+++ b/src/ruins.rs
@@ -27,32 +27,9 @@ use crate::palette::lin;
 
 // ── Mesh helpers (verified API forms; shared with `landmark_models`) ─────────
 
-/// Tag every vertex of a part with one flat linear colour. REQUIRED before merge —
-/// all merged parts must carry the same attribute set, and the scene's shared white
-/// `StandardMaterial` reads colour straight off `ATTRIBUTE_COLOR`.
-pub(crate) fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge a list of already-tinted parts into one mesh.
-pub(crate) fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("parts share attributes");
-    }
-    base
-}
-
-/// Un-index + recompute per-face normals → crisp flat-shaded low-poly facets.
-/// `duplicate_vertices()` MUST run before `compute_flat_normals()`. Call LAST, on the merge.
-pub(crate) fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
-}
+// The shared low-poly mesh trio now lives in `crate::meshkit`; re-exported here so the many
+// `crate::ruins::{tinted, merged, flat_shaded}` importers (e.g. `landmark_models`) keep working.
+pub(crate) use crate::meshkit::{flat_shaded, merged, tinted};
 
 pub(crate) fn yv(v: f32) -> Vec3 {
     Vec3::new(0.0, v, 0.0)

--- a/src/savegame.rs
+++ b/src/savegame.rs
@@ -38,7 +38,7 @@ use tileworld_core::town_store::Town;
 use tileworld_core::upgrade_store::{node_by_id, UpgradeEffect, UpgradeState};
 
 use crate::economy::{Bank, Defenses, EconomyState, Upgrades};
-use crate::game_state::{AppState, Modal};
+use crate::game_state::AppState;
 use crate::inventory::Inventory;
 use crate::landmarks::{Discoveries, Landmark};
 use crate::player::PlayerRes;
@@ -49,6 +49,7 @@ use crate::town::TownRes;
 use crate::chest::{Chest, ChestId, ChestLid, CHEST_LID_OPEN};
 use crate::ui::notice::Notice;
 use crate::villagers::RescuedCamps;
+use crate::game_state::SimAppExt;
 
 /// Bump on any breaking change to [`SaveData`] — an older/garbage file is then treated as "no
 /// save" (logged, never fatal).
@@ -150,7 +151,7 @@ impl Plugin for SaveGamePlugin {
             .add_message::<RequestSave>()
             .add_systems(Startup, detect_existing_save)
             // Snapshot at dawn (a cleared night). Gated like the rest of the sim.
-            .add_systems(Update, autosave_on_dawn.run_if(in_state(Modal::None)))
+            .add_sim_systems(autosave_on_dawn)
             // Manual save (pause-menu button). Runs in `Paused` — where the world is frozen but
             // every run-state resource still lives — so it can snapshot the current day on demand.
             .add_systems(Update, manual_save.run_if(in_state(AppState::Paused)))

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -23,8 +23,8 @@
 use bevy::prelude::*;
 
 use crate::orks::{Faction, OrkVariant};
-use crate::palette::lin;
 use crate::siege::InvaderArmory;
+use crate::meshkit::{merged_flat as merged, tinted_hex as tinted};
 
 // ── Public tags ──────────────────────────────────────────────────────────────────────
 
@@ -593,21 +593,6 @@ fn spawn_torch(commands: &mut Commands, meshes: &mut Assets<Mesh>, assets: &Scen
 
 // ── Prop meshes (vertex-coloured, flat-shaded — the shared-material contract) ───────────
 
-fn tinted(mut m: Mesh, hex: u32) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![lin(hex); n]);
-    m
-}
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("≥1 part");
-    for p in it {
-        base.merge(&p).expect("scene prop parts share attributes");
-    }
-    base.duplicate_vertices();
-    base.compute_flat_normals();
-    base
-}
 fn cube(w: f32, h: f32, d: f32, off: Vec3, hex: u32) -> Mesh {
     tinted(Cuboid::new(w, h, d).mesh().build().translated_by(off), hex)
 }

--- a/src/siege.rs
+++ b/src/siege.rs
@@ -15,7 +15,7 @@
 
 use bevy::prelude::*;
 
-use crate::game_state::{AppState, Modal};
+use crate::game_state::AppState;
 use crate::orks::{self, OrkVariant, WaveInvader};
 use crate::player::{Health, HeroState, PendingHeroDamage};
 use crate::projectile::{BoltSpawn, BoltSpawns};
@@ -24,6 +24,7 @@ use crate::ui::anim::{anim, AnimKind};
 use crate::ui::fonts::{label, UiFonts};
 use crate::ui::theme::*;
 use crate::worldmap::ground_at_world;
+use crate::game_state::SimAppExt;
 
 // ── Tuning (ported from waveStore.ts) ──────────────────────────────────────────────
 
@@ -553,13 +554,12 @@ impl Plugin for SiegePlugin {
             .add_systems(Startup, (setup_invader_armory, setup_siege_hud))
             .add_systems(PostStartup, seed_demo_wave) // FOREST_WAVE screenshot hook only
             // Pause-aware clock — advances before the sim, frozen behind any panel / outside Playing.
-            .add_systems(Update, advance_game_clock.run_if(in_state(Modal::None)))
+            .add_sim_systems(advance_game_clock)
             // Sim — frozen behind any panel / outside Playing.
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (run_director, invader_brain, siege_controls, night_warning, keep_attack_alert, director_march)
                     .after(advance_game_clock)
-                    .run_if(in_state(Modal::None)),
+                    ,
             )
             // HUD keeps drawing while frozen.
             .add_systems(Update, update_siege_hud);
@@ -567,9 +567,8 @@ impl Plugin for SiegePlugin {
         if (std::env::var("FOREST_CLIP").is_ok() || std::env::var("FOREST_PERFTEST").is_ok())
             && std::env::var("FOREST_WAVE").is_ok()
         {
-            app.add_systems(
-                Update,
-                siege_clip_refill.after(invader_brain).run_if(in_state(Modal::None)),
+            app.add_sim_systems(
+                siege_clip_refill.after(invader_brain),
             );
         }
         app

--- a/src/snowman.rs
+++ b/src/snowman.rs
@@ -20,9 +20,9 @@
 use bevy::prelude::*;
 
 use crate::audio::AudioCue;
-use crate::game_state::Modal;
 use crate::player::{Health, HeroState, PendingHeroDamage};
 use crate::steer::{self, footing};
+use crate::game_state::SimAppExt;
 
 // ── Tuning ──────────────────────────────────────────────────────────────────────────────────
 /// Hero must step this close (world units) to a dormant snowman to wake it.
@@ -125,11 +125,10 @@ impl Plugin for SnowmanPlugin {
         // the body early-returns until `WorldReady`, then runs its one-shot spawn.
         app.add_systems(Update, seed_snowmen);
         // Sim tier — frozen with the rest of the world on a panel/pause (Modal only lives in Play).
-        app.add_systems(
-            Update,
+        app.add_sim_systems(
             (snowman_brain, detect_snowman_deaths, respawn_snowmen)
                 .chain()
-                .run_if(in_state(Modal::None)),
+                ,
         );
     }
 }

--- a/src/town.rs
+++ b/src/town.rs
@@ -24,6 +24,7 @@ use crate::ui::anim::{anim, AnimKind};
 use crate::ui::fonts::{label, UiFonts};
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
+use crate::game_state::SimAppExt;
 
 /// A flame entity tied to a burning plot (despawned when extinguished/collapsed).
 #[derive(Component)]
@@ -248,11 +249,10 @@ impl Plugin for TownPlugin {
             // game_state::drive_fresh_run — so this OnExit(StartScreen) reap covers it; Load restores.)
             // Build mode (live — world stays unfrozen so the hero walks while placing): spawn /
             // despawn the palette on toggle, drive its rows, glow every valid plot, and place on E.
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (build_mode_toggle, build_strip_input, build_nav, build_strip_update, build_place)
                     .chain()
-                    .run_if(in_state(Modal::None)),
+                    ,
             )
             // Ungated, but self-gated on `Modal::None` inside: the palette + glow rings + the "[B]
             // Build" town prompt must be REAPED/hidden when play is left or a panel opens (a
@@ -261,21 +261,18 @@ impl Plugin for TownPlugin {
             // The timber pad marks where the NEXT house will rise (visible even outside build mode).
             .add_systems(Update, sync_house_site_pad)
             // Trailer Director (F1 → "Build stronghold"): live, real-time construction timelapse.
-            .add_systems(Update, director_build_timelapse.run_if(in_state(Modal::None)))
-            .add_systems(
-                Update,
+            .add_sim_systems(director_build_timelapse)
+            .add_sim_systems(
                 (auto_assign_workers, sync_staffed, release_orphan_workers, sync_plot_visibility)
-                    .run_if(in_state(Modal::None)),
+                    ,
             )
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (production_system, population_system, sync_population_bodies)
-                    .run_if(in_state(Modal::None)),
+                    ,
             )
             // Sim (gated): apply damage + repair only while playing.
-            .add_systems(
-                Update,
-                (apply_building_damage, repair_system).run_if(in_state(Modal::None)),
+            .add_sim_systems(
+                (apply_building_damage, repair_system),
             )
             // Rebuild building meshes to match a loaded `TownRes` (ungated; fires on a load).
             .add_systems(Update, restore_buildings)
@@ -285,7 +282,7 @@ impl Plugin for TownPlugin {
             .add_systems(Update, (stage_town_for_shot, open_build_for_shot));
         // Clip-only: raise the town one plot at a time for a construction timelapse.
         if std::env::var("FOREST_DEMO").ok().as_deref() == Some("build") {
-            app.add_systems(Update, demo_build_timelapse.run_if(in_state(Modal::None)));
+            app.add_sim_systems(demo_build_timelapse);
         }
         // Clip-only: instant working village for the peasants-at-work scene.
         if std::env::var("FOREST_DEMO").ok().as_deref() == Some("work") {

--- a/src/training_dummies.rs
+++ b/src/training_dummies.rs
@@ -8,7 +8,7 @@ use bevy::mesh::MeshBuilder;
 use bevy::prelude::*;
 
 use crate::biome::BiomeEntity;
-use crate::palette::lin;
+use crate::meshkit::{merged_flat as merged, tinted_hex as tinted};
 
 /// Swing reach the dummy tests against (hero melee cone + the dummy's girth) — matches the
 /// ore-mining reach so the two read the same.
@@ -26,21 +26,6 @@ pub struct Dummy {
 }
 
 // ── tiny local mesh helpers (the props.rs / critters.rs contract) ──────────────────
-fn tinted(mut m: Mesh, c: u32) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![lin(c); n]);
-    m
-}
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("≥1 part");
-    for p in it {
-        base.merge(&p).expect("dummy parts share attributes");
-    }
-    base.duplicate_vertices();
-    base.compute_flat_normals();
-    base
-}
 fn bx(w: f32, h: f32, d: f32, off: Vec3, c: u32) -> Mesh {
     tinted(Cuboid::new(w, h, d).mesh().build().translated_by(off), c)
 }

--- a/src/tree_ui.rs
+++ b/src/tree_ui.rs
@@ -22,12 +22,13 @@ use crate::ui::texture::UiTextures;
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
 use crate::ui::IconAtlas;
+use crate::game_state::SimAppExt;
 
 pub struct TreeUiPlugin;
 
 impl Plugin for TreeUiPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, open_tree.run_if(in_state(Modal::None)))
+        app.add_sim_systems(open_tree)
             .add_systems(OnEnter(Modal::UpgradeTree), spawn_tree)
             .add_systems(OnExit(Modal::UpgradeTree), despawn_tree)
             .add_systems(

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -23,6 +23,7 @@
 
 use bevy::prelude::*;
 
+use crate::meshkit::{flat_shaded, merged, tinted};
 use crate::palette::{
     lin, AUTUMN_DARK, AUTUMN_GOLD, AUTUMN_LIGHT, AUTUMN_MID, AUTUMN_OLIVE, AUTUMN_RED, BIRCH_DARK,
     BIRCH_LIGHT, BIRCH_MARK, BIRCH_TRUNK, CUT_WOOD, DEAD_WOOD, DEAD_WOOD_DARK, FOLIAGE_DARK,
@@ -41,26 +42,6 @@ pub enum TreeKind {
     Autumn,
     /// A waist-high sawn stump with a pale ringed cut face — ground-level forest detail.
     Stump,
-}
-
-/// Tag every vertex of `m` with a flat linear colour so it can be merged with other
-/// coloured parts (all parts must carry `ATTRIBUTE_COLOR` before `Mesh::merge`).
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
-}
-
-/// Merge a non-empty list of pre-`tinted` parts into ONE mesh (so the renderer keeps
-/// them in a single batch). All parts share POSITION/NORMAL/UV_0/COLOR, so the merge
-/// always succeeds; `.expect` makes a mismatch loud rather than silent.
-fn merged(parts: Vec<Mesh>) -> Mesh {
-    let mut it = parts.into_iter();
-    let mut base = it.next().expect("at least one part");
-    for p in it {
-        base.merge(&p).expect("tree parts share attributes");
-    }
-    base
 }
 
 /// A tapered TS trunk/branch → a Bevy `Cylinder` using the AVERAGE of the top/bottom
@@ -107,13 +88,6 @@ pub fn build_tree_mesh(kind: TreeKind) -> Mesh {
     // Flat-shade so the foliage shows crisp icosphere facets (TS `flatShading: true`)
     // rather than soft smooth "blobs"), then bake the painterly per-facet shading.
     bake_facet_shading(flat_shaded(m))
-}
-
-/// Un-index + recompute per-face normals → hard flat-shaded facets.
-fn flat_shaded(mut m: Mesh) -> Mesh {
-    m.duplicate_vertices();
-    m.compute_flat_normals();
-    m
 }
 
 /// Bake painterly shading into the vertex colours (call AFTER `flat_shaded`, so the

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -27,6 +27,7 @@ use crate::ui::texture::UiTextures;
 use crate::ui::theme::*;
 use crate::ui::widgets::{self, border};
 use crate::ui::IconAtlas;
+use crate::game_state::SimAppExt;
 
 /// Active tab (index into [`TAB_NAMES`]). Reset to Basics each time the panel opens.
 #[derive(Resource, Default)]
@@ -50,7 +51,7 @@ impl Plugin for TutorialPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TutorialTab>()
             // Open with H — only while playing with no other panel up.
-            .add_systems(Update, open_tutorial.run_if(in_state(Modal::None)))
+            .add_sim_systems(open_tutorial)
             .add_systems(OnEnter(Modal::Tutorial), spawn_tutorial)
             .add_systems(OnExit(Modal::Tutorial), despawn_tutorial)
             // Start-menu guide: the HOW TO PLAY button (or H) opens the same panel without the

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -14,11 +14,11 @@ use crate::audio::AudioCue;
 use crate::combat_fx::FloatReq;
 use crate::critters::Species;
 use crate::economy::Bank;
-use crate::game_state::Modal;
 use crate::inventory::{try_grant, Inventory, Toasts};
 use crate::palette::lin;
 use crate::player::HeroState;
 use crate::worldmap;
+use crate::game_state::SimAppExt;
 
 /// Forest ore HP — rescaled from core's TS-anchored 500 into forest's combat units, then bumped so
 /// a boulder is a REAL dig: at the flat [`HERO_HARVEST_DMG`] (30) it's a fixed ~20 swings, all run,
@@ -108,8 +108,7 @@ impl Plugin for VerbsPlugin {
             .add_message::<AnimalKilled>()
             .init_resource::<VerbRng>()
             .add_systems(Startup, setup_drop_assets)
-            .add_systems(
-                Update,
+            .add_sim_systems(
                 (
                     mine_ore,
                     regrow_ore,
@@ -124,7 +123,7 @@ impl Plugin for VerbsPlugin {
                     animal_drops,
                     ground_pickup,
                 )
-                    .run_if(in_state(Modal::None)),
+                    ,
             )
             // Impact-juice drivers — ungated (like `dying.rs` / `combat_fx`: a mid-fall tree
             // keeps toppling behind a panel; virtual time still freezes them under a hit-stop)

--- a/src/villagers.rs
+++ b/src/villagers.rs
@@ -28,6 +28,7 @@ use crate::palette::{lin, lin_scaled};
 use crate::peasant_model::{peasant_biped_meshes, PeasantKind};
 use crate::steer;
 use crate::worldmap;
+use crate::meshkit::tinted;
 
 /// Townsfolk turn at a relaxed rate. rad/s.
 const VIL_MAX_TURN: f32 = 3.0;
@@ -2944,11 +2945,6 @@ fn reskin_townsfolk(
 
 fn v(x: f32, y: f32, z: f32) -> Vec3 {
     Vec3::new(x, y, z)
-}
-fn tinted(mut m: Mesh, c: [f32; 4]) -> Mesh {
-    let n = m.count_vertices();
-    m.insert_attribute(Mesh::ATTRIBUTE_COLOR, vec![c; n]);
-    m
 }
 fn group(parts: Vec<Mesh>) -> Mesh {
     let mut it = parts.into_iter();

--- a/src/warlord.rs
+++ b/src/warlord.rs
@@ -18,7 +18,7 @@ use bevy::prelude::*;
 use crate::boss::Slowed;
 use crate::critters::PartKind;
 use crate::dying::Dying;
-use crate::game_state::{AppState, Modal};
+use crate::game_state::AppState;
 use crate::orks::{Armory, Faction, OrkPart, OrkVariant};
 use crate::player::{CombatFx, Health, HeroState, PendingCrit, PendingHeroDamage, PlayerRes};
 use crate::siege::{GamePhase, Siege};
@@ -27,6 +27,7 @@ use crate::ui::fonts::{label, UiFonts};
 use crate::ui::theme::*;
 use crate::ui::widgets;
 use crate::{steer, worldmap};
+use crate::game_state::SimAppExt;
 
 // ── Tuning (all forest-side) ─────────────────────────────────────────────────────────────
 /// Base HP at hero level 1, grown ×`HP_PER_LEVEL` per hero level so a fully-geared late hero still
@@ -89,7 +90,7 @@ impl Plugin for WarlordPlugin {
         app.add_systems(Update, warlord_limbs) // limb sway runs even while frozen
             .add_systems(Update, sync_warlord_bar.run_if(in_state(AppState::Playing)))
             .add_systems(OnExit(AppState::Playing), despawn_warlord_bar)
-            .add_systems(Update, (warlord_brain, warlord_death).run_if(in_state(Modal::None)));
+            .add_sim_systems((warlord_brain, warlord_death));
     }
 }
 


### PR DESCRIPTION
Review-driven cleanups to make the codebase easier to work in, plus a small DoF tuning fix. All behaviour-preserving except the intentional DoF change; verified by a clean link build and the 306 core parity tests.

## Changes

**`src/meshkit.rs` — consolidate the shared low-poly mesh trio.** The copy-pasted `tinted`/`merged`/`flat_shaded` helpers (~50 identical definitions across ~30 modules) now live in one place. Each call site keeps its exact semantics: hex-`u32` tints map to `tinted_hex`, and the merge-then-flat-shade variants (meadow/scenes/training_dummies) map to `merged_flat`, so no mesh changes shading. The three per-joint tints that bake a surface code into the alpha (`player/model`, `previs_knight`, `peasant_model`) keep their local helpers. `ruins` re-exports the trio, so `landmark_models` is untouched.

**`SimAppExt::add_sim_systems` — DRY + enforce the freeze-gate invariant.** The boilerplate `.add_systems(Update, X.run_if(in_state(Modal::None)))` (28 sites across 20 plugins) becomes `.add_sim_systems(X)`. Beyond shortening the call, it names the intent and makes the `Modal::None` gate impossible to forget for future sim systems — a silent bug CLAUDE.md warns about. Deliberately-ungated render/VFX/HUD systems are left alone; now-unused `Modal` imports cleaned up.

**`dof.rs` — soften and push out the far blur.** Per feedback that torches blur too soon/hard: `range` 42→60 moves the far-blur onset from ~70 to ~88 tiles, `max_radius` 13→9 softens the bokeh.

## Verification

- Full binary links (`cargo build`, exit 0) with every change.
- 306 core parity tests pass (`cargo test -p tileworld_core --lib`).
- No net-new warnings (47, same as baseline).
- The two refactors are provably behaviour-identical (byte-identical function bodies / an exactly-equivalent helper).

Note: a headless smoke render couldn't run in this container (`xkbcommon`/X11 under xvfb panics on window init — an environment gap, not a code issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmfPLMhBSgrJ9V9UYamctY

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmfPLMhBSgrJ9V9UYamctY)_