### PR TITLE
Polish map blockers and player obstacle assist

### DIFF
--- a/src/biome.rs
+++ b/src/biome.rs
@@ -53,6 +53,9 @@ const OPEN_COVER_BOOST: f32 = 0.45;
 const SLOPE_FREE: f32 = 0.35;
 const SLOPE_TREE_THIN: f32 = 1.2;
 const SLOPE_TREE_FLOOR: f32 = 0.1;
+/// Tree spacing is authored as centre-to-centre, but cross-biome scatter passes don't share the
+/// local `tree_pts` list. This blocker clearance makes later passes respect earlier trunks too.
+const TREE_BLOCKER_CLEAR_FRAC: f32 = 0.8;
 
 /// Fog knobs: `FOREST_FOG="clear,full"` overrides at runtime (no rebuild). `clear` = the
 /// fully-clear radius; `full` = distance the fog reaches the horizon colour (smaller = thicker).
@@ -984,16 +987,25 @@ pub fn scatter_region(
             if let Some(c) = chosen {
                 let vi = pick_weighted(&c.weights, r.next());
                 let s = r.range(c.scale.0, c.scale.1);
+                let landmark_buffered = crate::ruins::near_landmark_collision_buffer(cx, cz);
+                let landmark_core = crate::ruins::near_landmark_visual_footprint(cx, cz);
                 if c.tree {
                     let p = Vec2::new(cx, cz);
+                    let tree_clear = cfg.tree_min_dist * TREE_BLOCKER_CLEAR_FRAC;
                     // Skip trunk-trees that fall inside a warden glade (the boss arena must stay
-                    // open) OR too close to a neighbour — drop the fallback prop (a bush) there
-                    // instead, so the spot keeps low cover and the glade doesn't read bald.
+                    // open), in a landmark's collision apron, OR too close to a neighbour — drop a
+                    // walk-through fallback prop there so the ground keeps understorey rather than
+                    // turning into a stripped circle.
                     if crate::boss::in_warden_glade(cx, cz)
+                        || landmark_buffered
+                        || landmark_core
                         || tree_pts.iter().any(|q| q.distance_squared(p) < min_d2)
+                        || crate::blockers::any_within(cx, cz, tree_clear)
                     {
                         // Passive non-tree prop, so it merges into the chunk's props bucket.
-                        if let Some(fb) = fallback {
+                        if let Some(fb) = fallback
+                            .filter(|fb| !landmark_core && (fb.block_radius <= 0.0 || !landmark_buffered))
+                        {
                             let fi = pick_weighted(&fb.weights, r.next());
                             let fs = r.range(fb.scale.0, fb.scale.1);
                             queue(false, fb.variants[fi].clone(), Vec3::new(cx, py, cz), yaw(&mut r), fs);
@@ -1044,6 +1056,10 @@ pub fn scatter_region(
                         }
                     }
                 } else {
+                    if landmark_core || (landmark_buffered && c.block_radius > 0.0) {
+                        gz += 1.0;
+                        continue;
+                    }
                     // Big non-tree props (boulders) block, scaled with the instance and capped at
                     // the blockers neighbour-scan bound. Small clutter has block_radius 0 → nothing.
                     // A floor drops the small end of a mixed class — only clearly-big boulders block;
@@ -1089,6 +1105,7 @@ pub fn scatter_region(
                         // near_road (not on_road): flat cover discs are wide, so reject any whose
                         // body would overhang a trail even if its centre is just off it.
                         || crate::roads::near_road(x, z, 0.9)
+                        || crate::ruins::near_landmark_visual_footprint(x, z)
                     {
                         continue;
                     }

--- a/src/blockers.rs
+++ b/src/blockers.rs
@@ -166,6 +166,40 @@ pub fn any_within(wx: f32, wz: f32, margin: f32) -> bool {
     false
 }
 
+/// A small outward vector from nearby circular blockers (trees/cacti), weighted by how close the
+/// body is to their collision shell. This is intentionally circle-only: walls and buildings already
+/// slide well via axis-separated movement, while trunks are the snaggy case that benefits from a
+/// subtle steer assist.
+pub fn circle_repulsion(wx: f32, wz: f32, body_r: f32, sense_r: f32) -> (f32, f32) {
+    let map = CIRCLES.read().unwrap();
+    let (tx, tz) = tile(wx, wz);
+    let sense = sense_r.max(0.0);
+    let reach = 1 + (body_r + sense).ceil() as i32;
+    let mut out_x = 0.0;
+    let mut out_z = 0.0;
+    for dx in -reach..=reach {
+        for dz in -reach..=reach {
+            if let Some(bucket) = map.get(&(tx + dx, tz + dz)) {
+                for &(cx, cz, r) in bucket {
+                    let (ex, ez) = (wx - cx, wz - cz);
+                    let d2 = ex * ex + ez * ez;
+                    if d2 <= 1e-6 {
+                        continue;
+                    }
+                    let d = d2.sqrt();
+                    let influence = r + body_r + sense;
+                    if d < influence {
+                        let w = ((influence - d) / sense.max(0.001)).clamp(0.0, 1.0);
+                        out_x += (ex / d) * w;
+                        out_z += (ez / d) * w;
+                    }
+                }
+            }
+        }
+    }
+    (out_x, out_z)
+}
+
 /// True if `(wx, wz)` lies inside any solid obstacle (a circle or an oriented box).
 pub fn is_blocked(wx: f32, wz: f32) -> bool {
     {
@@ -306,6 +340,22 @@ mod tests {
         // read false there, so the broadened escape can't be abused to clip through a wall in play.
         assert!(!is_blocked(1.0 + PLAYER_R + 0.01, 0.0));
         assert!(!any_within(1.0 + PLAYER_R + 0.01, 0.0, PLAYER_R));
+        reset();
+    }
+
+    #[test]
+    fn circle_repulsion_points_away_from_nearby_trunks_only() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset();
+        add(0.0, 0.0, 0.5);
+        add_box(2.0, 0.0, 0.5, 0.5);
+
+        let (x, z) = circle_repulsion(0.75, 0.0, 0.22, 0.45);
+        assert!(x > 0.0, "near a trunk on the east side should push east");
+        assert!(z.abs() < 0.01, "a symmetric trunk contact should not add sideways noise");
+
+        let (far_x, far_z) = circle_repulsion(2.0, 0.0, 0.22, 0.45);
+        assert_eq!((far_x, far_z), (0.0, 0.0), "box blockers are ignored by the tree assist");
         reset();
     }
 }

--- a/src/camps.rs
+++ b/src/camps.rs
@@ -468,10 +468,10 @@ pub fn build(
         // (they did at the old −2.4/+2.2 spots). Tent at 0.7× the fortress size to fit the camp.
         let mut prop_rng = site.seed | 1;
         let solids = vec![
-            (crate::ork_fortress::tent_mesh(0.7, &mut prop_rng), v(-2.3, 0.0, -2.1), 0.0_f32, (1.3_f32, 1.1_f32)),
-            (banner_mesh(site.faction), v(0.0, 0.0, 0.0), 0.0, (0.25, 0.25)),
+            (crate::ork_fortress::tent_mesh(0.7, &mut prop_rng), v(-2.3, 0.0, -2.1), 0.0_f32, (1.05_f32, 0.85_f32)),
+            (banner_mesh(site.faction), v(0.0, 0.0, 0.0), 0.0, (0.0, 0.0)),
             (spikes_mesh(), v(0.0, 0.0, 0.0), 0.0, (0.0, 0.0)),
-            (fire_base_mesh(), v(0.2, 0.0, 0.0), 0.0, (0.55, 0.55)),
+            (fire_base_mesh(), v(0.2, 0.0, 0.0), 0.0, (0.32, 0.32)),
         ];
         for (m, local, lyaw, (hw, hd)) in solids {
             let h = meshes.add(m);
@@ -507,8 +507,7 @@ pub fn build(
         crate::blockers::add_obb(cage_world.x, cage_world.z, 1.2, 1.2, site.rot + 0.6);
 
         // Log sit-stumps ringing the fire (fire is at local (0.2,0,0)) — orks roost on these
-        // between musters. Small footprint blockers so the hero bumps them but they don't wall
-        // the camp.
+        // between musters. Decorative-only: tiny stump blockers made camp melee snaggy.
         for (i, local) in [v(1.25, 0.0, 0.5), v(-0.5, 0.0, 0.95), v(0.45, 0.0, -1.05)].into_iter().enumerate() {
             let w = place(local);
             let seed = site.seed.wrapping_add(i as u32 * 37).wrapping_add(7) | 1;
@@ -518,7 +517,6 @@ pub fn build(
                 Transform { translation: w, rotation: ry((seed % 628) as f32 / 100.0), scale: Vec3::ONE },
                 BiomeEntity,
             ));
-            crate::blockers::add(w.x, w.z, 0.26);
         }
         // The banner's cloth — a fluttering faction flag on the pole `banner_mesh` left bare.
         let flag = crate::banner::spawn_flag(

--- a/src/castle_decor.rs
+++ b/src/castle_decor.rs
@@ -5,16 +5,16 @@
 //! pieces in the yard: Town Guard Arms raises an armory corner, the Tax Office opens a counting
 //! booth, the Healing Shrine gets an actual shrine, Reinforced Keep scaffolds the keep wall,
 //! Tower Mastery lights standing braziers by the towers, the Arsenal unlocks go up on display
-//! stands. The upgrade tree becomes visible history — you can read a run's purchases off the
-//! courtyard.
+//! stands. Small/thin props stay visual-only so the courtyard reads lived-in without snagging
+//! movement; the upgrade tree becomes visible history you can read off a run's purchases.
 //!
 //! All parts follow the castle's conventions: built from [`crate::castle::Mats`]'s shared
 //! textured materials at local origin (base y = 0, front +Z), baked to a world spot by
 //! [`build`], and revealed by [`sync_decor`] off the live [`Defenses`] / [`EconomyState`] /
 //! [`Upgrades`] / town state (flag-driven, so staged `FOREST_DEFEND` shots and loaded saves
-//! both show the right dressing). Each piece is **solid**: [`sync_decor`] registers a tight
-//! oriented collision box ([`DecorSolid`]) in [`crate::blockers`] the first frame the piece is
-//! shown, so the hero (and AI) route around the props instead of walking through them — lazy +
+//! both show the right dressing). Chunky pieces can be **solid**: [`sync_decor`] registers a tight
+//! oriented collision box ([`DecorSolid`]) in [`crate::blockers`] the first frame such a piece is
+//! shown, so the hero (and AI) route around major props instead of walking through them — lazy +
 //! once-only because the blocker set is append-only (same model as `castle::sync_castle`). Every
 //! spot is hand-picked clear of the keep, bell, gate lanes, torches, training dummies, house
 //! slots and the path network.
@@ -222,13 +222,13 @@ pub fn build(commands: &mut Commands, meshes: &mut Assets<Mesh>, mats: &Mats) {
     };
 
     // ── Day-one life (Always) ────────────────────────────────────────────────────
-    // Each piece carries a tight collision footprint (local half-extents) — the hero now slides
-    // around the props instead of walking through them. Sized to the prop's solid ground mass.
-    set(notice_board_parts(), Vec3::new(-3.3, 0.0, 4.4), 0.35, DecorGate::Always, Vec2::new(0.7, 0.18));
-    set(trough_parts(), Vec3::new(3.6, 0.0, 4.7), 0.25, DecorGate::Always, Vec2::new(0.6, 0.3));
+    // Small furniture is visual-only so the plaza lanes stay smooth; larger upgrade structures
+    // below keep tight collision footprints where walking through them would look wrong.
+    set(notice_board_parts(), Vec3::new(-3.3, 0.0, 4.4), 0.35, DecorGate::Always, Vec2::ZERO);
+    set(trough_parts(), Vec3::new(3.6, 0.0, 4.7), 0.25, DecorGate::Always, Vec2::ZERO);
     // (The old plaza market-goods pile lived here — removed; the merchant shop by the south gate
     // (`villagers::shop_parts`) is now the town's single market focal point.)
-    set(bench_parts(), Vec3::new(-5.9, 0.0, -1.4), HALF_PI, DecorGate::Always, Vec2::new(0.62, 0.2));
+    set(bench_parts(), Vec3::new(-5.9, 0.0, -1.4), HALF_PI, DecorGate::Always, Vec2::ZERO);
     // A few lantern posts along the main lanes (thinned down — the bailey was getting busy).
     for (lx, lz, lyaw) in [
         (2.0, -6.6, 0.0),
@@ -239,8 +239,8 @@ pub fn build(commands: &mut Commands, meshes: &mut Assets<Mesh>, mats: &Mats) {
     }
 
     // ── Filled in as the town grows (House(n): shown once houses > n) ───────────
-    set(garden_parts(), Vec3::new(-4.2, 0.0, -9.4), 0.15, DecorGate::House(1), Vec2::new(0.6, 0.48));
-    set(woodpile_parts(), Vec3::new(5.4, 0.0, -9.5), 0.4, DecorGate::House(2), Vec2::new(0.62, 0.32));
+    set(garden_parts(), Vec3::new(-4.2, 0.0, -9.4), 0.15, DecorGate::House(1), Vec2::ZERO);
+    set(woodpile_parts(), Vec3::new(5.4, 0.0, -9.5), 0.4, DecorGate::House(2), Vec2::ZERO);
     // Laundry line = cloth hung overhead on a string between two thin posts — you walk UNDER it.
     // No collision (a 2.6-wide box across the lane just walls off the courtyard for no reason).
     set(laundry_parts(), Vec3::new(-10.0, 0.0, -10.2), 0.05, DecorGate::House(1), Vec2::ZERO);
@@ -249,22 +249,22 @@ pub fn build(commands: &mut Commands, meshes: &mut Assets<Mesh>, mats: &Mats) {
     // ── Upgrade set pieces ───────────────────────────────────────────────────────
     // The armory corner west of the plaza: racked spears + shields + a leather stand (tier 1),
     // extended with steel — sword rail + iron stand (tier 2). Arsenal unlocks join on display.
-    set(armory_parts(), Vec3::new(-8.6, 0.0, 3.0), 0.5, DecorGate::ArmsTier(1), Vec2::new(1.0, 0.4));
-    set(armory_veteran_parts(), Vec3::new(-8.2, 0.0, 4.9), 0.8, DecorGate::ArmsTier(2), Vec2::new(0.9, 0.35));
+    set(armory_parts(), Vec3::new(-8.6, 0.0, 3.0), 0.5, DecorGate::ArmsTier(1), Vec2::new(0.7, 0.3));
+    set(armory_veteran_parts(), Vec3::new(-8.2, 0.0, 4.9), 0.8, DecorGate::ArmsTier(2), Vec2::ZERO);
     set(axe_display_parts(), Vec3::new(-6.9, 0.0, 6.3), 0.9, DecorGate::Weapon("axe"), Vec2::new(0.32, 0.25));
     set(sword_display_parts(), Vec3::new(-7.9, 0.0, 7.6), 1.1, DecorGate::Weapon("sword_gold"), Vec2::new(0.3, 0.25));
-    set(grindstone_parts(), Vec3::new(-5.6, 0.0, 8.4), 0.8, DecorGate::Purchased("hero_dmg_1"), Vec2::new(0.45, 0.32));
+    set(grindstone_parts(), Vec3::new(-5.6, 0.0, 8.4), 0.8, DecorGate::Purchased("hero_dmg_1"), Vec2::ZERO);
 
     // Civic east side: the tax-collector's counting booth; the shrine the heal aura lives in.
-    set(tax_booth_parts(), Vec3::new(8.5, 0.0, 2.9), -0.6, DecorGate::TaxOffice, Vec2::new(0.85, 0.6));
-    set(shrine_parts(), Vec3::new(8.0, 0.0, -3.4), -0.8, DecorGate::Shrine, Vec2::new(0.52, 0.42));
+    set(tax_booth_parts(), Vec3::new(8.5, 0.0, 2.9), -0.6, DecorGate::TaxOffice, Vec2::new(0.65, 0.45));
+    set(shrine_parts(), Vec3::new(8.0, 0.0, -3.4), -0.8, DecorGate::Shrine, Vec2::new(0.4, 0.32));
 
     // Bounty board inside the north gate — wanted papers for the ork warlords.
-    set(bounty_board_parts(), Vec3::new(3.4, 0.0, -10.4), 0.1, DecorGate::Purchased("eco_bounty"), Vec2::new(0.78, 0.18));
+    set(bounty_board_parts(), Vec3::new(3.4, 0.0, -10.4), 0.1, DecorGate::Purchased("eco_bounty"), Vec2::ZERO);
 
     // Reinforced Keep: a mason's scaffold against the keep's west wall + dressed stone waiting.
-    set(scaffold_parts(), Vec3::new(-3.55, 0.0, 0.0), 0.0, DecorGate::Reinforced, Vec2::new(0.45, 1.7));
-    set(stone_pile_parts(), Vec3::new(-4.8, 0.0, 1.3), 0.3, DecorGate::Reinforced, Vec2::new(0.35, 0.5));
+    set(scaffold_parts(), Vec3::new(-3.55, 0.0, 0.0), 0.0, DecorGate::Reinforced, Vec2::ZERO);
+    set(stone_pile_parts(), Vec3::new(-4.8, 0.0, 1.3), 0.3, DecorGate::Reinforced, Vec2::ZERO);
 
     // Tower Mastery: a standing fire basket inside each wall corner (the crews work all night).
     for (sx, sz) in [(-1.0_f32, -1.0_f32), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)] {

--- a/src/landmarks.rs
+++ b/src/landmarks.rs
@@ -343,17 +343,14 @@ impl Plugin for LandmarksPlugin {
     }
 }
 
-/// Fell every tree and despawn merged ground-cover chunks within [`LANDMARK_CLEAR_R`] of a
-/// landmark, once, after the landmarks exist. Tree/cover scatter (worldmap build phases 5–9
-/// and 12) runs long before landmark placement (phase 23), so props crowd right up to the
-/// set-pieces; this opens the ground around each so flowers don't poke through the mesh and
-/// the rune-trial arena is clear. Cover chunks use a slightly wider radius (chunk half-extent)
-/// so a 16×16 merged mesh can't straddle the landmark with one corner still full of tufts.
+/// Fell every tree within [`LANDMARK_CLEAR_R`] of a landmark, once, after the landmarks exist.
+/// Tree scatter runs long before landmark placement (worldmap build phases 5–9 vs. 23), so trunks
+/// otherwise crowd right up to the set-pieces. Non-colliding bushes, stones and ground cover stay:
+/// they dress the shrine without blocking the rune-trial arena.
 fn clear_around_landmarks(
     mut commands: Commands,
     landmarks: Query<&Transform, With<Landmark>>,
     trees: Query<(Entity, &Transform), With<crate::verbs::ChopTree>>,
-    cover: Query<(Entity, &Transform), With<crate::biome::GroundCoverChunk>>,
     mut done: Local<bool>,
 ) {
     if *done {
@@ -365,18 +362,10 @@ fn clear_around_landmarks(
     }
     *done = true;
     let r2 = LANDMARK_CLEAR_R * LANDMARK_CLEAR_R;
-    let cover_r = LANDMARK_CLEAR_R + crate::biome::COVER_CHUNK * 0.75;
-    let cover_r2 = cover_r * cover_r;
     for (e, tf) in &trees {
         let p = Vec2::new(tf.translation.x, tf.translation.z);
         if centers.iter().any(|c| c.distance_squared(p) < r2) {
             crate::blockers::remove_at(p.x, p.y); // p.y is world Z
-            commands.entity(e).try_despawn();
-        }
-    }
-    for (e, tf) in &cover {
-        let p = Vec2::new(tf.translation.x, tf.translation.z);
-        if centers.iter().any(|c| c.distance_squared(p) < cover_r2) {
             commands.entity(e).try_despawn();
         }
     }

--- a/src/player/movement.rs
+++ b/src/player/movement.rs
@@ -46,6 +46,12 @@ const STEP_FREQ: f32 = 7.0;
 const ACCEL: f32 = 14.0;
 const DECEL: f32 = 9.0;
 pub(super) const PLAYER_R: f32 = 0.22;
+/// How far outside a trunk's collision shell the player starts getting a gentle steer assist.
+const OBSTACLE_ASSIST_SENSE: f32 = 0.55;
+/// Max sideways bias mixed into raw input near a trunk. Kept low so it helps a snag, not drives.
+const OBSTACLE_ASSIST_TANGENT: f32 = 0.26;
+/// Tiny outward bias so the player separates from bark while the tangent finds a slide path.
+const OBSTACLE_ASSIST_OUTWARD: f32 = 0.06;
 /// Walking down a terrace drops the ground a full height class (`worldmap::GROUND_STEP` 0.5) under
 /// the body in one tile. Without a snap the body floats above the new-lower ground for a frame or
 /// two each step, flicking `on_ground` off→on → the walk/fall anim strobes all the way down a
@@ -112,6 +118,33 @@ fn move_input(keys: &ButtonInput<KeyCode>, cam: Option<&Transform>) -> Option<Ve
     .clamp(-1.0, 1.0);
     let dir = fwd * fwd_amt + right * rgt_amt;
     (dir.length_squared() > 1e-6).then(|| Vec2::new(dir.x, dir.z).normalize())
+}
+
+fn obstacle_assisted_dir(pos: Vec2, input_dir: Vec2, current_vel: Vec2) -> Vec2 {
+    let (rx, rz) = blockers::circle_repulsion(pos.x, pos.y, PLAYER_R, OBSTACLE_ASSIST_SENSE);
+    let away = Vec2::new(rx, rz);
+    if away.length_squared() < 1e-6 {
+        return input_dir;
+    }
+    let away_dir = away.normalize();
+    // Only help when the player is pushing into bark; retreating or skimming past stays raw input.
+    if input_dir.dot(away_dir) >= -0.08 {
+        return input_dir;
+    }
+    let strength = away.length().min(1.0);
+    let mut tangent = Vec2::new(-away_dir.y, away_dir.x);
+    let continuity = if current_vel.length_squared() > 1e-4 {
+        current_vel.normalize()
+    } else {
+        input_dir
+    };
+    if tangent.dot(continuity) < 0.0 {
+        tangent = -tangent;
+    }
+    (input_dir
+        + tangent * (OBSTACLE_ASSIST_TANGENT * strength)
+        + away_dir * (OBSTACLE_ASSIST_OUTWARD * strength))
+        .normalize_or_zero()
 }
 
 /// Arm the **dodge roll** on Alt: pick the dive direction (move input, else a backward dive away
@@ -484,7 +517,12 @@ pub fn player_move(
         * if hero.charge_t > super::combat::CHARGE_GRACE { super::combat::CHARGE_MOVE_MULT } else { 1.0 }
         // Combat stance: strafing/backpedaling around the ringed foe is slower than advancing.
         * stance_speed_mult;
-    let desired = if moving { move_dir * want_speed } else { Vec2::ZERO };
+    let travel_dir = if moving && hero.stance_amt < 0.5 {
+        obstacle_assisted_dir(hero.pos, move_dir, hero.vel)
+    } else {
+        move_dir
+    };
+    let desired = if moving { travel_dir * want_speed } else { Vec2::ZERO };
     let ramp = if moving { ACCEL } else { DECEL }; // faster to start than to stop
     let new_vel = hero.vel + (desired - hero.vel) * (dt * ramp).min(1.0);
     hero.vel = new_vel;

--- a/src/ruins.rs
+++ b/src/ruins.rs
@@ -511,6 +511,33 @@ const SITE_PARAMS: [(crate::biome::Biome, f32, f32); 5] = [
     (crate::biome::Biome::Swamp, 1.4, 1.5),
 ];
 
+/// Extra collision-free apron around each landmark's real footprint. Scatter can still place
+/// walk-through bushes, pebbles and ground cover here; only trunks / blocking boulders stay out.
+const LANDMARK_COLLISION_APRON: f32 = 4.0;
+/// Tiny visual core that stays empty so scatter does not poke straight through the landmark mesh.
+const LANDMARK_VISUAL_APRON: f32 = 0.75;
+
+fn near_site_with_apron(x: f32, z: f32, apron: f32) -> bool {
+    let p = Vec2::new(x, z);
+    landmark_sites().iter().any(|site| {
+        SITE_PARAMS
+            .iter()
+            .find(|(biome, _, _)| *biome == site.biome)
+            .is_some_and(|(_, scale, foot_r)| {
+                let r = foot_r * scale + apron;
+                site.pos.distance_squared(p) < r * r
+            })
+    })
+}
+
+pub fn near_landmark_collision_buffer(x: f32, z: f32) -> bool {
+    near_site_with_apron(x, z, LANDMARK_COLLISION_APRON)
+}
+
+pub fn near_landmark_visual_footprint(x: f32, z: f32) -> bool {
+    near_site_with_apron(x, z, LANDMARK_VISUAL_APRON)
+}
+
 /// The five landmark spots, chosen once (flattest valid candidate per biome) and cached. Decoupled
 /// from `blockers` — those aren't populated this early (the road field bakes at the ground pass,
 /// long before scatter) — so spots shifted slightly vs. the old post-scatter search; the

--- a/src/training_dummies.rs
+++ b/src/training_dummies.rs
@@ -81,9 +81,8 @@ pub fn populate(
             Dummy { wobble_until: 0.0, knock: Vec2::ZERO },
             BiomeEntity,
         ));
-        // Solid pell — a small base so you can't walk through it, but the hero still steps in
-        // well within HIT_RANGE to swing at it.
-        crate::blockers::add(x, z, 0.3);
+        // Solid pell — a slim base so you feel it, without snagging the courtyard lane.
+        crate::blockers::add(x, z, 0.22);
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Space scattered trees against existing blockers so cross-biome passes do not crowd trunks.
- Add landmark collision and visual buffers so blocking props stay clear while walk-through decoration can remain nearby.
- Add subtle tree-only player obstacle assist that nudges movement around trunks without replacing collision.
- Reduce movement-blocking clutter in ork camps and the castle courtyard while keeping the visual dressing.

### Walkthrough
[Forest landmark clearance after blocker polish](https://cursor.com/agents/bc-d02fe498-64c6-4426-a837-7f4d1e905b1c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fforest_landmark_collision_polish.png)
[Castle courtyard with reduced clutter blockers](https://cursor.com/agents/bc-d02fe498-64c6-4426-a837-7f4d1e905b1c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcastle_clutter_polish.png)
[Ork camp with reduced clutter blockers](https://cursor.com/agents/bc-d02fe498-64c6-4426-a837-7f4d1e905b1c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcamp_clutter_polish.png)

### Testing
- `cargo check`
- `cargo test -p tileworld_core`
- `cargo test circle_repulsion_points_away_from_nearby_trunks_only`
- `cargo build`
- Castle capture: `BEVY_ASSET_ROOT=$PWD FOREST_SHOT=/tmp/castle_clutter_polish.png FOREST_CAM="0,28,24,0,0,0" FOREST_DEFEND=1 FOREST_TOWN=1 FOREST_NOHUD=1 FOREST_QUALITY=low FOREST_TIME=0.28 timeout 570 xvfb-run -a -s "-screen 0 1280x720x24" ./target/debug/tileworld_bevy_forest > /tmp/castle_clutter_polish.log 2>&1`
- Camp capture: `BEVY_ASSET_ROOT=$PWD FOREST_SHOT=/tmp/camp_clutter_polish.png FOREST_CAM="5.8,22,-52,5.8,0,-65" FOREST_NOHUD=1 FOREST_QUALITY=low FOREST_TIME=0.28 timeout 570 xvfb-run -a -s "-screen 0 1280x720x24" ./target/debug/tileworld_bevy_forest > /tmp/camp_clutter_polish.log 2>&1`

Note: capture logs still show two pre-existing missing rival voice files (`rival_fell_a/b.ogg`), but no render asset misses; both screenshots saved successfully.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d02fe498-64c6-4426-a837-7f4d1e905b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d02fe498-64c6-4426-a837-7f4d1e905b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

