### PR TITLE
FP melee polish: swing shaping, camera sway, close-quarters FOV & HP bar fixes

### DIFF
--- a/.claude/skills/visual-debug-cloud/SKILL.md
+++ b/.claude/skills/visual-debug-cloud/SKILL.md
@@ -56,6 +56,14 @@ Notes:
 - Expect **~3–5 minutes per shot** on llvmpipe (the `software rendering ... very slow`
   warning and the X11 `XSETTINGS` warning are normal). Wrap in `timeout 570` so a hang
   can't eat the Bash tool's 10-minute ceiling.
+- **FOREST_CLIP: set `FOREST_CLIP_WARMUP=70`+ — the default 30 records the boot LOADING
+  VEIL.** The veil (a full-screen dark backdrop, `loading.rs`) lifts ~1.4s of *sim* time
+  after boot, so with the default 30-frame warmup the first ~50 saved frames are dimmed
+  grey / pure black *behind an intact HUD*, in every scene. This is spectacularly
+  misleading when you're debugging a visual: it reads as "some mesh/overlay blacks out my
+  frames at t≈1.1–1.4s" and it is invariant to any code you change (an entire debugging
+  session was once lost to chasing it as a viewmodel bug). It is NOT a game bug — real
+  players never see it; the SHOT harness warms ≥240 frames precisely to skip it.
 - Run shots **sequentially**, not in parallel — llvmpipe saturates all cores.
 - The HUD renders over the scene (the harness boots straight into Playing); ignore it.
 - Sim time during a capture is short (frame `dt` is clamped), but wandering NPCs still
@@ -76,9 +84,11 @@ All `FOREST_*` env hooks from CLAUDE.md work here; the load-bearing ones for vis
 | `FOREST_BIOME` / `FOREST_PANEL` / `FOREST_MENU` | biome view / UI panels / start screen |
 
 Useful anchors for framing (castle at world origin, 1 tile = 1 unit):
-- Hero default spawn: just outside the **north gate** at ~`(0, -15)`, facing the castle
-  (+Z). A good close-up: `FOREST_CAM="0.55,0.8,-13.85,0,0.45,-15"`. Mirror x (or use
-  `-0.55`) to see the shield side.
+- Hero default spawn: `player::spawn_point()` = **`(-26, 18)`**, facing the castle at the
+  origin (bearing ≈ `(0.82, 0, -0.57)` — mostly +X, a bit −Z). `FOREST_HERO` moves the hero
+  but KEEPS this boot bearing, so anything staged "in front" (an orkline for an FP shot)
+  must sit along `hero + d·(0.82, -0.57)` — NOT simply at `z+d`. (An earlier version of this
+  note claimed spawn ≈ `(0,-15)`; that's stale — staging placed off it lands out of frame.)
 - Walls run at `x=±17`, `z=±12` with gates at the axis midpoints (`castle::gate_centers`).
 - Hero is small (~0.9u tall after `HERO_SCALE`); a camera ~1.5–2u away at y≈0.8–1.0
   looking at y≈0.45 fills the frame. Orks are ~1.3–1.6u; back off to 4–9u for a group.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,9 +345,24 @@ reads it to drop a beaten warden). `Lives.heirs` mirrors `town.population`, so i
   idles on the start screen and the probes read the menu camera). The eye sits at
   `FP_EYE_H`/`FP_FWD_OFF` in `player/camera.rs`; and the main-camera **near-plane**
   (`scene.rs::setup_camera`, `near: 0.04`) is lowered so the close-held weapon doesn't slice the
-  near-plane (that slicing was the walk-time "flicker"). NB: FP melee inherently puts the enemy in
-  your face — no view-model trick fixes that; third-person is the design's combat view.
+  near-plane (that slicing was the walk-time "flicker"). July 2026 FP-combat polish knobs:
+  per-variant swing shaping is `anim::fp_swing` (wind/punch endpoints + `sw_roll` edge-roll about
+  the blade axis + `arc` mid-strike crescent). **The FP eye sits ~0.2u from the shoulder pivot, so
+  any real shoulder-Y sweep parks the forearm ON the lens (whole frames black out) — cross-frame
+  travel must live in the WRIST**, with `sw_x` compensating the tilted hand frame (a big wrist yaw
+  alone reads as a rising poke). Swings also drive a small per-variant **camera swing-sway**
+  (`anim::fp_cam_sway` → `FirstPerson::sway`, applied post-`look_at` in `player_camera`; a lean,
+  never a shake) and an FP **close-quarters FOV widen** (`camera::FP_CLOSE_FOV_DEG` eased off the
+  ringed foe's distance) buys back a melee-range ork's silhouette. Enemy **HP bars clamp into a
+  view cone above the eye** (`combat_fx::HP_BAR_CONE_SLOPE` — the bar slides down toward the chest
+  and pulls toward a close camera, shrinking) so a towering foe's bar stays on screen in FP melee.
+  NB: FP melee inherently puts the enemy in your face — the widen softens it, but no view-model
+  trick removes it; third-person is the design's combat view.
 - **Capture-harness flakes — confirm the `Screenshot saved` log line, and retry before debugging.**
+  For `FOREST_CLIP`, set `FOREST_CLIP_WARMUP=70`+ — the default 30 records the tail of the boot
+  **loading veil** (`loading.rs`, lifts ~1.4s of sim time): the first ~50 saved frames render
+  dimmed/black *behind an intact HUD* in every scene, which reads exactly like a full-frame
+  rendering bug and is invariant to any code change (a whole session was once lost chasing it).
   A `FOREST_SHOT` run can emit a junk frame that is NOT a code bug: a **black** frame (cold pipeline,
   see the bevy-0.19 note) or an **overview/god-cam** frame (the follow-cam hadn't engaged yet under
   `FOREST_FP`/`FOREST_TPS`). And if the run **crashed** (e.g. a wgpu validation error) no new PNG is

--- a/src/combat_fx.rs
+++ b/src/combat_fx.rs
@@ -52,6 +52,16 @@ const HP_BAR_Y_NPC: f32 = 1.2;
 /// Beyond this camera distance a bar is hidden — keeps far-off damaged enemies from floating
 /// bars across the sky (they read as detached when the body's behind trees / off-screen).
 const HP_BAR_MAX_DIST: f32 = 26.0;
+/// Max height a bar may float ABOVE THE CAMERA EYE, as a slope over horizontal distance (≈tan 20°).
+/// In first-person melee a `WORLD_BUMP`-scaled ork towers over the 1.32 eye, so its overhead bar
+/// (root + ~2.1) sits far outside the top of the frame — past this cone the bar slides DOWN onto
+/// the foe's chest/face line where it stays readable. Third person is untouched in practice: the
+/// orbit eye rides above head height, so the cone almost never binds.
+const HP_BAR_CONE_SLOPE: f32 = 0.36;
+/// Within this camera distance a *lowered* bar is pulled toward the lens (out of the body it now
+/// overlaps — depth-test would bury a chest-height quad inside the torso) and the whole bar is
+/// shrunk, so an at-arm's-length bar doesn't stripe across half the frame.
+const HP_BAR_NEAR: f32 = 4.0;
 
 // ── Ported float colours ────────────────────────────────────────────────────
 /// Red `-N` when the hero is struck (`#ff5a4a`).
@@ -98,11 +108,23 @@ fn spawn_floats(
     mut commands: Commands,
     time: Res<Time>,
     fonts: Res<UiFonts>,
+    cam_q: Query<&GlobalTransform, With<Camera3d>>,
     mut q: ResMut<FloatQueue>,
 ) {
     let now = time.elapsed_secs();
+    let cam_pos = cam_q.single().map(|gt| gt.translation()).ok();
     for r in q.0.drain(..) {
         let len = r.text.chars().count();
+        // Same close-range clamp as the HP bars: hit sites anchor numbers ~2.2u above the
+        // target, which at FP melee range is far above the frame's top edge — every damage
+        // number on a point-blank foe spawned invisible. Cap the anchor to a view cone above
+        // the camera eye (minus a little rise headroom) so close-quarters numbers pop where
+        // the player is actually looking.
+        let mut world = r.world;
+        if let Some(cp) = cam_pos {
+            let flat = Vec2::new(world.x - cp.x, world.z - cp.z).length();
+            world.y = world.y.min(cp.y + flat * HP_BAR_CONE_SLOPE - FLOAT_RISE * 0.4);
+        }
         commands.spawn((
             Text::new(r.text),
             // Rounded to a whole-pixel bucket (drive_floats animates within the same integer set):
@@ -119,7 +141,7 @@ fn spawn_floats(
             },
             UiTransform::IDENTITY,
             GlobalZIndex(20),
-            FloatText { anchor: r.world, born: now, color: r.color, scale: r.scale, len },
+            FloatText { anchor: world, born: now, color: r.color, scale: r.scale, len },
         ));
     }
 }
@@ -434,15 +456,37 @@ fn drive_hp_bars(
             *vis = Visibility::Hidden;
             continue;
         }
-        let head = ork_gt.translation() + Vec3::Y * bar.y;
+        let root = ork_gt.translation();
+        let mut head = root + Vec3::Y * bar.y;
+        // Close-range readability (the FP melee case): as the camera closes inside HP_BAR_NEAR
+        // the bar SLIDES DOWN from overhead to the foe's CHEST — at arm's length even a
+        // cone-clamped overhead bar sits right at the frame's top edge (a WORLD_BUMP ork's bar
+        // floats ~0.8u above the 1.32 FP eye), while the chest line reads dead-centre. A view
+        // cone above the eye catches the mid-range in between, and any lowered bar is pulled
+        // toward the camera so the depth test doesn't bury it inside the torso.
+        let flat = Vec2::new(head.x - cam_pos.x, head.z - cam_pos.z).length();
+        let closeness = ((HP_BAR_NEAR - flat) / HP_BAR_NEAR).clamp(0.0, 1.0);
+        let chest = root.y + bar.y * 0.55;
+        let mut want_y = head.y - (head.y - chest) * closeness;
+        let max_y = cam_pos.y + flat * HP_BAR_CONE_SLOPE;
+        want_y = want_y.min(max_y).max(chest.min(head.y));
+        if want_y < head.y {
+            head.y = want_y;
+            let pull = closeness * 0.8;
+            head += (cam_pos - head).normalize_or_zero() * pull;
+        }
         // Cull distant bars so a damaged enemy across the map doesn't float a bar in the sky.
-        if head.distance(cam_pos) > HP_BAR_MAX_DIST {
+        let dist = head.distance(cam_pos);
+        if dist > HP_BAR_MAX_DIST {
             *vis = Visibility::Hidden;
             continue;
         }
         *vis = Visibility::Visible;
         tf.translation = head;
         tf.look_at(cam_pos, Vec3::Y); // billboard (materials are double-sided)
+        // Close-up shrink: a 0.6u quad at arm's length stripes across the frame; ease it down as
+        // the camera closes (full size at/inside third-person follow distances).
+        tf.scale = Vec3::splat((dist / HP_BAR_NEAR).clamp(0.55, 1.0));
         let hurting = hurt.is_some_and(|h| now < h.until);
         for &c in children {
             if let Ok((mut fg_tf, mut fg_mat)) = fgs.get_mut(c) {

--- a/src/player/anim.rs
+++ b/src/player/anim.rs
@@ -962,53 +962,111 @@ struct FpSwing {
     sw_x: (f32, f32),
     /// Wrist Y — blade cocks out / whips across the frame.
     sw_y: (f32, f32),
+    /// EDGE ROLL about the BLADE'S OWN AXIS (mesh +Y), applied as a right-multiplied local
+    /// `Quat::from_rotation_y` — NOT a wrist-euler Z term, which in XYZ order deflects the blade
+    /// sideways off its line (the first cut of this feature pointed the thrust's blade vertical).
+    /// Pronate on the cock / turn the edge over through the cut; the thrust corkscrews.
+    sw_roll: (f32, f32),
+    /// Mid-STRIKE perpendicular bulge on the shoulder `(X, Y)`, scaled by `sin(π·strike-p)` — 0 at
+    /// both strike endpoints, peaking mid-cut. Bows the blade's path into a crescent instead of a
+    /// straight endpoint-to-endpoint lerp (the old "toporny"/stick-swing read).
+    arc: (f32, f32),
 }
 
 fn fp_swing(variant: u8) -> FpSwing {
     match variant {
         // attack2 — horizontal slash: a falling cross-cut — the blade cocks out to the sword side
-        // and sweeps across the MID frame as the arm drops and carries the hilt over. (Probe note:
-        // wrist-Y toward 0 tips the blade skyward through the tilted FP hand frame — the first cut
-        // of this clip pushed Y positive and read as a rising poke, so the lateral travel now
-        // lives in the SHOULDER and the wrist keeps the blade on the level-to-down band.)
+        // and sweeps across the MID frame. (Probe history: an all-shoulder sweep marched the
+        // forearm through the lens; an all-wrist one read as a rising poke — the travel is now
+        // SPLIT between them, with sw_x keeping the blade on the level-to-down band.)
         1 => FpSwing {
-            sh_x: (-0.25, -0.05),
-            sh_y: (-0.50, 0.90),
-            el: (-0.25, 0.55),
-            sw_x: (-0.12, 0.30),
-            sw_y: (0.10, 0.35),
+            // Cross-travel lives almost entirely in the WRIST (sw_y): the FP eye sits ~0.2u from
+            // the shoulder, so ANY real shoulder-Y sweep (0.9 originally, still at 0.6) parks the
+            // forearm ON the lens — whole frames blacked out mid-slash. The hilt now holds
+            // low-right; the blade whips across, sw_x riding it down onto the level band (the big
+            // wrist yaw alone reads as a rising poke through the tilted hand frame).
+            // BOTH sh_x endpoints DROP (positive): the ready base holds the fist high near the
+            // face (-0.70 raise / -1.05 fold), so any cross-cut through it passes the hand
+            // straight THROUGH the lens — the mid-slash full-frame blackout every earlier cut
+            // of this table reproduced. The whole slash now runs at WAIST height (wind included;
+            // the classic FP belly-cut), the blade doing the cross-travel in the WRIST (sw_y)
+            // while sh_y.0 cocks the wind outward-right.
+            sh_x: (0.35, 0.55),
+            sh_y: (0.20, 0.25),
+            el: (0.10, 0.55),
+            sw_x: (-0.10, 0.45),
+            sw_y: (0.15, 1.15),
+            sw_roll: (-0.35, 0.60), // edge cocked over on the wind, turned through the cross-cut
+            arc: (0.0, 0.0),
         },
         // attack3 — forward thrust: the wind folds the elbow deep (hilt drawn to the ribs, blade
         // kept LEVEL at the target), the strike EXTENDS the whole arm at the frame centre — the
         // punch reads in the reach, so the wrist barely moves (X≈2.56 is the probe-solved
         // blade-level-forward angle for the raised FP arm; sw_x holds it there through the punch).
         2 => FpSwing {
-            sh_x: (-0.10, 0.05),
-            sh_y: (-0.10, 0.30),
+            // sh_x.1 NEGATIVE: the punch RAISES the extending arm to chest line, so the blade
+            // reaches across the lower-centre frame instead of vanishing under the bottom edge
+            // as the unfolding elbow drops the hand. sw_x.0 pitches the cocked blade forward,
+            // countering the deep elbow fold that otherwise stands it vertical at the frame edge.
+            sh_x: (-0.10, -0.10),
+            sh_y: (-0.10, 0.25),
             el: (-0.60, 1.05),
-            sw_x: (-0.12, -0.10),
+            sw_x: (0.55, 0.0),
             sw_y: (0.15, 0.0),
+            sw_roll: (0.10, 0.90), // corkscrew: a quarter-turn about the blade axis through the punch
+            arc: (0.0, 0.0),       // a thrust IS the straight line — no crescent
         },
         // Heavy Strike — the overhead chop writ large: hauled higher, smashed hard down the middle
         // (this shape is also what the held charge coils into). sw_x.1 stops at +0.55: the probe
         // showed +1.05 swung the blade PAST straight-down into pointing back at the camera.
         v if v == super::combat::HEAVY_VARIANT => FpSwing {
-            sh_x: (-0.60, 0.45),
-            sh_y: (-0.05, 0.10),
+            // Drive capped (sh_x/sw_x .1) so the hilt lands in the LOWER FRAME, not past its
+            // bottom edge — a smash that exits the screen entirely reads as nothing at all.
+            sh_x: (-0.50, 0.32),
+            // sh_y.1 pulls the extended smash toward frame CENTRE (safe from the lens here —
+            // the arm is near-straight by then), so the blow lands down the middle, not along
+            // the right edge.
+            sh_y: (-0.05, 0.28),
             el: (-0.30, 0.90),
-            sw_x: (-0.95, 0.55),
+            sw_x: (-0.95, 0.45),
             sw_y: (0.05, 0.20),
+            sw_roll: (-0.20, 0.45),
+            arc: (0.0, 0.40), // the smash bows outward mid-drop — an axe-arc, not an elevator
         },
         // attack1 — overhead chop: blade cocked high over the shoulder, driven DOWN the frame —
         // the Heavy's arc at a lighter scale (the first cut played the whole chop below the
         // bottom frame edge; raising the shoulder and capping sw_x keeps the sweep IN frame).
         _ => FpSwing {
-            sh_x: (-0.55, 0.35),
-            sh_y: (-0.05, 0.10),
+            sh_x: (-0.50, 0.30),
+            sh_y: (-0.05, 0.22), // slight centre-pull at extension (see the Heavy note)
             el: (-0.32, 0.80),
             sw_x: (-0.85, 0.55),
             sw_y: (0.10, 0.25),
+            sw_roll: (-0.12, 0.35),
+            arc: (0.0, 0.30), // the downcut bows toward the sword side mid-strike
         },
+    }
+}
+
+/// Per-variant FP **camera swing-sway** (screen-space radians: x = pitch(+up), y = yaw(+left),
+/// z = roll). `.0` leans through the wind-up — a small anticipation pull OPPOSITE the cut — and
+/// `.1` rides the strike WITH the blade. Written onto [`super::FirstPerson::sway`] scaled by the
+/// same wind/punch envelopes as the arms, applied by `player::camera` after `look_at`, so the view
+/// itself commits to every cut (the missing half of the old "toporne" stick-swings). Deliberately
+/// small (≤~3°) and one smooth arc per swing — a lean, never a shake (motion-sickness guard); aim
+/// is unaffected (`hero.facing` comes from the un-swayed yaw).
+fn fp_cam_sway(variant: u8) -> (Vec3, Vec3) {
+    match variant {
+        // horizontal slash: gather right, then sweep left across the frame with a matching roll.
+        1 => (Vec3::new(0.008, -0.020, 0.014), Vec3::new(-0.006, 0.032, -0.026)),
+        // thrust: a breath back, then a forward nod into the punch.
+        2 => (Vec3::new(-0.006, -0.006, 0.006), Vec3::new(0.012, 0.006, -0.008)),
+        // Heavy: the chop writ large — rise with the overhead haul, drop hard with the smash.
+        v if v == super::combat::HEAVY_VARIANT => {
+            (Vec3::new(0.028, 0.0, -0.010), Vec3::new(-0.050, 0.006, 0.016))
+        }
+        // overhead chop: rise with the cock, dip with the blow.
+        _ => (Vec3::new(0.016, -0.006, -0.008), Vec3::new(-0.034, 0.008, 0.012)),
     }
 }
 
@@ -1016,7 +1074,8 @@ pub fn hero_anim(
     time: Res<Time>,
     player: Res<super::PlayerRes>,
     dir: Res<crate::cinematic::DirectorState>,
-    fp: Res<super::FirstPerson>,
+    // `ResMut`: hero_anim WRITES `fp.sway` (the FP camera swing-sway target) each frame.
+    mut fp: ResMut<super::FirstPerson>,
     hero_q: Query<(&Hero, &HeroHealth)>,
     mut parts: Query<(&HeroPart, &mut Transform)>,
     // Edge-detect touchdown (was airborne, now grounded) to stamp a short landing-squash window.
@@ -1042,6 +1101,7 @@ pub fn hero_anim(
 
     // Slain: let the limbs go slack while the body keels over (root rotation owned by health.rs).
     if !player.0.is_alive() {
+        fp.sway = Vec3::ZERO; // no stale FP swing-lean on the death camera
         for (part, mut tf) in &mut parts {
             tf.rotation = match part.joint {
                 Joint::Hips => {
@@ -1106,11 +1166,26 @@ pub fn hero_anim(
             None => (0.0, 0.0),
         }
     };
+    // Mid-strike crescent envelope: 0 at both strike endpoints, peaking mid-cut — feeds the
+    // per-variant `arc` bulge so the blade's path bows instead of lerping straight.
+    let fp_atk_arc = match &attack {
+        Some((Phase::Strike, p)) => (*p * PI).sin(),
+        _ => 0.0,
+    };
     // A held charge coils into the Heavy's shape even before the release stamps the variant.
-    let fp_sw = if hero.charge_t > CHARGE_GRACE && attack.is_none() {
-        fp_swing(super::combat::HEAVY_VARIANT)
+    let fp_variant = if hero.charge_t > CHARGE_GRACE && attack.is_none() {
+        super::combat::HEAVY_VARIANT
     } else {
-        fp_swing(hero.attack_variant)
+        hero.attack_variant
+    };
+    let fp_sw = fp_swing(fp_variant);
+    // FP camera swing-sway target — screen-space (NOT mirrored, unlike the rig targets below),
+    // ridden by `player::camera`. Zeroed outside FP so re-entering never inherits a stale lean.
+    fp.sway = if fp_amt > 0.0 {
+        let (wind, strike) = fp_cam_sway(fp_variant);
+        (wind * fp_atk_back + strike * fp_atk_fwd) * fp_amt
+    } else {
+        Vec3::ZERO
     };
 
     let (fp_breath, fp_bob_v, fp_bob_l, fp_sway) = if fp_amt > 0.0 {
@@ -1225,16 +1300,25 @@ pub fn hero_anim(
                     // An attack layers a compact wind→punch envelope on top (the blade's sweep
                     // itself plays on the Sword joint below). Breath/bob/sway keep it alive.
                     let (back, fwd) = (fp_atk_back, fp_atk_fwd);
+                    // While the shield is braced the sword arm DROPS back toward the low carry —
+                    // at full ready its forearm hangs right at the lens edge (elbow z≈-0.12 in
+                    // camera space) and paints a full-height dark band down the right of the
+                    // blocking frame. The blade is tucked away during a block anyway.
+                    let fp_ready = fp_ready * (1.0 - 0.65 * block_amt);
                     let target = if elbow {
                         rx(lerp(-0.35, -1.05, fp_ready) + fp_sw.el.0 * back + fp_sw.el.1 * fwd + fp_bob_v * 0.6)
                     } else {
+                        // `arc` bows the strike's path mid-cut (crescent), on top of the
+                        // endpoint envelope — see the `FpSwing::arc` note.
                         e3(
                             lerp(0.10, -0.70, fp_ready) + fp_sw.sh_x.0 * back + fp_sw.sh_x.1 * fwd
+                                + fp_sw.arc.0 * fp_atk_arc
                                 + fp_breath
                                 + fp_bob_v,
                             -(fp_sway + fp_bob_l) * lerp(0.5, 1.0, fp_ready) - 0.35 * fp_ready
                                 + fp_sw.sh_y.0 * back
-                                + fp_sw.sh_y.1 * fwd,
+                                + fp_sw.sh_y.1 * fwd
+                                + fp_sw.arc.1 * fp_atk_arc,
                             lerp(0.12, 0.10, fp_ready),
                         )
                     };
@@ -1259,11 +1343,20 @@ pub fn hero_anim(
                     // relaxed here (blade angled easy down-forward out of the frame's way, riding
                     // the walk bob), drawn up into `combat` as `fp_ready` rises.
                     let carry = e3(3.02 + fp_bob_v * 0.4, -0.30 - fp_sway * 0.5, -0.44);
+                    // `sw_roll` turns the EDGE about the blade's own axis through the cut
+                    // (pronated on the cock, rolled over through the strike; the thrust
+                    // corkscrews). Right-multiplied local +Y spin — the blade runs along mesh
+                    // +Y, so this rolls it in place without deflecting its line.
+                    let edge_roll = fp_sw.sw_roll.0 * fp_atk_back + fp_sw.sw_roll.1 * fp_atk_fwd;
+                    // Ready base: yaw −0.20 (not the old −0.60) angles the blade as a DIAGONAL
+                    // across the lower-right — the −0.60 carry pointed it almost dead along the
+                    // view axis, which on screen read as a disembodied floating rod ("jakies
+                    // nienaturalne"): a sliver of near-axial blade with the hand below frame.
                     let combat = e3(
-                        2.68 + fp_sw.sw_x.0 * fp_atk_back + fp_sw.sw_x.1 * fp_atk_fwd + fp_bob_v * 0.5,
-                        -0.60 - fp_sway + fp_sw.sw_y.0 * fp_atk_back + fp_sw.sw_y.1 * fp_atk_fwd,
+                        2.70 + fp_sw.sw_x.0 * fp_atk_back + fp_sw.sw_x.1 * fp_atk_fwd + fp_bob_v * 0.5,
+                        -0.20 - fp_sway + fp_sw.sw_y.0 * fp_atk_back + fp_sw.sw_y.1 * fp_atk_fwd,
                         -0.44,
-                    );
+                    ) * Quat::from_rotation_y(edge_roll);
                     let ready_w = if attack.is_some() { 1.0 } else { fp_ready };
                     let target = carry.slerp(combat, ready_w).slerp(e3(-2.42, -0.60, -0.33), block_amt);
                     rot = rot.slerp(target, fp_amt);
@@ -1294,13 +1387,35 @@ pub fn hero_anim(
                 }
             }
             Joint::Shield => {
+                // FP: the shield joint is FULLY viewmodel-owned, like the sword wrist. The
+                // third-person attack clips write the shield EVERY swing (the slash lays the
+                // plate flat, the thrust braces it forward) — and in FP the shield hand hangs
+                // right at the lens, so those writes swept the dark plate ACROSS the camera:
+                // the "whole frame blacks out mid-swing" bug that survived every arm retune.
+                // Out of block, pin it to the edge-on rest carry instead.
+                if fp_amt > 0.0 && block_amt <= 0.001 {
+                    rot = rot.slerp(shield_rest_r(), fp_amt);
+                    tf.translation = tf.translation.lerp(SHIELD_REST_T, fp_amt);
+                }
                 // FP block: turn the plate's FACE to the camera, low in frame — the pose-space
                 // defend brace (rx(π/2)) shows its BACK through the FP hand frame. Solved from
-                // the FPDBG probes like the sword wrist. Out of block, no override — the rest
-                // carry keeps the shield edge-on along the forearm (a subtle corner sliver).
+                // the FPDBG probes like the sword wrist.
                 if fp_amt > 0.0 && block_amt > 0.001 {
+                    let k = fp_amt * block_amt;
                     // Z carries a π roll — the other solution branch held the heater point-UP.
-                    rot = rot.slerp(e3(-0.98, -0.02, -2.97), fp_amt * block_amt);
+                    // X tips the plate's face UP into the skylight (probe: face.y moves ≈ +1.1
+                    // per +rad of X here; -0.85 lands ≈0.4) so the brace catches light and reads
+                    // as a dimensional plate, not a flat dark wall. (A stronger -0.70 tilt +
+                    // higher mount was tried: the plate rode up into the frame centre and ate
+                    // half the view — this framing keeps it low with the rim/boss just in shot.)
+                    rot = rot.slerp(e3(-0.85, -0.02, -2.97), k);
+                    // Push the braced plate OUT of the lens. The defend pose's (0,0,0.1) mount
+                    // left the plate ~0.38u from the FP eye — it filled half the frame as one
+                    // featureless slab (the "odwrócona tarcza" read: too close to show its rim
+                    // or boss). Probe-solved hand-frame push: -Y runs along the raised forearm
+                    // AWAY from the camera, -Z drops it toward the lower frame edge — lands the
+                    // centre ≈(-0.27,-0.38,-0.6) in camera space: lower-left frame, plate in view.
+                    tf.translation = tf.translation.lerp(Vec3::new(0.0, -0.28, -0.18), k);
                 }
             }
             _ => {}

--- a/src/player/camera.rs
+++ b/src/player/camera.rs
@@ -68,6 +68,12 @@ const FP_FWD_OFF: f32 = 0.05;
 /// First-person look-pitch clamp (radians): how far you can crane up/down. Symmetric, unlike the
 /// third-person `MIN/MAX_PITCH` (which is camera *elevation*, always tilting the view downward).
 const FP_PITCH_LIMIT: f32 = 1.3;
+/// First-person close-quarters FOV widen: up to this many degrees as the ringed foe closes from
+/// [`FP_CLOSE_RANGE`] to point-blank. Enemies are taller than the 1.32 FP eye and stop at melee
+/// range, so without this a big foe is one face filling the lens. Eased slowly (~3/s) so it reads
+/// as breathing room, never a zoom pump; scaled by the FP blend so third person is untouched.
+const FP_CLOSE_FOV_DEG: f32 = 8.0;
+const FP_CLOSE_RANGE: f32 = 3.5;
 
 /// Build-mode camera pose — eye + look-at, framing the WHOLE settlement (the castle at the origin)
 /// centred above the bottom build palette. The look-target is pushed forward (z = 5, toward the
@@ -154,6 +160,15 @@ pub struct FirstPerson {
     pub active: bool,
     pub blend: f32,
     pub pitch: f32,
+    /// FP swing camera-sway (screen-space radians: x = pitch(+up), y = yaw(+left), z = roll),
+    /// written by `anim::hero_anim` from the attack envelopes and applied here on top of the
+    /// settled FP pose — one smooth lean per cut (anticipation pulls opposite, the strike rides
+    /// the blade), NOT a shake. Zeroed outside FP.
+    pub sway: Vec3,
+    /// Smoothed FP close-quarters FOV widen (degrees). A `WORLD_BUMP`-scaled ork at melee range
+    /// fills the whole first-person frame (face-in-lens); this eases a modest wide-angle in as
+    /// the ringed foe closes, buying back its silhouette + HP bar. See `FP_CLOSE_FOV_DEG`.
+    pub close_fov: f32,
 }
 
 /// Backtick toggles Play ↔ FreeRoam. Leaving Play frees the cursor and syncs the fly-cam's
@@ -411,6 +426,14 @@ pub fn player_camera(
     cam_tf.translation = eye;
     cam_tf.look_at(look, Vec3::Y);
 
+    // FP swing sway: the small smooth camera lean `anim::hero_anim` derives from the attack
+    // envelopes (anticipation ↔ strike). Composed AFTER look_at so it tilts the settled view;
+    // purely cosmetic — `hero.facing`/aim still come from the un-swayed look_yaw above.
+    if fpb > 0.0 && fp.sway != Vec3::ZERO {
+        let s = fp.sway * fpb;
+        cam_tf.rotation *= Quat::from_euler(EulerRot::YXZ, s.y, s.x, s.z);
+    }
+
     // Trauma-based screen shake + FOV punch layered on the settled pose (fed by combat_fx on hits).
     // Damped by ~75% in first person: at eye-scale the raw high-frequency jitter would fill the
     // whole view (a motion-sickness + photosensitive-oscillation hazard) — damped, not removed, so
@@ -433,6 +456,18 @@ pub fn player_camera(
             cam_tf.translation += jitter * s;
         }
     }
+    // FP close-quarters widen: ramp by how close the ringed foe stands (soft_pos already tracks
+    // the engaged hostile). Slow ease both ways so a foe crossing the range can't pump the FOV.
+    let want_close = if fp.active {
+        hero.soft_pos.map_or(0.0, |tp| {
+            ((FP_CLOSE_RANGE - tp.distance(hero.pos)) / FP_CLOSE_RANGE).clamp(0.0, 1.0)
+        })
+    } else {
+        0.0
+    };
+    fp.close_fov +=
+        (want_close * FP_CLOSE_FOV_DEG - fp.close_fov) * (1.0 - (-time.delta_secs() * 3.0).exp());
+
     // FOV = rest (captured once) + decaying combat punch (damped in FP) + a gentle sprint widen for a
     // sense of speed.
     if let Projection::Perspective(p) = &mut *cam_proj {
@@ -441,6 +476,6 @@ pub fn player_camera(
         let speed_fov = hero.run_amt.clamp(0.0, 1.0) * SPRINT_FOV_DEG;
         // A slight wide-angle as the combat dolly pulls back, so a mob fight reads the arena.
         let combat_fov = orbit.combat * COMBAT_FOV_PER_UNIT;
-        p.fov = base + (kick + speed_fov + combat_fov).to_radians();
+        p.fov = base + (kick + speed_fov + combat_fov + fp.close_fov * fpb).to_radians();
     }
 }

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -1312,6 +1312,7 @@ pub(crate) fn spawn_splat(commands: &mut Commands, fx: &CombatFx, mats: &mut Ass
 pub fn hero_blade_trail(
     time: Res<Time>,
     fx: Option<Res<CombatFx>>,
+    fp: Res<super::FirstPerson>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut commands: Commands,
     mut last_tip: Local<Option<Vec3>>,
@@ -1319,6 +1320,14 @@ pub fn hero_blade_trail(
     weapon_q: Query<&GlobalTransform, With<super::HeroWeapon>>,
 ) {
     let Some(fx) = fx else { return };
+    // First person: NO ribbon. The tip path sweeps right across the lens (the whole viewmodel
+    // lives within ~0.5u of the eye), so each camera-rolled segment quad lands ON the camera as
+    // a frame-filling pale wash — the mysterious "whole frame goes tan/black mid-swing" frames
+    // that survived every arm retune. The FP swing reads through the arm + camera sway instead.
+    if fp.blend > 0.3 {
+        *last_tip = None;
+        return;
+    }
     let Ok(hero) = hero_q.single() else { return };
     let phase = if hero.attacking { hero.attack_t / hero.attack_dur } else { -1.0 };
     if !(0.25..0.55).contains(&phase) {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -700,6 +700,7 @@ fn env_cam() -> Option<Transform> {
 fn drive_dof_focus(
     mode: Res<crate::player::PlayMode>,
     build_mode: Res<crate::town::BuildMode>,
+    fp: Res<crate::player::FirstPerson>,
     mut cam_q: Query<(&GlobalTransform, &mut crate::dof::Dof), With<Camera3d>>,
     hero_q: Query<&crate::player::Hero>,
     mut saved_radius: Local<Option<f32>>,
@@ -731,10 +732,23 @@ fn drive_dof_focus(
         return;
     }
     let target = if *mode == crate::player::PlayMode::Play {
-        hero_q
+        let hero_d = hero_q
             .single()
             .map(|h| cam_tf.translation().distance(Vec3::new(h.pos.x, h.y + 1.0, h.pos.y)))
-            .unwrap_or(28.0)
+            .unwrap_or(28.0);
+        // First person: the camera IS (in) the hero, so the camera→hero distance is ~0.33 —
+        // a focal plane parked ON the lens defocuses the whole world, and any CoC excuse
+        // (most visibly mid-swing) washed the entire FP frame into one flat smear of the
+        // dominant colour. Focus the ringed foe instead (never closer than 2, which would
+        // re-park the plane on the viewmodel), or a combat mid-ground when nothing's ringed;
+        // `max` with the dolly distance keeps the third⇄first transition smooth.
+        let fp_focus = hero_q
+            .single()
+            .ok()
+            .and_then(|h| h.soft_pos.map(|tp| tp.distance(h.pos)))
+            .map(|d| d.clamp(2.0, 12.0))
+            .unwrap_or(6.0);
+        hero_d.max(fp.blend.clamp(0.0, 1.0) * fp_focus)
     } else {
         // Free-cam / clips: focus the hero when he's the subject (close to the camera, e.g. the
         // chase-cam scenes), so he stays sharp; otherwise a fixed mid-ground plane.


### PR DESCRIPTION
## Summary

Comprehensive first-person melee combat polish addressing the core FP melee problem: the enemy fills the lens at close range, and the viewmodel sweeps across the camera. This adds per-variant swing shaping with edge-roll and arc, a small camera swing-sway that leans with the blade, a close-quarters FOV widen to recover the foe's silhouette, and HP bar repositioning to keep enemy health readable in FP melee.

## Key Changes

**Swing Shaping & Animation (`anim.rs`)**
- Added `sw_roll` (edge-roll about the blade's own axis) and `arc` (mid-strike crescent bulge) to `FpSwing` struct
- Rewrote all four attack variants (horizontal slash, thrust, heavy, overhead chop) with detailed probe-history comments explaining the cross-frame travel split between shoulder and wrist, and the readability fixes for each
- New `fp_cam_sway()` function derives per-variant camera swing-sway (screen-space radians: pitch/yaw/roll) — a small lean that anticipates opposite the cut, then rides the strike with the blade
- `hero_anim` now writes `FirstPerson::sway` each frame from attack envelopes; zeroed outside FP and on death
- Shield joint now pins to rest carry in FP outside block (was sweeping across the lens mid-swing), and block pose adjusted with X tilt for light catch and translation push to keep the plate in frame

**Camera & FOV (`camera.rs`)**
- Added `FirstPerson::sway` (swing-sway target) and `close_fov` (smoothed close-quarters widen)
- `player_camera` applies sway post-`look_at` as a pure cosmetic lean (aim unaffected)
- New close-quarters FOV widen: eases up to `FP_CLOSE_FOV_DEG` (8°) as the ringed foe closes from `FP_CLOSE_RANGE` (3.5u) to point-blank, recovering the melee-range ork's silhouette
- DOF focus in FP now targets the ringed foe (clamped 2–12u) instead of the camera-to-hero distance (~0.33u), which was parking the focal plane on the lens

**HP Bar & Damage Numbers (`combat_fx.rs`)**
- HP bars now clamp into a view cone above the FP eye (`HP_BAR_CONE_SLOPE` ≈ tan 20°) — the bar slides down from overhead toward the foe's chest as the camera closes
- Close-range bars pull toward the camera (depth-test no longer buries them in the torso) and shrink (a 0.6u quad at arm's length no longer stripes the frame)
- Damage numbers clamped to the same cone so close-quarters hits pop where the player is looking, not invisible above the frame

**Blade Trail (`combat.rs`)**
- Disabled in FP (blend > 0.3) — the tip path sweeps across the lens, causing frame-filling pale washes mid-swing; the FP swing reads through the arm + camera sway instead

**Documentation (`CLAUDE.md`)**
- Added detailed FP melee polish notes: swing shaping, wrist-vs-shoulder split, camera sway, close-quarters FOV, HP bar cone, and the design rationale (FP melee inherently puts the enemy in your face; these knobs soften it)
- Clarified hero spawn point (`(-26, 18)` with bearing toward origin) and staging coordinates for FP shots
- Added `FOREST_CLIP_WARMUP` warning: the default 30 frames records the boot loading veil (dimmed/black frames behind the HUD), which is NOT a code bug but spectacularly misleading when debugging visuals

## Implementation Details

- **Wrist-vs-shoulder split:** The FP eye sits ~0.2u from the shoulder pivot, so any real shoulder-Y sweep parks the forearm on the lens (whole frames black out). Cross-frame travel now lives in the wrist (`sw_y`),

https://claude.ai/code/session_016Nd3QspAa1hzHEXzGQyC39