### PR TITLE
In-process Campaign ⇄ Skirmish mode switch (no window close)

### DIFF
--- a/src/biome.rs
+++ b/src/biome.rs
@@ -382,7 +382,6 @@ impl Plugin for BiomePlugin {
             .init_resource::<BuildJob>()
             .init_resource::<BuildProgress>()
             .init_resource::<crate::worldmap::ActiveMap>()
-            .add_systems(Startup, init_active_map_from_env)
             .add_systems(
                 Update,
                 (
@@ -405,15 +404,6 @@ fn build_active(pending: Res<PendingBuild>, job: Res<BuildJob>) -> bool {
 /// Atmosphere tuple: (sky, fog_density, sun_color, sun_illuminance, ambient_color,
 /// ambient_brightness, sun_pos).
 type Atmo = (u32, f32, u32, f32, u32, f32, Vec3);
-
-/// Debug boot hook: `FOREST_MAP=2` starts the run on the Volcanic Ashlands map (the start-screen
-/// toggle is the normal path; this is for the screenshot harness + quick testing).
-fn init_active_map_from_env(mut active: ResMut<crate::worldmap::ActiveMap>) {
-    if std::env::var("FOREST_MAP").ok().as_deref() == Some("2") {
-        active.0 = crate::worldmap::MapId::Ashlands;
-        info!("FOREST_MAP=2 → booting Volcanic Ashlands");
-    }
-}
 
 /// The world-build driver. When [`PendingBuild`] is raised it arms a [`BuildJob`], waits
 /// [`BUILD_WARMUP`] so the veil presents, wipes the prior world ONCE, then runs one

--- a/src/compass.rs
+++ b/src/compass.rs
@@ -91,8 +91,10 @@ struct CompassPip {
 pub struct CompassPlugin;
 impl Plugin for CompassPlugin {
     fn build(&self, app: &mut App) {
-        // Campaign-only: the hero compass strip has no place in the RTS iso view.
-        app.add_systems(Startup, setup_compass.run_if(crate::rts::in_campaign))
+        // Ungated spawn: the compass strip is built in EVERY boot (the mode can flip mid-process)
+        // and tagged `CampaignOnly`, so `apply_mode_visibility` hides it in the RTS iso view. The
+        // per-frame update systems stay `in_campaign`-gated.
+        app.add_systems(Startup, setup_compass)
             .add_systems(Update, (update_compass, update_blips).run_if(crate::rts::in_campaign));
     }
 }
@@ -140,6 +142,7 @@ fn setup_compass(mut commands: Commands, fonts: Res<UiFonts>, assets: Res<AssetS
                 },
                 GlobalZIndex(95), // above the rest of the HUD — the compass owns the very top
                 CompassRoot,
+                crate::game_state::CampaignOnly,
             ))
             .with_children(|s| {
                 // Baseline.

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -106,6 +106,13 @@ pub struct ConfirmWipe(pub Option<bool>);
 #[derive(Resource, Default)]
 pub struct RunInProgress(pub bool);
 
+/// Marker on campaign-only presentation — the hero rig, campaign HUD roots, compass, quest
+/// tracker, hint root, sky clouds… Tag the ROOT entity (visibility cascades to children).
+/// [`apply_mode_visibility`] hides everything tagged while the live mode is Skirmish and shows it
+/// again in Campaign, so an in-process mode flip never leaves campaign dressing over the arena.
+#[derive(Component)]
+pub struct CampaignOnly;
+
 pub struct GameStatePlugin;
 
 impl Plugin for GameStatePlugin {
@@ -120,6 +127,8 @@ impl Plugin for GameStatePlugin {
             .init_resource::<RunInProgress>()
             // Drive a pending in-process fresh run to completion (ungated — works over every screen).
             .add_systems(Update, drive_fresh_run)
+            // Hide/show campaign vs RTS presentation whenever the live GameMode flips (ungated).
+            .add_systems(Update, apply_mode_visibility)
             // Sweep the dead run's battlefield the frame an in-process Continue lands in Playing.
             .add_systems(Update, clear_battlefield.run_if(in_state(AppState::Playing)))
             // Overwrite-confirm dialog: reconcile its overlay + resolve its input. Ungated so it
@@ -177,25 +186,75 @@ fn skip_menu() -> bool {
         || std::env::var("FOREST_PERFTEST").is_ok()
 }
 
-/// Relaunch the game as a **fresh process**, entering Potyczka (`skirmish = true`) or the classic
-/// campaign (`false`). This is the ONLY way to switch [`crate::rts::GameMode`], which is decided
-/// once at boot from `FOREST_RTS` (`rts::mode_from_env`) and never changes mid-process — so the
-/// mode toggle spawns a new exe carrying (or explicitly dropping) the flag, then exits this one.
-///
-/// Note the asymmetry with the campaign New Game reset, which is *in-process* (`FreshRunPending` →
-/// `drive_fresh_run`, window kept): only the **mode** needs a fresh boot; a same-mode restart does
-/// not. On "Menu główne" we `env_remove` the flag so the child does NOT inherit this skirmish
-/// process's `FOREST_RTS` and lands back in the campaign. A failed spawn is a no-op (we stay put).
-fn relaunch_process(skirmish: bool) {
-    let Ok(exe) = std::env::current_exe() else { return };
-    let mut cmd = std::process::Command::new(exe);
-    if skirmish {
-        cmd.env("FOREST_RTS", "1");
-    } else {
-        cmd.env_remove("FOREST_RTS"); // don't let a skirmish parent leak the flag into the campaign child
+// ── In-process mode switch (Campaign ⇄ Potyczka, the window never closes) ────────────────
+
+/// The resource set every mode-switch button needs, bundled so the four button systems
+/// (start / pause / game-over click + game-over keys) don't each grow five parameters.
+/// Replaces the old `relaunch_process` (which spawned a fresh exe with/without `FOREST_RTS` and
+/// exited — the visible window-close on entering Potyczka).
+#[derive(bevy::ecs::system::SystemParam)]
+struct ModeSwitch<'w> {
+    mode: ResMut<'w, crate::rts::GameMode>,
+    active_map: ResMut<'w, crate::worldmap::ActiveMap>,
+    run_gen: ResMut<'w, crate::rts::RtsRunGen>,
+    run: ResMut<'w, RunInProgress>,
+    veil: ResMut<'w, crate::loading::Veil>,
+}
+
+impl ModeSwitch<'_> {
+    /// Enter (or replay) Potyczka **in-process**: flip the live mode, point the map at the arena,
+    /// bump the RTS run generation (sweeps the previous run's entities + resources, re-arms the
+    /// arena stagers), and request the standard in-process fresh run — `drive_fresh_run` rebuilds
+    /// the world to the arena under the loading veil and drops into `Playing`. The
+    /// `OnExit(StartScreen)` campaign resets it routes through are `in_campaign`-gated or
+    /// harmless resource wipes, so they don't fight the skirmish.
+    fn enter_skirmish(&mut self, fresh: &mut FreshRunPending, diff: crate::siege::Difficulty) {
+        *self.mode = crate::rts::GameMode::Skirmish;
+        self.active_map.0 = crate::worldmap::MapId::Arena;
+        self.run_gen.0 += 1;
+        fresh.0 = Some(diff);
     }
-    if cmd.spawn().is_ok() {
-        std::process::exit(0); // hand the window over to the fresh process
+
+    /// Leave Potyczka for the campaign **title screen**, in-process. Flips the mode back (which
+    /// re-gates every system and lets `rts_camera_restore` hand the camera back), points the map
+    /// home, bumps the generation (sweeps the arena's RTS entities), and hops to the start
+    /// screen. The stale arena *terrain* deliberately stays behind the title: `run.0 = false`
+    /// hides RESUME, so the only ways forward are **New Game** — whose `map_changed` check sees
+    /// Arena ≠ Home and forces the full in-process reset — or **Continue**, whose
+    /// `restore_active_map` rebuilds the saved map itself. Both rebuild before play; nothing can
+    /// re-enter the arena world. The veil covers the hop (world_ready is true, so it fades on
+    /// its own after the reveal hold).
+    fn to_campaign_menu(&mut self, next_app: &mut NextState<AppState>, now: f32) {
+        *self.mode = crate::rts::GameMode::Campaign;
+        self.active_map.0 = crate::worldmap::MapId::Home;
+        self.run_gen.0 += 1;
+        self.run.0 = false;
+        self.veil.raise(now);
+        next_app.set(AppState::StartScreen);
+    }
+}
+
+/// Reconcile what's on screen with the live [`crate::rts::GameMode`]: campaign-only presentation
+/// (hero, campaign HUD roots, compass, quest tracker, clouds — everything tagged
+/// [`CampaignOnly`]) hides in Skirmish; persistent RTS UI (HUD roots, minimap, pooled bars —
+/// tagged [`crate::rts::RtsUi`]) hides in Campaign. Visibility-only, never despawn: the spawn
+/// latches and bar pools stay valid, so flipping back is a pure re-show. Runs on the mode
+/// resource's change ticks (including its boot insertion, which hides campaign dressing on a
+/// `FOREST_RTS=1` boot the frame it starts).
+fn apply_mode_visibility(
+    mode: Res<crate::rts::GameMode>,
+    mut campaign: Query<&mut Visibility, (With<CampaignOnly>, Without<crate::rts::RtsUi>)>,
+    mut rts: Query<&mut Visibility, (With<crate::rts::RtsUi>, Without<CampaignOnly>)>,
+) {
+    if !mode.is_changed() {
+        return;
+    }
+    let skirmish = matches!(*mode, crate::rts::GameMode::Skirmish);
+    for mut v in &mut campaign {
+        *v = if skirmish { Visibility::Hidden } else { Visibility::Inherited };
+    }
+    for mut v in &mut rts {
+        *v = if skirmish { Visibility::Inherited } else { Visibility::Hidden };
     }
 }
 
@@ -500,7 +559,7 @@ fn gameover_input(
     keys: Res<ButtonInput<KeyCode>>,
     mut fresh: ResMut<FreshRunPending>,
     siege: Option<Res<crate::siege::Siege>>,
-    mode: Res<crate::rts::GameMode>,
+    mut sw: ModeSwitch,
     save: Res<crate::savegame::SaveExists>,
     mut confirm: ResMut<ConfirmWipe>,
     mut pending: ResMut<crate::savegame::PendingLoad>,
@@ -510,14 +569,15 @@ fn gameover_input(
     if confirm.0.is_some() {
         return; // dialog owns the keyboard
     }
-    // Skirmish: Enter replays the skirmish (a fresh process); nothing else applies (no save).
-    if matches!(*mode, crate::rts::GameMode::Skirmish) {
+    let cur_diff = current_difficulty(siege.as_deref());
+    // Skirmish: Enter replays the skirmish (an in-process fresh arena); nothing else applies
+    // (no save exists in Potyczka).
+    if matches!(*sw.mode, crate::rts::GameMode::Skirmish) {
         if keys.just_pressed(KeyCode::Enter) {
-            relaunch_process(true);
+            sw.enter_skirmish(&mut fresh, cur_diff);
         }
         return;
     }
-    let cur_diff = current_difficulty(siege.as_deref());
     let defeat = !matches!(siege.as_deref().map(|s| s.phase), Some(crate::siege::GamePhase::Victory));
     // C resumes last night in-process (defeat + save only); Enter starts a fresh run (confirming
     // first if it'd overwrite) — a full in-process reset, no relaunch.
@@ -553,8 +613,9 @@ struct StartResumeButton;
 /// The "Settings" button on the start screen — opens the graphics Settings page.
 #[derive(Component)]
 struct StartSettingsButton;
-/// The "Potyczka" button on the start screen — enters the RTS skirmish mode by relaunching the exe
-/// with `FOREST_RTS=1` (the mode can only be picked at boot; see [`relaunch_process`]).
+/// The "Potyczka" button on the start screen — enters the RTS skirmish mode **in-process**
+/// ([`ModeSwitch::enter_skirmish`]): the live [`crate::rts::GameMode`] flips and the world
+/// rebuilds to the arena under the loading veil; the window never closes.
 #[derive(Component)]
 struct SkirmishButton;
 /// The "Credits" button on the start screen — opens the credits overlay ([`mainmenu::CreditsOpen`]).
@@ -764,8 +825,8 @@ fn spawn_start_screen(
                 .with_children(|b| {
                     b.spawn(label(&fonts.extrabold, "NEW GAME", 19.0, INK));
                 });
-                // Potyczka — the RTS skirmish mode. A separate entry point (not a campaign run), so
-                // it relaunches the exe with FOREST_RTS=1 rather than starting a run in-process.
+                // Potyczka — the RTS skirmish mode. A separate entry point (not a campaign run):
+                // it flips the live GameMode and rebuilds the world to the arena in-process.
                 m.spawn((
                     Node {
                         padding: UiRect::axes(Val::Px(44.0), Val::Px(13.0)),
@@ -1076,9 +1137,9 @@ fn spawn_pause_screen(
                 BackgroundColor(BORDER_SOFT),
             ));
             if skirmish {
-                // Skirmish has no save/load and no in-process campaign reset — the mode is chosen at
-                // boot, so both a fresh skirmish and a return to the campaign menu are exe relaunches
-                // (handled in `pause_click`). Reuse the Restart / Main Menu markers for the routing.
+                // Skirmish has no save/load — a fresh skirmish and a return to the campaign menu
+                // are both in-process mode moves (handled in `pause_click` via `ModeSwitch`).
+                // Reuse the Restart / Main Menu markers for the routing.
                 pause_btn(c, &fonts.extrabold, "NEW SKIRMISH", PauseRestartBtn, (), 0.11);
                 pause_btn(c, &fonts.extrabold, "MAIN MENU", PauseMenuBtn, (), 0.14);
             } else {
@@ -1141,7 +1202,8 @@ fn pause_click(
     mut next_app: ResMut<NextState<AppState>>,
     mut fresh: ResMut<FreshRunPending>,
     siege: Option<Res<crate::siege::Siege>>,
-    mode: Res<crate::rts::GameMode>,
+    mut sw: ModeSwitch,
+    time: Res<Time>,
     mut gfx_menu: ResMut<crate::ui::graphics_menu::GraphicsMenuOpen>,
     save: Res<crate::savegame::SaveExists>,
     mut confirm: ResMut<ConfirmWipe>,
@@ -1152,14 +1214,14 @@ fn pause_click(
     if confirm.0.is_some() {
         return; // dialog owns input
     }
-    let skirmish = matches!(*mode, crate::rts::GameMode::Skirmish);
+    let skirmish = matches!(*sw.mode, crate::rts::GameMode::Skirmish);
     let cur_diff = current_difficulty(siege.as_deref());
     for (interaction, resume, load, restart_b, gfx_b, save_b, menu_b) in &q {
         if *interaction != Interaction::Pressed {
             continue;
         }
-        // Skirmish: Resume + Settings work in place; Restart / Main Menu are mode changes, so they
-        // relaunch (the campaign save/load/in-process-reset routing below never runs here).
+        // Skirmish: Resume + Settings work in place; Restart / Main Menu are in-process mode
+        // moves (the campaign save/load/in-process-reset routing below never runs here).
         if skirmish {
             if resume.is_some() {
                 next_app.set(AppState::Playing);
@@ -1168,10 +1230,10 @@ fn pause_click(
                 gfx_menu.0 = true;
             }
             if restart_b.is_some() {
-                relaunch_process(true); // NOWA POTYCZKA — fresh skirmish process
+                sw.enter_skirmish(&mut fresh, cur_diff); // NOWA POTYCZKA — fresh in-process arena
             }
             if menu_b.is_some() {
-                relaunch_process(false); // MENU GŁÓWNE — relaunch into the campaign (drop the flag)
+                sw.to_campaign_menu(&mut next_app, time.elapsed_secs()); // MENU GŁÓWNE
             }
             continue;
         }
@@ -1237,7 +1299,7 @@ fn spawn_gameover_screen(
         player.map(|p| format!("Level {}     Gold {}", p.0.level, p.0.gold)).unwrap_or_default()
     };
     // On a defeat with a save, offer to resume last night; a victory ends the saga (no Continue).
-    // Skirmish has no save/continue at all (mode is relaunch-per-run).
+    // Skirmish has no save/continue at all (each Potyczka is a fresh in-process run).
     let can_continue = !skirmish && !won && save.0;
 
     commands.spawn((modal_root(50), GameOverUi)).with_children(|root| {
@@ -1341,10 +1403,9 @@ fn start_click(
     siege: Option<ResMut<crate::siege::Siege>>,
     save: Res<crate::savegame::SaveExists>,
     mut confirm: ResMut<ConfirmWipe>,
-    run: Res<RunInProgress>,
+    mut sw: ModeSwitch,
     mut fresh: ResMut<FreshRunPending>,
     mut credits: ResMut<crate::mainmenu::CreditsOpen>,
-    active_map: Res<crate::worldmap::ActiveMap>,
     mut gfx_menu: ResMut<crate::ui::graphics_menu::GraphicsMenuOpen>,
     mut exit: MessageWriter<AppExit>,
 ) {
@@ -1361,7 +1422,10 @@ fn start_click(
             exit.write(AppExit::Success);
         }
         if skirmish_b.is_some() {
-            relaunch_process(true); // enter Potyczka — a fresh boot with FOREST_RTS=1 (exits this process)
+            // Enter Potyczka in-process: flip the mode + rebuild to the arena under the veil.
+            // Any live campaign run is abandoned un-saved (same contract as the old relaunch);
+            // its last dawn autosave remains for Continue.
+            sw.enter_skirmish(&mut fresh, cur_diff);
         }
         if settings_b.is_some() {
             gfx_menu.0 = true; // open the graphics Settings page over the start screen
@@ -1370,7 +1434,7 @@ fn start_click(
             if save.0 {
                 confirm.0 = Some(false); // New Game would overwrite — confirm first
             } else {
-                begin_new_game(run.0, cur_diff, map_changed(&active_map), &mut pending, &mut next_app, &mut fresh);
+                begin_new_game(sw.run.0, cur_diff, map_changed(&sw.active_map), &mut pending, &mut next_app, &mut fresh);
             }
         }
         if resume.is_some() {
@@ -1423,7 +1487,8 @@ fn gameover_click(
     >,
     mut fresh: ResMut<FreshRunPending>,
     siege: Option<Res<crate::siege::Siege>>,
-    mode: Res<crate::rts::GameMode>,
+    mut sw: ModeSwitch,
+    time: Res<Time>,
     save: Res<crate::savegame::SaveExists>,
     mut confirm: ResMut<ConfirmWipe>,
     mut pending: ResMut<crate::savegame::PendingLoad>,
@@ -1433,19 +1498,19 @@ fn gameover_click(
     if confirm.0.is_some() {
         return;
     }
-    let skirmish = matches!(*mode, crate::rts::GameMode::Skirmish);
+    let skirmish = matches!(*sw.mode, crate::rts::GameMode::Skirmish);
     let cur_diff = current_difficulty(siege.as_deref());
     for (interaction, again, cont, menu_b) in &q {
         if *interaction != Interaction::Pressed {
             continue;
         }
-        // Skirmish: both actions are mode-scoped relaunches (no save/continue exists here).
+        // Skirmish: both actions are in-process mode moves (no save/continue exists here).
         if skirmish {
             if again.is_some() {
-                relaunch_process(true); // ZAGRAJ PONOWNIE — fresh skirmish process
+                sw.enter_skirmish(&mut fresh, cur_diff); // ZAGRAJ PONOWNIE — fresh arena
             }
             if menu_b.is_some() {
-                relaunch_process(false); // MENU GŁÓWNE — relaunch into the campaign
+                sw.to_campaign_menu(&mut next_app, time.elapsed_secs()); // MENU GŁÓWNE
             }
             continue;
         }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -144,7 +144,7 @@ impl Plugin for GameStatePlugin {
             .add_systems(OnEnter(AppState::GameOver), clear_run_active)
             .add_systems(
                 Update,
-                (start_screen_input, cycle_difficulty, start_click, update_diff_seg, cycle_map, update_map_seg)
+                (start_screen_input, cycle_difficulty, start_click, update_diff_seg)
                     .run_if(in_state(AppState::StartScreen)),
             )
             .add_systems(
@@ -572,9 +572,6 @@ struct GameOverMenuBtn;
 /// A difficulty segment (click to select).
 #[derive(Component)]
 struct SegButton(crate::siege::Difficulty);
-/// A map segment on the start screen (click to choose which world a New Game generates).
-#[derive(Component)]
-struct MapSeg(crate::worldmap::MapId);
 // ── Pause-menu buttons ──
 #[derive(Component)]
 struct PauseResumeBtn;
@@ -627,10 +624,8 @@ fn spawn_start_screen(
     siege: Option<Res<crate::siege::Siege>>,
     mut save: ResMut<crate::savegame::SaveExists>,
     run: Res<RunInProgress>,
-    active_map: Res<crate::worldmap::ActiveMap>,
 ) {
     let cur = current_difficulty(siege.as_deref());
-    let cur_map = active_map.0;
     // Re-check the file here: Bevy runs the initial `OnEnter(StartScreen)` *before* `Startup`
     // (where `detect_existing_save` sets the flag), so reading `save.0` directly would miss an
     // existing save on a fresh launch. Recompute + write it back so the flag is right from frame 0.
@@ -824,53 +819,6 @@ fn spawn_start_screen(
                             ))
                             .with_children(|b| {
                                 b.spawn(label(&fonts.semibold, diff_name(d), 13.0, if on { INK } else { TEXT_FAINT }));
-                            });
-                        }
-                    });
-                });
-                // Map selector — which world a New Game builds (Green Isle / Ashlands). Mirrors the
-                // difficulty segmented control; the live choice lives in the `ActiveMap` resource.
-                m.spawn((
-                    Node { flex_direction: FlexDirection::Column, row_gap: Val::Px(7.0), ..default() },
-                    anim(AnimKind::Rise, 0.35, 0.7),
-                ))
-                .with_children(|d| {
-                    d.spawn(label(&fonts.semibold, "MAP", 11.0, KICKER));
-                    d.spawn((
-                        Node {
-                            flex_direction: FlexDirection::Row,
-                            padding: UiRect::all(Val::Px(3.0)),
-                            border: widgets::border(1.0),
-                            border_radius: radius(10.0),
-                            ..default()
-                        },
-                        BackgroundColor(rgba(24, 19, 13, 0.72)),
-                        BorderColor::all(BORDER_SOFT),
-                    ))
-                    .with_children(|seg| {
-                        for mp in MAPS {
-                            let on = mp == cur_map;
-                            seg.spawn((
-                                Button,
-                                Interaction::default(),
-                                Node {
-                                    padding: UiRect::axes(Val::Px(20.0), Val::Px(7.0)),
-                                    border_radius: radius(7.0),
-                                    flex_direction: FlexDirection::Row,
-                                    align_items: AlignItems::Center,
-                                    column_gap: Val::Px(6.0),
-                                    ..default()
-                                },
-                                BackgroundColor(if on { GOLD_DEEP } else { Color::NONE }),
-                                BorderColor::all(Color::NONE),
-                                MapSeg(mp),
-                            ))
-                            .with_children(|b| {
-                                b.spawn(label(&fonts.semibold, map_name(mp), 13.0, if on { INK } else { TEXT_FAINT }));
-                                // Flag a not-yet-finished map so players know what they're picking.
-                                if !map_ready(mp) {
-                                    b.spawn(label(&fonts.semibold, "(not ready)", 10.0, if on { INK } else { TEXT_FAINT }));
-                                }
                             });
                         }
                     });
@@ -1382,7 +1330,6 @@ fn start_click(
             Option<&StartResumeButton>,
             Option<&CreditsButton>,
             Option<&SegButton>,
-            Option<&MapSeg>,
             Option<&QuitButton>,
             Option<&StartSettingsButton>,
             Option<&SkirmishButton>,
@@ -1397,7 +1344,7 @@ fn start_click(
     run: Res<RunInProgress>,
     mut fresh: ResMut<FreshRunPending>,
     mut credits: ResMut<crate::mainmenu::CreditsOpen>,
-    mut active_map: ResMut<crate::worldmap::ActiveMap>,
+    active_map: Res<crate::worldmap::ActiveMap>,
     mut gfx_menu: ResMut<crate::ui::graphics_menu::GraphicsMenuOpen>,
     mut exit: MessageWriter<AppExit>,
 ) {
@@ -1406,7 +1353,7 @@ fn start_click(
     }
     let mut siege = siege;
     let cur_diff = current_difficulty(siege.as_deref());
-    for (interaction, play, cont, resume, cred, seg, mapseg, quit, settings_b, skirmish_b) in &q {
+    for (interaction, play, cont, resume, cred, seg, quit, settings_b, skirmish_b) in &q {
         if *interaction != Interaction::Pressed {
             continue;
         }
@@ -1418,10 +1365,6 @@ fn start_click(
         }
         if settings_b.is_some() {
             gfx_menu.0 = true; // open the graphics Settings page over the start screen
-        }
-        // Pick a map segment first, so a New Game in the same click batch sees the new choice.
-        if let Some(ms) = mapseg {
-            active_map.0 = ms.0;
         }
         if play.is_some() {
             if save.0 {
@@ -1457,54 +1400,6 @@ fn update_diff_seg(
     let cur = current_difficulty(siege.as_deref());
     for (seg, mut bg, children) in &mut q {
         let on = seg.0 == cur;
-        bg.0 = if on { GOLD_DEEP } else { Color::NONE };
-        for child in children.iter() {
-            if let Ok(mut tc) = text_q.get_mut(child) {
-                tc.0 = if on { Color::WHITE } else { TEXT_FAINT };
-            }
-        }
-    }
-}
-
-/// The maps offered on the start screen (order = segment order).
-const MAPS: [crate::worldmap::MapId; 2] =
-    [crate::worldmap::MapId::Home, crate::worldmap::MapId::Ashlands];
-fn map_name(m: crate::worldmap::MapId) -> &'static str {
-    match m {
-        crate::worldmap::MapId::Home => "Green Isle",
-        crate::worldmap::MapId::Ashlands => "Ashlands",
-        // Entered via the Potyczka relaunch, never the M-cycle — named here for completeness.
-        crate::worldmap::MapId::Arena => "Arena",
-    }
-}
-/// Whether a map is finished enough to ship without a caveat. Ashlands is a playable prototype
-/// (ground/atmosphere reskinned, but tree foliage etc. not yet charred), so the menu flags it.
-fn map_ready(m: crate::worldmap::MapId) -> bool {
-    !matches!(m, crate::worldmap::MapId::Ashlands)
-}
-
-/// On the start screen, **M** cycles which map a New Game builds. The segmented control reflects it.
-fn cycle_map(keys: Res<ButtonInput<KeyCode>>, mut active: ResMut<crate::worldmap::ActiveMap>) {
-    if !keys.just_pressed(KeyCode::KeyM) {
-        return;
-    }
-    active.0 = match active.0 {
-        crate::worldmap::MapId::Home => crate::worldmap::MapId::Ashlands,
-        // Arena is skirmish-only (relaunch flag), not part of the campaign M-cycle.
-        crate::worldmap::MapId::Ashlands | crate::worldmap::MapId::Arena => {
-            crate::worldmap::MapId::Home
-        }
-    };
-}
-
-/// Recolour the map segments to match the live [`crate::worldmap::ActiveMap`] (M key or click).
-fn update_map_seg(
-    active: Res<crate::worldmap::ActiveMap>,
-    mut q: Query<(&MapSeg, &mut BackgroundColor, &Children)>,
-    mut text_q: Query<&mut TextColor>,
-) {
-    for (seg, mut bg, children) in &mut q {
-        let on = seg.0 == active.0;
         bg.0 = if on { GOLD_DEEP } else { Color::NONE };
         for child in children.iter() {
             if let Ok(mut tc) = text_q.get_mut(child) {

--- a/src/hints.rs
+++ b/src/hints.rs
@@ -37,8 +37,10 @@ pub struct HintsPlugin;
 
 impl Plugin for HintsPlugin {
     fn build(&self, app: &mut App) {
-        // Campaign-only: the hero-economy hint toasts don't apply to the RTS.
-        app.add_systems(Startup, setup_hint_root.run_if(crate::rts::in_campaign))
+        // Ungated spawn: the hint-toast root is built in EVERY boot (the mode can flip mid-process)
+        // and tagged `CampaignOnly`, so `apply_mode_visibility` hides it in the RTS. The per-frame
+        // `drive_hints` stays `in_campaign`-gated.
+        app.add_systems(Startup, setup_hint_root)
             .add_sim_systems(drive_hints.run_if(crate::rts::in_campaign));
     }
 }
@@ -201,6 +203,7 @@ struct HintRow;
 fn setup_hint_root(mut commands: Commands) {
     commands.spawn((
         HintRoot,
+        crate::game_state::CampaignOnly,
         Node {
             position_type: PositionType::Absolute,
             right: Val::Px(16.0),

--- a/src/hud.rs
+++ b/src/hud.rs
@@ -114,7 +114,10 @@ impl Plugin for HudPlugin {
     fn build(&self, app: &mut App) {
         // Campaign-only: the hero HP/stamina/inventory/town HUD chrome is replaced by the RTS HUD
         // (src/rts/hud.rs) in Skirmish.
-        app.add_systems(Startup, (setup_hud, setup_inv_hud).run_if(crate::rts::in_campaign))
+        // Ungated spawn: the campaign HUD chrome is built in EVERY boot (the mode can flip
+        // Campaign⇄Skirmish mid-process) and tagged `CampaignOnly`, so `apply_mode_visibility`
+        // hides it in Skirmish. The per-frame update systems below stay `in_campaign`-gated.
+        app.add_systems(Startup, (setup_hud, setup_inv_hud))
             .add_systems(
                 Update,
                 (setup_stat_bar, update_hud, update_inv_hud, update_town_stats, flash_quick_slots)
@@ -163,15 +166,18 @@ fn track(h: f32) -> impl Bundle {
 
 fn setup_hud(mut commands: Commands, fonts: Res<UiFonts>) {
     commands
-        .spawn(Node {
-            position_type: PositionType::Absolute,
-            left: Val::Px(18.0),
-            bottom: Val::Px(18.0),
-            flex_direction: FlexDirection::Row,
-            align_items: AlignItems::Center,
-            column_gap: Val::Px(8.0),
-            ..default()
-        })
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(18.0),
+                bottom: Val::Px(18.0),
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                column_gap: Val::Px(8.0),
+                ..default()
+            },
+            crate::game_state::CampaignOnly,
+        ))
         .with_children(|root| {
             // Level badge.
             root.spawn((
@@ -240,6 +246,9 @@ fn setup_stat_bar(mut done: Local<bool>, atlas: Res<IconAtlas>, fonts: Res<UiFon
             BorderColor::all(rgba(224, 168, 74, 0.3)),
             shadow_hud(),
             bevy::ui::FocusPolicy::Pass,
+            // Kept `in_campaign`-gated (it self-spawns when campaign is live), but tagged so a
+            // later mid-process flip to Skirmish hides it too.
+            crate::game_state::CampaignOnly,
         ))
         .with_children(|row| {
             // Money + resources first, then the town's people + daily food balance. Each stat is an
@@ -295,6 +304,7 @@ fn setup_inv_hud(mut commands: Commands, fonts: Res<UiFonts>) {
         },
         bevy::ui::FocusPolicy::Pass,
         ToastRoot,
+        crate::game_state::CampaignOnly,
     ));
     // Buff pips, bottom-left above the vitals.
     commands.spawn((
@@ -310,20 +320,24 @@ fn setup_inv_hud(mut commands: Commands, fonts: Res<UiFonts>) {
         },
         bevy::ui::FocusPolicy::Pass,
         BuffRoot,
+        crate::game_state::CampaignOnly,
     ));
     // (The single top-left stat bar — gold/stone/wood/pop/food as icon+number — is built in
     // `setup_stat_bar` once the icon atlas is ready.)
     // Bottom-centre quick-bar: four quick-use slots.
     commands
-        .spawn(Node {
-            position_type: PositionType::Absolute,
-            bottom: Val::Px(14.0),
-            width: Val::Percent(100.0),
-            flex_direction: FlexDirection::Column,
-            align_items: AlignItems::Center,
-            row_gap: Val::Px(5.0),
-            ..default()
-        })
+        .spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(14.0),
+                width: Val::Percent(100.0),
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                row_gap: Val::Px(5.0),
+                ..default()
+            },
+            crate::game_state::CampaignOnly,
+        ))
         .with_children(|col| {
             col.spawn((
                 Node {

--- a/src/player/arts.rs
+++ b/src/player/arts.rs
@@ -392,6 +392,7 @@ pub(crate) fn spawn_arts_hud(mut commands: Commands, fonts: Res<UiFonts>, atlas:
             },
             GlobalZIndex(30),
             AbilityBar,
+            crate::game_state::CampaignOnly,
         ))
         .with_children(|bar| {
             for (kind, key, sym) in

--- a/src/player/charge.rs
+++ b/src/player/charge.rs
@@ -49,6 +49,7 @@ pub(crate) fn spawn_charge_bar(mut commands: Commands, fonts: Res<UiFonts>) {
             GlobalZIndex(30),
             bevy::ui::FocusPolicy::Pass,
             ChargeBarRoot,
+            crate::game_state::CampaignOnly,
         ))
         .with_children(|root| {
             // Track + fill.

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -456,10 +456,15 @@ impl Plugin for PlayerPlugin {
             // ungated modules (projectile/defenses impact sparks) read, and RTS archer arrows
             // reuse those FX in Skirmish. Everything hero-specific below is Campaign-only.
             .add_systems(Startup, combat::setup_combat_fx)
+            // Ungated spawn: the hero rig + its campaign HUD (ability bar, charge bar, target ring)
+            // are built in EVERY boot (the mode can flip Campaign⇄Skirmish mid-process). Each root
+            // is tagged `CampaignOnly`, so `apply_mode_visibility` hides them on a Skirmish boot the
+            // first Update frame (the mode resource's boot change-tick). `debug_grant_boons` is
+            // internally env-gated (no-op unless `FOREST_BOONS`), so it rides along un-gated. All
+            // per-frame hero systems below stay `in_campaign`-gated.
             .add_systems(
                 PostStartup,
-                (spawn_hero, arts::spawn_arts_hud, charge::spawn_charge_bar, debug_grant_boons, softlock::spawn_target_ring)
-                    .run_if(crate::rts::in_campaign),
+                (spawn_hero, arts::spawn_arts_hud, charge::spawn_charge_bar, debug_grant_boons, softlock::spawn_target_ring),
             )
             // Fresh run: wipe progression + revive the hero on a new run (NOT on un-pause).
             .add_systems(
@@ -636,6 +641,7 @@ fn spawn_hero(
             Visibility::Visible,
             Hero::fresh(pos, y, facing),
             HeroHealth::default(),
+            crate::game_state::CampaignOnly,
         ))
         .id();
 

--- a/src/player/softlock.rs
+++ b/src/player/softlock.rs
@@ -67,6 +67,7 @@ pub fn spawn_target_ring(
         Visibility::Hidden,
         bevy::light::NotShadowCaster,
         TargetRing,
+        crate::game_state::CampaignOnly,
     ));
 }
 

--- a/src/quest.rs
+++ b/src/quest.rs
@@ -63,7 +63,10 @@ impl Plugin for QuestPlugin {
         app.init_resource::<QuestLogRes>()
             .init_resource::<QuestTracking>()
             .add_message::<QuestSignal>()
-            .add_systems(Startup, setup_quest_root.run_if(crate::rts::in_campaign))
+            // Ungated spawn: the tracker root is built in EVERY boot (the mode can flip
+            // mid-process) and tagged `CampaignOnly`, so `apply_mode_visibility` hides it in
+            // Skirmish. Everything else (reset/detect/panel) stays `in_campaign`-gated.
+            .add_systems(Startup, setup_quest_root)
             // Fresh run → restart the chain (mirrors the economy/town resets).
             .add_systems(OnExit(AppState::StartScreen), reset_quests.run_if(crate::rts::in_campaign))
             .add_systems(OnExit(AppState::GameOver), reset_quests.run_if(crate::rts::in_campaign))
@@ -275,6 +278,7 @@ fn setup_quest_root(mut commands: Commands) {
     commands
         .spawn((
             QuestRoot,
+            crate::game_state::CampaignOnly,
             Node {
                 position_type: PositionType::Absolute,
                 right: Val::Px(16.0),

--- a/src/rival.rs
+++ b/src/rival.rs
@@ -494,9 +494,7 @@ const WALL_AT: usize = 8;
 
 // ── Build (a worldmap build phase) ──────────────────────────────────────────────────
 
-/// Raise the rival stronghold at [`RIVAL_CENTRE`]. Called once from `worldmap::build_step`. Home map
-/// only — the desert sits elsewhere on the Ashlands layout, so the fort would land in the wrong
-/// biome there; a future step can place an Ashlands variant.
+/// Raise the rival stronghold at [`RIVAL_CENTRE`]. Called once from `worldmap::build_step`.
 ///
 /// Only the KEEP is raised here (permanent world geometry). The bailey starts bare AND wall-less —
 /// just like the player's own castle starts unwalled — and the rival's economy raises buildings and

--- a/src/rts/build.rs
+++ b/src/rts/build.rs
@@ -84,7 +84,10 @@ pub struct RtsBuildPlugin;
 
 impl Plugin for RtsBuildPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, setup_build_assets.run_if(super::in_skirmish));
+        // Ungated: bakes meshes/materials into a resource with no gameplay side effects, so it must
+        // run in EVERY boot — a campaign-booted process can flip to skirmish mid-process and needs
+        // these assets ready.
+        app.add_systems(Startup, setup_build_assets);
         app.add_systems(
             Update,
             (
@@ -123,6 +126,10 @@ pub struct RtsBuildAssets {
     ghost_body: Handle<StandardMaterial>,
 }
 
+/// Bake the per-building meshes + shared materials into [`RtsBuildAssets`]. Runs at Startup in
+/// EVERY boot (not just a skirmish one) — the mode can flip Campaign→Skirmish mid-process, so the
+/// assets have to exist before the first skirmish frame; it's pure asset baking with no gameplay
+/// side effects, so running it in a campaign process is harmless.
 fn setup_build_assets(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -168,16 +175,20 @@ fn setup_build_assets(
 // ────────────────────────────────────────────────────────────── pre-built halls
 
 /// Once the arena terrain is up (`WorldReady`), drop a completed Town Hall on each base plateau and
-/// seed that side's bank + pop cap. Runs every frame until it has fired once (`Local` latch).
+/// seed that side's bank + pop cap. Re-fires once per skirmish run (generation-keyed on
+/// [`crate::rts::RtsRunGen`]): the `Local<u32>` latch trails the live generation, so a fresh
+/// skirmish entry (which bumps the generation) re-stages the halls instead of firing only once per
+/// process. Still waits for assets + `WorldReady` before latching.
 fn spawn_starting_halls(
     mut commands: Commands,
     assets: Option<Res<RtsBuildAssets>>,
     world_ready: Res<crate::biome::WorldReady>,
     mut banks: ResMut<RtsBanks>,
     mut pop: ResMut<RtsPop>,
-    mut done: Local<bool>,
+    run_gen: Res<crate::rts::RtsRunGen>,
+    mut last_gen: Local<u32>,
 ) {
-    if *done {
+    if *last_gen == run_gen.0 {
         return;
     }
     let Some(assets) = assets else { return };
@@ -198,7 +209,7 @@ fn spawn_starting_halls(
         pop.0[side.ix()].count = 0;
         pop.0[side.ix()].cap = HALL_POP;
     }
-    *done = true;
+    *last_gen = run_gen.0;
 }
 
 /// Spawn a **completed** Town Hall (built, full scale, blocker + Health registered).
@@ -213,6 +224,7 @@ fn spawn_hall(commands: &mut Commands, assets: &RtsBuildAssets, side: Side, pos:
             RtsBuilding { kind: BuildingKind::TownHall, built: true },
             side,
             crate::player::Health { hp: def.hp, max: def.hp },
+            crate::rts::RtsSpawned,
         ))
         .id();
     commands.entity(root).with_children(|p| {
@@ -458,6 +470,9 @@ fn territory_ring(
                     MeshMaterial3d(mat),
                     Transform::from_xyz(PLAYER_BASE.x, y, PLAYER_BASE.y)
                         .with_rotation(Quat::from_rotation_x(-FRAC_PI_2)),
+                    // `RtsUi` (hide-don't-despawn): the `Local<Option<Entity>>` above caches this
+                    // id for the process lifetime, so the generation sweep must not reap it.
+                    super::RtsUi,
                 ))
                 .id(),
         );
@@ -470,7 +485,11 @@ fn territory_ring(
 }
 
 fn spawn_ghost(commands: &mut Commands, assets: &RtsBuildAssets, kind: BuildingKind) -> Entity {
-    let root = commands.spawn((Transform::default(), Visibility::Visible)).id();
+    // `RtsUi`, not `RtsSpawned`: `GhostState` (a `Local`) holds these entity ids, so the
+    // generation sweep must not despawn them out from under it. If one is alive across a
+    // Skirmish → Campaign flip (paused mid-placement), the mode reconciler hides it; back in
+    // skirmish, `ghost_placement` sees `Placing::None` and `clear_ghost`s it properly.
+    let root = commands.spawn((Transform::default(), Visibility::Visible, super::RtsUi)).id();
     let handles = assets.building.get(&kind).cloned().unwrap_or_default();
     commands.entity(root).with_children(|p| {
         for (h, _m) in &handles {
@@ -598,6 +617,7 @@ fn spawn_scaffold(
             RtsBuilding { kind, built: false },
             side,
             crate::player::Health { hp: def.hp, max: def.hp },
+            crate::rts::RtsSpawned,
         ))
         .id();
     commands.entity(root).with_children(|p| {

--- a/src/rts/buildingbars.rs
+++ b/src/rts/buildingbars.rs
@@ -97,7 +97,7 @@ fn sync_building_bars(
     let have = bars.iter().count();
     for _ in have..want.len() {
         commands
-            .spawn((Transform::from_xyz(0.0, -100.0, 0.0), Visibility::Hidden, BldgBar))
+            .spawn((Transform::from_xyz(0.0, -100.0, 0.0), Visibility::Hidden, BldgBar, crate::rts::RtsUi))
             .with_children(|p| {
                 p.spawn((
                     Mesh3d(a.quad.clone()),

--- a/src/rts/camera.rs
+++ b/src/rts/camera.rs
@@ -129,13 +129,17 @@ pub struct RtsCameraPlugin;
 
 impl Plugin for RtsCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<RtsCamFocus>().add_systems(
-            Update,
-            (rts_camera_boot, rts_drive_camera)
-                .chain() // boot swaps to ortho first, so drive sees the ortho to apply zoom
-                .run_if(super::in_skirmish)
-                .run_if(in_state(AppState::Playing)),
-        );
+        app.init_resource::<RtsCamFocus>()
+            .add_systems(
+                Update,
+                (rts_camera_boot, rts_drive_camera)
+                    .chain() // boot swaps to ortho first, so drive sees the ortho to apply zoom
+                    .run_if(super::in_skirmish)
+                    .run_if(in_state(AppState::Playing)),
+            )
+            // The give-back half of the in-process mode switch: whenever the mode is Campaign but
+            // the camera is still the skirmish ortho rig, restore the authored perspective camera.
+            .add_systems(Update, rts_camera_restore.run_if(super::in_campaign));
     }
 }
 
@@ -207,6 +211,28 @@ fn rts_camera_boot(
             ec.remove::<crate::atmospherics::Atmospherics>();
         }
     }
+}
+
+/// Undo [`rts_camera_boot`] after an in-process Skirmish → Campaign switch: the ortho projection
+/// is the tell (only skirmish ever sets it), so swap back the authored perspective
+/// (`scene::default_projection`), re-insert the `DistanceFog` that boot stripped (nothing else
+/// re-adds fog — `apply_quality` doesn't own it), and nudge [`GraphicsSettings`] so
+/// `quality::apply_quality` re-inserts DoF / god-rays / atmospherics / the subtle campaign
+/// outline per the player's settings. Re-inserting those through `apply_quality` is the proven
+/// live path (it's what the F1 settings menu does); with the mode now Campaign, `rts_camera_boot`
+/// no longer runs, so nothing strips them again.
+fn rts_camera_restore(
+    mut commands: Commands,
+    mut cam: Query<(Entity, &mut Projection), With<Camera3d>>,
+    mut gfx: ResMut<crate::quality::GraphicsSettings>,
+) {
+    let Ok((e, mut proj)) = cam.single_mut() else { return };
+    if !matches!(*proj, Projection::Orthographic(_)) {
+        return;
+    }
+    *proj = crate::scene::default_projection();
+    commands.entity(e).try_insert(crate::scene::default_fog());
+    gfx.set_changed();
 }
 
 /// Per-frame: fold WASD/edge-pan/wheel input into `RtsCamFocus`, then glide the single camera into

--- a/src/rts/deposits.rs
+++ b/src/rts/deposits.rs
@@ -129,18 +129,22 @@ pub fn take(deposit: &mut Deposit, amount: f64) -> f64 {
 }
 
 /// After the arena world is up ([`crate::biome::WorldReady`], the same signal `build.rs` waits on),
-/// seed the nine deposits at `worldmap::arena_sites()` — one-shot.
+/// seed the nine deposits at `worldmap::arena_sites()`. Re-fires once per skirmish run
+/// (generation-keyed on [`crate::rts::RtsRunGen`]): the `Local<u32>` latch trails the live
+/// generation so a fresh skirmish entry re-seeds the deposits instead of firing only once per
+/// process. Still waits for `WorldReady` before latching.
 fn spawn_arena_deposits(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     ready: Res<crate::biome::WorldReady>,
-    mut done: Local<bool>,
+    run_gen: Res<crate::rts::RtsRunGen>,
+    mut last_gen: Local<u32>,
 ) {
-    if *done || !ready.0 {
+    if *last_gen == run_gen.0 || !ready.0 {
         return;
     }
-    *done = true;
+    *last_gen = run_gen.0;
 
     let sites = crate::worldmap::arena_sites();
     // Colour lives in the mesh vertex COLOR (mesh contract), so one shared white material batches
@@ -198,18 +202,22 @@ fn spawn_arena_deposits(
 /// register modest nav blockers like the deposit clusters; the MOUNTAIN crags deliberately DON'T
 /// (they ring the central ore bowl, so a blocker there could fence workers out of the vein — the
 /// walkable terraced slope keeps units off them anyway). All sit on the flanks well off the
-/// base-to-base lane. One-shot on [`crate::biome::WorldReady`].
+/// base-to-base lane. Re-fires once per skirmish run (generation-keyed on
+/// [`crate::rts::RtsRunGen`]): the `Local<u32>` latch trails the live generation so a fresh
+/// skirmish entry re-crowns the hills instead of firing only once per process. Still waits for
+/// [`crate::biome::WorldReady`] before latching.
 fn spawn_arena_hills(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     ready: Res<crate::biome::WorldReady>,
-    mut done: Local<bool>,
+    run_gen: Res<crate::rts::RtsRunGen>,
+    mut last_gen: Local<u32>,
 ) {
-    if *done || !ready.0 {
+    if *last_gen == run_gen.0 || !ready.0 {
         return;
     }
-    *done = true;
+    *last_gen = run_gen.0;
     let rock_mat = materials.add(StandardMaterial {
         base_color: Color::WHITE,
         perceptual_roughness: 0.95,
@@ -241,6 +249,7 @@ fn spawn_arena_hills(
                 Transform::from_xyz(rx, ry, rz)
                     .with_rotation(Quat::from_rotation_y(yaw))
                     .with_scale(Vec3::splat(sc)),
+                crate::rts::RtsSpawned,
             ));
         }
     }
@@ -275,6 +284,7 @@ fn spawn_arena_hills(
                 Transform::from_xyz(rx, ry, rz)
                     .with_rotation(Quat::from_rotation_y(yaw))
                     .with_scale(Vec3::splat(sc)),
+                crate::rts::RtsSpawned,
             ));
         }
     }
@@ -297,6 +307,7 @@ fn spawn_grove(
             Transform::from_xyz(centre.x, cy, centre.y),
             Visibility::Hidden,
             Deposit { kind: DepositKind::Wood, remaining },
+            crate::rts::RtsSpawned,
         ))
         .id();
 
@@ -317,6 +328,7 @@ fn spawn_grove(
                 Transform::from_xyz(tx, ty, tz)
                     .with_rotation(Quat::from_rotation_y(yaw))
                     .with_scale(Vec3::splat(sc)),
+                crate::rts::RtsSpawned,
             ))
             .id();
         parts.push((e, None));
@@ -344,6 +356,7 @@ fn spawn_cluster(
             Transform::from_xyz(centre.x, cy, centre.y),
             Visibility::Hidden,
             Deposit { kind, remaining },
+            crate::rts::RtsSpawned,
         ))
         .id();
 
@@ -368,6 +381,7 @@ fn spawn_cluster(
                 Transform::from_xyz(rx, ry, rz)
                     .with_rotation(Quat::from_rotation_y(yaw))
                     .with_scale(Vec3::splat(sc)),
+                crate::rts::RtsSpawned,
             ))
             .id();
         parts.push((e, Some(Vec2::new(rx, rz))));

--- a/src/rts/hud.rs
+++ b/src/rts/hud.rs
@@ -210,6 +210,7 @@ fn spawn_top_bar(commands: &mut Commands, fonts: &UiFonts, atlas: &IconAtlas) {
             },
             GlobalZIndex(60),
             bevy::ui::FocusPolicy::Pass,
+            crate::rts::RtsUi,
         ))
         .with_children(|w| {
             w.spawn((
@@ -296,6 +297,7 @@ fn spawn_build_strip(commands: &mut Commands, fonts: &UiFonts, atlas: &IconAtlas
             widgets::card_paint(),
             GlobalZIndex(60),
             bevy::ui::FocusPolicy::Pass,
+            crate::rts::RtsUi,
         ))
         .with_children(|col| {
             col.spawn(label(&fonts.display, "Build", 12.0, GOLD));
@@ -367,6 +369,7 @@ fn spawn_selection_panels(commands: &mut Commands, fonts: &UiFonts, atlas: &Icon
             widgets::card_paint(),
             GlobalZIndex(60),
             SelUnitPanel,
+            crate::rts::RtsUi,
         ))
         .with_children(|panel| {
             // Count chips (rebuilt each frame by `update_unit_summary` into this host).
@@ -411,6 +414,7 @@ fn spawn_selection_panels(commands: &mut Commands, fonts: &UiFonts, atlas: &Icon
             widgets::card_paint(),
             GlobalZIndex(60),
             SelBldgPanel,
+            crate::rts::RtsUi,
         ))
         .with_children(|p| {
             p.spawn((label(&fonts.display, "", 16.0, GOLD), BldgText::Name));

--- a/src/rts/minimap.rs
+++ b/src/rts/minimap.rs
@@ -87,6 +87,7 @@ fn spawn_panel(mut commands: Commands, panel: Query<Entity, With<MinimapPanel>>)
             BorderColor::all(Color::srgba(0.55, 0.45, 0.25, 0.9)),
             GlobalZIndex(40),
             MinimapPanel,
+            crate::rts::RtsUi,
         ))
         .with_children(|p| {
             // The camera-view outline (spawned first so blips draw over it).

--- a/src/rts/mod.rs
+++ b/src/rts/mod.rs
@@ -29,17 +29,53 @@ pub mod workers;
 
 // ---------------------------------------------------------------- mode
 
-/// Coarse process-wide mode, decided once at boot from `FOREST_RTS=1` and never changed
-/// mid-process (entering Potyczka relaunches the exe, exactly like New Game).
+/// Coarse app mode. Seeded at boot from `FOREST_RTS=1` (`mode_from_env`) and **switchable
+/// mid-process**: the menu's Potyczka button (and the skirmish pause/game-over buttons) flip this
+/// resource live and rebuild the world in-process (`game_state::enter_skirmish` /
+/// `to_campaign_menu`) — the window never closes. Every RTS system gates on the live resource via
+/// [`in_skirmish`], so a flip re-gates the whole mode the same frame; [`RtsRunGen`] +
+/// [`reset_skirmish_state`] handle the entity/resource turnover between runs.
 #[derive(Resource, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum GameMode {
     Campaign,
     Skirmish,
 }
 
+/// The mode a fresh process boots into. Boot-time only — after startup the [`GameMode`]
+/// **resource** is the live truth (it can be flipped mid-process); don't call this from
+/// per-frame systems.
 pub fn mode_from_env() -> GameMode {
     if std::env::var("FOREST_RTS").is_ok() { GameMode::Skirmish } else { GameMode::Campaign }
 }
+
+/// Bumped once per skirmish (re)entry *and* per skirmish exit. Two consumers: the arena stagers
+/// (halls / deposits / hills / workers) re-fire when their `Local<u32>` last-generation trails
+/// this, replacing the old fire-once `Local<bool>` latches; and [`reset_skirmish_state`] sweeps
+/// the previous run's entities + resources on the same edge. Starts at 1 so the boot generation
+/// stages exactly once (the stagers' `Local` defaults to 0).
+#[derive(Resource)]
+pub struct RtsRunGen(pub u32);
+
+impl Default for RtsRunGen {
+    fn default() -> Self {
+        RtsRunGen(1)
+    }
+}
+
+/// Umbrella marker on every RTS-spawned **world** entity (units, buildings, scaffolds, deposit
+/// anchors + their tree/boulder parts, arena hills/crags, order marks…) so one query can sweep
+/// the whole arena between runs. Deliberately NOT `BiomeEntity` — the biome rebuild despawn and
+/// the RTS run turnover are separate lifecycles. Screen/world UI that persists across runs (HUD
+/// roots, minimap, pooled bars) uses [`RtsUi`] + visibility instead.
+#[derive(Component)]
+pub struct RtsSpawned;
+
+/// Marker on RTS UI that outlives a single run (HUD roots, minimap panel, pooled unit/building
+/// bars, the selection band): hidden in Campaign / shown in Skirmish by
+/// `game_state::apply_mode_visibility` rather than despawned, so the spawn-once latches and bar
+/// pools stay valid across mode flips.
+#[derive(Component)]
+pub struct RtsUi;
 
 /// Run condition: this system only runs in the RTS skirmish mode.
 pub fn in_skirmish(mode: Res<GameMode>) -> bool {
@@ -443,6 +479,46 @@ pub enum RtsOutcome {
     RivalWon,
 }
 
+// ---------------------------------------------------------------- run turnover
+
+/// Sweep the previous skirmish's leavings whenever [`RtsRunGen`] bumps: despawn every
+/// [`RtsSpawned`] entity and zero the run resources (banks / pop / outcome / placement / camera
+/// focus), so the next skirmish — or the campaign the player just returned to — starts clean.
+/// Ungated (it must fire on the way *out* of skirmish too); at boot (gen 1, nothing staged) it's
+/// a no-op sweep. The arena stagers re-populate afterwards, once the arena rebuild lands.
+fn reset_skirmish_state(
+    run_gen: Res<RtsRunGen>,
+    mut last: Local<u32>,
+    mut commands: Commands,
+    spawned: Query<Entity, With<RtsSpawned>>,
+    selected: Query<Entity, With<Selected>>,
+    mut banks: ResMut<RtsBanks>,
+    mut pop: ResMut<RtsPop>,
+    mut outcome: ResMut<RtsOutcome>,
+    mut placing: ResMut<Placing>,
+    mut focus: ResMut<camera::RtsCamFocus>,
+) {
+    if *last == run_gen.0 {
+        return;
+    }
+    *last = run_gen.0;
+    for e in &spawned {
+        commands.entity(e).try_despawn();
+    }
+    // Belt-and-braces: `Selected` should only ever sit on RtsSpawned entities, but a stray marker
+    // left on a survivor would wrongly route campaign clicks, so strip any leftovers explicitly.
+    for e in &selected {
+        if let Ok(mut ec) = commands.get_entity(e) {
+            ec.remove::<Selected>();
+        }
+    }
+    *banks = RtsBanks::default();
+    *pop = RtsPop::default();
+    *outcome = RtsOutcome::default();
+    placing.0 = None;
+    *focus = camera::RtsCamFocus::default();
+}
+
 // ---------------------------------------------------------------- plugin assembly
 
 /// Added unconditionally in `main.rs`; every system inside the submodules is gated on
@@ -455,6 +531,10 @@ impl Plugin for RtsPlugin {
             .init_resource::<RtsBanks>()
             .init_resource::<RtsPop>()
             .init_resource::<RtsOutcome>()
+            .init_resource::<RtsRunGen>()
+            // Ungated + ordered before everything mode-gated: the sweep must run in Campaign too
+            // (a skirmish exit bumps the generation) and must not race the same-frame stagers.
+            .add_systems(Update, reset_skirmish_state)
             .add_message::<RtsOrder>()
             .add_message::<TrainOrder>()
             .init_resource::<Placing>()

--- a/src/rts/ordermark.rs
+++ b/src/rts/ordermark.rs
@@ -72,6 +72,7 @@ fn spawn_marks(
                 .with_rotation(Quat::from_rotation_x(-FRAC_PI_2))
                 .with_scale(Vec3::splat(1.5)),
             ClickMarker { spawned: now, mat },
+            crate::rts::RtsSpawned,
         ));
     }
 }

--- a/src/rts/select.rs
+++ b/src/rts/select.rs
@@ -241,6 +241,7 @@ fn draw_band(
             Visibility::Hidden,
             GlobalZIndex(50),
             SelectionBand,
+            crate::rts::RtsUi,
         ));
         return; // node shows from next frame
     }

--- a/src/rts/unitbars.rs
+++ b/src/rts/unitbars.rs
@@ -97,7 +97,7 @@ fn sync_unit_bars(
     let have = bars.iter().count();
     for _ in have..want.len() {
         commands
-            .spawn((Transform::from_xyz(0.0, -100.0, 0.0), Visibility::Hidden, UnitBar))
+            .spawn((Transform::from_xyz(0.0, -100.0, 0.0), Visibility::Hidden, UnitBar, crate::rts::RtsUi))
             .with_children(|p| {
                 // Backing.
                 p.spawn((

--- a/src/rts/units.rs
+++ b/src/rts/units.rs
@@ -360,6 +360,7 @@ fn spawn_soldier(
             crate::player::Health { hp, max: hp },
             crate::scenes::SceneActor,
             crate::navgrid::NavPath::default(),
+            crate::rts::RtsSpawned,
         ))
         .remove::<crate::biome::BiomeEntity>();
     if archer {

--- a/src/rts/workers.rs
+++ b/src/rts/workers.rs
@@ -66,7 +66,10 @@ pub struct RtsWorkersPlugin;
 
 impl Plugin for RtsWorkersPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Startup, init_carry_assets.run_if(in_skirmish)).add_systems(
+        // `init_carry_assets` is ungated: it only bakes carried-load meshes/materials into a
+        // resource (no gameplay side effects), so it must run in EVERY boot — a campaign-booted
+        // process can flip to skirmish mid-process and needs these assets ready.
+        app.add_systems(Startup, init_carry_assets).add_systems(
             Update,
             (
                 spawn_starting_workers,
@@ -217,6 +220,10 @@ impl CarryAssets {
     }
 }
 
+/// Bake the carried-load props (shouldered log / stone lump / gold sack / food sack) into
+/// [`CarryAssets`]. Runs at Startup in EVERY boot (not just a skirmish one) — the mode can flip
+/// Campaign→Skirmish mid-process, so these assets must exist before the first skirmish frame; it's
+/// pure asset baking with no gameplay side effects.
 fn init_carry_assets(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -268,6 +275,7 @@ pub(crate) fn spawn_worker_body(
             crate::player::Health { hp, max: hp },
             crate::scenes::SceneActor,
             crate::navgrid::NavPath::default(),
+            crate::rts::RtsSpawned,
         ))
         // The spawn helpers tag bodies `BiomeEntity`; drop it so a campaign biome-swap (keys 1-5,
         // if ever wired in this mode) can't despawn a live RTS unit.
@@ -276,16 +284,20 @@ pub(crate) fn spawn_worker_body(
 }
 
 /// Once both Town Halls stand, drop 3 idle workers beside each and seed the population count.
-/// One-shot (waits until it can find a hall for *both* sides so neither is missed).
+/// Re-fires once per skirmish run (generation-keyed on [`crate::rts::RtsRunGen`]): the `Local<u32>`
+/// latch trails the live generation so a fresh skirmish entry re-spawns the starting workers
+/// instead of firing only once per process. Still waits until it can find a hall for *both* sides
+/// (so neither is missed) — it only latches on the frame it actually spawns.
 fn spawn_starting_workers(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut creature_mats: ResMut<Assets<crate::creature::CreatureMaterial>>,
     mut pop: ResMut<RtsPop>,
     halls: Query<(&RtsBuilding, &Side, &Transform)>,
-    mut done: Local<bool>,
+    run_gen: Res<crate::rts::RtsRunGen>,
+    mut last_gen: Local<u32>,
 ) {
-    if *done {
+    if *last_gen == run_gen.0 {
         return;
     }
     let mut player = None;
@@ -300,7 +312,7 @@ fn spawn_starting_workers(
         }
     }
     let (Some(pp), Some(rp)) = (player, rival) else { return };
-    *done = true;
+    *last_gen = run_gen.0;
     for (side, hall) in [(Side::Player, pp), (Side::Rival, rp)] {
         for k in 0..5u32 {
             let ang = k as f32 / 5.0 * TAU;

--- a/src/savegame.rs
+++ b/src/savegame.rs
@@ -151,7 +151,10 @@ impl Plugin for SaveGamePlugin {
             .init_resource::<SaveExists>()
             .add_message::<GameLoaded>()
             .add_message::<RequestSave>()
-            .add_systems(Startup, detect_existing_save.run_if(crate::rts::in_campaign))
+            // Ungated: only checks whether a save file exists (no gameplay side effects), so it can
+            // run in EVERY boot — a campaign-booted process can flip modes mid-process. Save/load
+            // systems below stay `in_campaign`-gated.
+            .add_systems(Startup, detect_existing_save)
             // Snapshot at dawn (a cleared night). Gated like the rest of the sim.
             .add_sim_systems(autosave_on_dawn.run_if(crate::rts::in_campaign))
             // Manual save (pause-menu button). Runs in `Paused` — where the world is frozen but

--- a/src/savegame.rs
+++ b/src/savegame.rs
@@ -492,8 +492,8 @@ pub(crate) fn restore_discovered_landmarks(
 
 /// On load, if the saved run was on a different map than the one currently built, swap the
 /// [`crate::worldmap::ActiveMap`] resource and re-arm the world rebuild. The booted world is Home
-/// by default, so resuming an Ashlands run would otherwise land on Home terrain. Same-map loads
-/// (the common case) skip the rebuild and resume in place. Reads the carried `SaveData`.
+/// by default, so resuming a run saved on another map would otherwise land on Home terrain. Same-map
+/// loads (the common case) skip the rebuild and resume in place. Reads the carried `SaveData`.
 pub(crate) fn restore_active_map(
     mut ev: MessageReader<GameLoaded>,
     mut active: ResMut<crate::worldmap::ActiveMap>,
@@ -558,7 +558,7 @@ mod tests {
             keep_hp: 640.0,
             keep_max: 1400.0,
             heirs: 5,
-            map_id: 1, // Ashlands — exercises the non-default map round-trip
+            map_id: 2, // Arena — a non-default map id exercises the round-trip
             player,
             bank: tbank,
             bag,
@@ -593,7 +593,7 @@ mod tests {
         assert_eq!(back.wave_index, 2);
         assert_eq!(back.player.gold, 777);
         assert_eq!(back.heirs, 5);
-        assert_eq!(back.map_id, 1, "map id round-trips");
+        assert_eq!(back.map_id, 2, "map id round-trips");
         assert_eq!(back.upgrades, data.upgrades);
         assert!(back.defenses.walls);
         assert_eq!(back.rescued_camps, vec![true, false, true]);

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -565,6 +565,34 @@ fn light_glow_color(high: f32) -> Color {
     lerp_col(Color::srgb(1.0, 0.6, 0.35), Color::srgb(1.0, 0.93, 0.78), high)
 }
 
+/// The main camera's authored perspective projection. Shared by [`setup_camera`] and the RTS
+/// camera restore (`rts::camera::rts_camera_restore`) when an in-process Skirmish → Campaign
+/// switch hands the single camera back.
+///
+/// far=230 (was the 1000 default). The Linear fog reaches full horizon colour by 190 tiles
+/// (biome.rs), so everything past ~190 is solid fog — invisible but still drawn at full cost.
+/// Clipping the frustum at 230 (40-tile margin) lets Bevy's frustum culler drop all that far
+/// geometry for free. near=0.04 (was the 0.1 default): in first person the sword/shield are held
+/// right at the lens and the default near-plane sliced through them ("flicker" bug); safe for
+/// depth precision since `far` is only 230.
+pub fn default_projection() -> Projection {
+    Projection::from(PerspectiveProjection { fov: 50f32.to_radians(), near: 0.04, far: 230.0, ..default() })
+}
+
+/// The authored campaign distance-fog. Shared by [`setup_camera`] and the RTS camera restore —
+/// `rts_camera_boot` strips `DistanceFog` for the crisp top-down read and nothing else re-adds it
+/// (`quality::apply_quality` doesn't own fog), so the restore re-inserts exactly this.
+pub fn default_fog() -> DistanceFog {
+    DistanceFog {
+        color: SKY,
+        directional_light_color: Color::srgb(1.0, 0.93, 0.78),
+        // 7 (was 12): a wider sun-toward-camera in-scatter lobe — the haze catches the
+        // light across a broad band of the frame instead of a tight sun-adjacent glow.
+        directional_light_exponent: 7.0,
+        falloff: FogFalloff::ExponentialSquared { density: FOG_DENSITY },
+    }
+}
+
 fn setup_camera(
     mut commands: Commands,
     mut images: ResMut<Assets<Image>>,
@@ -606,7 +634,7 @@ fn setup_camera(
         // lens and the default near-plane sliced through them, popping bits in/out every frame as the
         // walk-bob moved them across z=near (the "flicker" bug). 0.04 keeps the close viewmodel whole.
         // Safe for depth precision — `far` is only 230 (ratio ~5750:1), not the 1000 default.
-        Projection::from(PerspectiveProjection { fov: 50f32.to_radians(), near: 0.04, far: 230.0, ..default() }),
+        default_projection(),
         cam_tf,
         Hdr,
         Exposure { ev100: 10.85 },
@@ -646,14 +674,7 @@ fn setup_camera(
         // auto-focused on the player by `drive_dof_focus`, fore/background melting into
         // bokeh. Tunable live in F1 → Blur+Bloom (sharp band / blur radius).
         crate::dof::default_dof(),
-        DistanceFog {
-            color: SKY,
-            directional_light_color: Color::srgb(1.0, 0.93, 0.78),
-            // 7 (was 12): a wider sun-toward-camera in-scatter lobe — the haze catches the
-            // light across a broad band of the frame instead of a tight sun-adjacent glow.
-            directional_light_exponent: 7.0,
-            falloff: FogFalloff::ExponentialSquared { density: FOG_DENSITY },
-        },
+        default_fog(),
         GeneratedEnvironmentMapLight { environment_map: env, intensity: IBL_INTENSITY, ..default() },
     ))
     // Procedural sky — real blue sky + sun disk + horizon glow, using the DirectionalLight as the

--- a/src/siege.rs
+++ b/src/siege.rs
@@ -554,7 +554,10 @@ impl Plugin for SiegePlugin {
         app.init_resource::<KeepHp>()
             .init_resource::<Siege>()
             .init_resource::<GameTime>()
-            .add_systems(Startup, (setup_invader_armory, setup_siege_hud).run_if(crate::rts::in_campaign))
+            // Ungated spawn: the invader armory (asset baking) + the siege HUD root are built in
+            // EVERY boot (the mode can flip mid-process); the HUD root is tagged `CampaignOnly` so
+            // `apply_mode_visibility` hides it in Skirmish. All sim/update systems stay gated.
+            .add_systems(Startup, (setup_invader_armory, setup_siege_hud))
             .add_systems(PostStartup, seed_demo_wave.run_if(crate::rts::in_campaign)) // FOREST_WAVE screenshot hook only
             // Pause-aware clock — advances before the sim, frozen behind any panel / outside Playing.
             .add_sim_systems(advance_game_clock.run_if(crate::rts::in_campaign))
@@ -1289,6 +1292,7 @@ fn setup_siege_hud(mut commands: Commands, fonts: Res<UiFonts>, assets: Res<Asse
                 ..default()
             },
             anim(AnimKind::SlideDown, 0.0, 0.36),
+            crate::game_state::CampaignOnly,
         ))
         .with_children(|col| {
             // Objective row: the one number that matters this phase.

--- a/src/visual.rs
+++ b/src/visual.rs
@@ -133,10 +133,9 @@ fn spawn_clouds(
         return;
     }
     // Same blanket problem in the RTS skirmish: the iso ortho camera looks down through the
-    // cloud band the whole match, so the arena skips the layer entirely.
-    if crate::rts::mode_from_env() == crate::rts::GameMode::Skirmish {
-        return;
-    }
+    // cloud band the whole match. The layer is spawned regardless (the mode can now flip
+    // mid-process) and tagged `CampaignOnly`, so `game_state::apply_mode_visibility` hides it
+    // for the arena and re-shows it back in the campaign.
     let cloud_mat = mats.add(StandardMaterial {
         base_color: Color::srgb(1.0, 1.0, 1.0),
         // Small white emissive keeps the shaded side bright (clouds, not grey rocks).
@@ -165,6 +164,7 @@ fn spawn_clouds(
             Transform::from_xyz(x, y, z).with_scale(Vec3::splat(s)),
             NotShadowCaster,
             Cloud,
+            crate::game_state::CampaignOnly,
         ));
     }
 }

--- a/src/worldmap.rs
+++ b/src/worldmap.rs
@@ -114,7 +114,7 @@ pub const ATMOSPHERE: (u32, f32, u32, f32, u32, f32, Vec3) =
 // are the grass meadow macro-patch tones; `swamp_*` the wet marsh mottle; `blight_*` the
 // trampled-ork-mud mottle; `snow_shade/_bright` the wind-drift sastrugi; `forest_dark/_dry`
 // the canopy loam/litter; `dirt` grass-cliff soil; `snow_cliff_*` the snow lip over rock;
-// `road_dirt` the baked approach-road tint; `lava_*` the volcanic-map magma field (map 2).
+// `road_dirt` the baked approach-road tint.
 #[derive(Clone, Copy)]
 struct Palette {
     grass: u32,
@@ -143,10 +143,6 @@ struct Palette {
     snow_cliff_lip: u32,
     snow_cliff_rock: u32,
     road_dirt: u32,
-    // ── Lava field (map 2 only — see `TB::Lava`) ──
-    lava_basalt: u32,
-    lava_seam: u32,
-    lava_seam_hot: u32,
 }
 
 /// The home island's original palette — values unchanged from the pre-second-map era.
@@ -177,47 +173,6 @@ const PAL_HOME: Palette = Palette {
     snow_cliff_lip: 0xe9f0f9,
     snow_cliff_rock: 0x7b8597,
     road_dirt: 0x8a6d44,
-    lava_basalt: 0x2a2421,
-    lava_seam: 0xc8521a,
-    lava_seam_hot: 0xffb347,
-};
-
-/// **Volcanic Ashlands** (map 2) — the 5 biomes reskinned for a charred volcanic world, but each
-/// kept VISUALLY DISTINCT so a biome still reads as itself under the ember sun (an earlier muddy
-/// pass made snow read tan + forest read flat-brown). Snow stays COOL (blue-grey ash) so it never
-/// warms to desert; forest keeps a sooty GREEN (g>r) so the terrain shader's foliage layer fires
-/// and it reads as scorched woodland, not mud; desert is clearly warm sand; rock is near-black
-/// basalt; swamp a sulfur olive.
-const PAL_ASH: Palette = Palette {
-    grass: 0x575249,       // cinder flats (the neutral "safe" ground)
-    grass_dark: 0x3c3931,  // shaded ash hollows
-    grass_dry: 0x6f6453,   // dry warm cinder
-    grass_gold: 0x8c6838,  // scorched sun-baked sweeps
-    sand: 0x837458,        // grey-tan volcanic grit beaches
-    forest: 0x424e36,      // sooty GREEN grove floor (g>r → reads as woodland)
-    rock: 0x312c27,        // near-black basalt range
-    snow: 0xe2e7f0,        // BRIGHT cool ashfall — value (not hue) is what reads as snow vs tan
-    desert: 0x9c8a63,      // warm tan dunes (clearly sandy)
-    swamp: 0x4a4226,       // sulfur-tainted muck
-    swamp_dark: 0x2a2615,  // tar pools
-    swamp_moss: 0x726232,  // sulfur crust
-    swamp_algae: 0x5c4c22, // brimstone seep
-    blight: 0x3a2e1f,      // trampled ash mud
-    blight_dark: 0x1f1810,
-    blight_ash: 0x6a6258,
-    blight_green: 0x55502f,
-    blight_rust: 0x6a3318,
-    snow_shade: 0xa2aab8,  // cool drift shadow
-    snow_bright: 0xdfe6ee, // wind-polished cool ash crest
-    forest_dark: 0x313b27, // charred green loam
-    forest_dry: 0x586338,  // ash-dusted leaf litter (greenish)
-    dirt: 0x3a2c1d,        // cliff soil
-    snow_cliff_lip: 0xd0d8e2,
-    snow_cliff_rock: 0x565b64,
-    road_dirt: 0x4a3a26,
-    lava_basalt: 0x2a2421, // cooled crust between the seams
-    lava_seam: 0xc8521a,   // glowing crack
-    lava_seam_hot: 0xffb347, // white-hot core
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -232,10 +187,6 @@ enum TB {
     /// The ork-blighted mire around Gnashfang Hold (south extension). Maps to
     /// [`Biome::Swamp`] for gameplay (poison, slow, ambience) but draws its own ground.
     Blight,
-    /// **Lava field** — the Volcanic Ashlands signature biome (map 2 only). Like the Blight it
-    /// draws its own ground (basalt + glowing magma seams) but maps to [`Biome::Swamp`] for
-    /// gameplay, so standing in it burns (the swamp poison-and-slow floor, reskinned).
-    Lava,
 }
 
 struct Region {
@@ -342,30 +293,6 @@ const PLATEAUS: [Plateau; 4] = [
 const DELIBERATE_LAKE: (f32, f32, f32, f32) = (92.0, 80.0, 5.0, 3.0); // x,z,rx,rz
 
 // ── Map selection (which world to generate) ──────────────────────────────────────
-/// **Volcanic Ashlands** atmosphere (map 2): a dim red-brown sky + orange fog carry the hellish
-/// mood, while the sun is only *warm* (not pure-orange) so biome hues still read — a fully
-/// saturated ember sun washed snow to tan and erased every biome's colour. Low sun = long hostile
-/// shadows. Same tuple shape as [`ATMOSPHERE`]; fog stays moderate (heavy volumetric fog blacks
-/// the Atmosphere sky — see the ultra-graphics note).
-const ASH_ATMOSPHERE: (u32, f32, u32, f32, u32, f32, Vec3) =
-    (0x5a3b32, 0.0075, 0xffdca8, 10_500.0, 0x6a5e54, 145.0, Vec3::new(90.0, 64.0, 30.0));
-
-/// Ashlands biome layout — the same five biome kinds (reskinned by [`PAL_ASH`]) placed in a
-/// deliberately DIFFERENT arrangement from the home island, so the world reads as a new place
-/// even before the palette/atmosphere land. Mirror was dropped (it desyncs colour-vs-class +
-/// bridges/town-plots); bespoke positions + the noise reseed do the layout work instead.
-// Ashlands stays on the legacy smooth-terraced mountains (cliffy: false) for now — the mesa
-// treatment is tuned for the home island first; give the charcoal massif its own pass set when
-// the Ashlands gets its character pass.
-const ASH_REGIONS: [Region; 6] = [
-    Region { x: 24.0, z: 54.0, r: 32.0, biome: TB::Rock, peak: 18, cliffy: false, passes: &[] }, // W charcoal massif (home put it E)
-    Region { x: 112.0, z: 26.0, r: 28.0, biome: TB::Snow, peak: 9, cliffy: false, passes: &[] }, // NE ashfall drifts
-    Region { x: 110.0, z: 82.0, r: 30.0, biome: TB::Desert, peak: 0, cliffy: false, passes: &[] }, // SE bleached dunes
-    Region { x: 58.0, z: 92.0, r: 26.0, biome: TB::Forest, peak: 0, cliffy: false, passes: &[] }, // S burnt grove
-    Region { x: 96.0, z: 48.0, r: 18.0, biome: TB::Lava, peak: 0, cliffy: false, passes: &[] }, // E lava field (the signature biome)
-    Region { x: 70.0, z: 14.0, r: 20.0, biome: TB::Swamp, peak: 0, cliffy: false, passes: &[] }, // N sulfur seep
-];
-
 /// Which world a run generates. `u8` on the wire (0 = Home, default) so it rides the save +
 /// the boot global trivially. Add a variant + a [`MapDef`] to ship a third map.
 #[repr(u8)]
@@ -373,7 +300,6 @@ const ASH_REGIONS: [Region; 6] = [
 pub enum MapId {
     #[default]
     Home = 0,
-    Ashlands = 1,
     /// The RTS-skirmish **arena** (`FOREST_RTS=1`): a small symmetric grass island, no biome blobs
     /// / rivers / mountains — just two base plateaus, a dirt road between them and mirrored deposit
     /// sites. Generated by [`classify_arena`] / the arena arm of [`build_step`].
@@ -409,7 +335,6 @@ struct MapDef {
     /// Added inside `noise_a`/`noise_b` → reseeds the coastline fray, river winding and inland
     /// hills. Home is `0.0` (identical output — the regression anchor).
     noise_phase: f32,
-    has_lava: bool,
 }
 
 const MAP_HOME: MapDef = MapDef {
@@ -417,14 +342,6 @@ const MAP_HOME: MapDef = MapDef {
     palette: PAL_HOME,
     atmosphere: ATMOSPHERE,
     noise_phase: 0.0,
-    has_lava: false,
-};
-const MAP_ASH: MapDef = MapDef {
-    regions: &ASH_REGIONS,
-    palette: PAL_ASH,
-    atmosphere: ASH_ATMOSPHERE,
-    noise_phase: 13.37,
-    has_lava: true,
 };
 
 /// **Arena** atmosphere (RTS skirmish): bright, clear high-noon daylight so the top-down battle
@@ -440,15 +357,14 @@ const ARENA_ATMOSPHERE: (u32, f32, u32, f32, u32, f32, Vec3) =
 const PAL_ARENA: Palette = PAL_HOME;
 
 /// The arena map def: **no regions** (uniform grass/light-forest, no biome blobs / mountains), the
-/// home green palette, bright clear daylight, its own noise phase so the coast fray + rolling
-/// knolls don't echo the home island, and no lava. All the arena's structure (island ellipse, base
+/// home green palette, bright clear daylight, and its own noise phase so the coast fray + rolling
+/// knolls don't echo the home island. All the arena's structure (island ellipse, base
 /// plateaus, road, deposit spots) lives in [`classify_arena`], not in shared region/river data.
 const MAP_ARENA: MapDef = MapDef {
     regions: &[],
     palette: PAL_ARENA,
     atmosphere: ARENA_ATMOSPHERE,
     noise_phase: 5.0,
-    has_lava: false,
 };
 
 /// Process-global active map id, set once per build by [`set_active_map`] (from
@@ -474,7 +390,6 @@ impl MapId {
     /// Decode the `u8` stored in a save (unknown ids fall back to Home).
     pub fn from_u8(v: u8) -> Self {
         match v {
-            1 => MapId::Ashlands,
             2 => MapId::Arena,
             _ => MapId::Home,
         }
@@ -482,7 +397,6 @@ impl MapId {
 }
 fn active_map() -> &'static MapDef {
     match active_id() {
-        1 => &MAP_ASH,
         2 => &MAP_ARENA,
         _ => &MAP_HOME,
     }
@@ -654,20 +568,8 @@ const HOME_RIVERS: &[RiverDef] = &[
     RiverDef { pts: &[(78.0, 33.0), (76.0, 24.0), (74.0, 14.0), (72.0, 5.0), (70.0, -3.0)], w_src: 0.4, w_mouth: 0.64 },
 ];
 
-// Ashlands — its own three courses off ITS highlands (rock massif W, snow drifts NE): a west
-// torrent off the charcoal massif to the west coast, a north seep, and an eastern drain.
-const ASH_RIVERS: &[RiverDef] = &[
-    // Clear of the W charcoal massif — drains south.
-    RiverDef { pts: &[(66.0, 72.0), (68.0, 82.0), (70.0, 92.0), (72.0, 101.0)], w_src: 0.35, w_mouth: 0.7 },
-    // Clear of the NE snow drifts — north to the coast.
-    RiverDef { pts: &[(80.0, 44.0), (78.0, 32.0), (76.0, 20.0), (74.0, 8.0), (72.0, -2.0)], w_src: 0.35, w_mouth: 0.66 },
-    // East drain.
-    RiverDef { pts: &[(78.0, 66.0), (84.0, 76.0), (90.0, 86.0), (96.0, 96.0)], w_src: 0.35, w_mouth: 0.62 },
-];
-
 fn active_rivers() -> &'static [RiverDef] {
     match active_id() {
-        1 => ASH_RIVERS,
         2 => &[], // the arena carries no rivers
         _ => HOME_RIVERS,
     }
@@ -1927,10 +1829,9 @@ fn classify(x: f32, z: f32) -> Option<(TB, i32)> {
             let h = if sd > 2.5 && fine > 0.7 { 2 } else { 1 };
             return Some((TB::Swamp, h));
         }
-        // Flat biomes get the inland-hills field: dunes in the desert, wooded rises in the forest;
-        // lava stays perfectly flat. Next to a mesa rim the hills flatten to a contrast APRON —
-        // tall reads tall beside flat.
-        let max = if near_cliffy_rim(x, z, 8.0) || reg.biome == TB::Lava { 1 } else { 4 };
+        // Flat biomes get the inland-hills field: dunes in the desert, wooded rises in the forest.
+        // Next to a mesa rim the hills flatten to a contrast APRON — tall reads tall beside flat.
+        let max = if near_cliffy_rim(x, z, 8.0) { 1 } else { 4 };
         return Some((reg.biome, inland_hills(x, z, dc, max)));
     }
     let h = if near_cliffy_rim(x, z, 8.0) { 1 } else { inland_hills(x, z, dc, 5) };
@@ -2094,20 +1995,14 @@ pub fn tile_biome_world(wx: f32, wz: f32) -> Option<Biome> {
         TB::Snow => Some(Biome::Snow),
         TB::Rock => Some(Biome::Rocky),
         TB::Desert => Some(Biome::Desert),
-        // The Blight + Lava field both ARE swamp to gameplay: poison + slow (`player::movement`),
-        // swamp ambience/weather, swamp wildlife/forage. Only the ground + scatter differ. (For
-        // the Lava field the swamp DoT reads as a lava burn.)
-        TB::Swamp | TB::Blight | TB::Lava => Some(Biome::Swamp),
+        // The Blight ARE swamp to gameplay: poison + slow (`player::movement`), swamp
+        // ambience/weather, swamp wildlife/forage. Only the ground + scatter differ.
+        TB::Swamp | TB::Blight => Some(Biome::Swamp),
         _ => None,
     }
 }
 pub fn is_grass_world(wx: f32, wz: f32) -> bool {
     matches!(tile_at((wx + GX).floor() as i32, (wz + GZ).floor() as i32).map(|t| t.0), Some(TB::Grass))
-}
-/// Is world `(x, z)` a Lava-field tile? Lava maps to gameplay [`Biome::Swamp`], so scatter keys
-/// off the underlying `TB` directly (swamp props are kept off it; basalt boulders go on it).
-fn is_lava_world(wx: f32, wz: f32) -> bool {
-    matches!(tile_at((wx + GX).floor() as i32, (wz + GZ).floor() as i32).map(|t| t.0), Some(TB::Lava))
 }
 /// Smoothed terrain height at integer grid CORNER `(cx, cz)` **as seen from a tile of class
 /// `h_ref`**: the mean flat-top Y of the corner's land tiles that are CLUSTER-CONNECTED to
@@ -2332,7 +2227,6 @@ fn biome_col(b: TB) -> [f32; 3] {
         TB::Desert => p.desert,
         TB::Swamp => p.swamp,
         TB::Blight => p.blight,
-        TB::Lava => p.lava_basalt,
     })
 }
 
@@ -2398,16 +2292,6 @@ fn biome_col_at(b: TB, x: f32, z: f32) -> [f32; 3] {
             let col = mix3(col, lin3(p.blight_dark), crack * 0.22);
             mix3(col, lin3(p.blight_ash), crust * 0.18)
         }
-        TB::Lava => {
-            // Cooled black basalt veined with a network of glowing magma seams. Seams sit at the
-            // noise zero-crossings (`1 - smoothstep(|n|)` → a thin bright line), with white-hot
-            // cores where two seam systems cross.
-            let seam = 1.0 - smoothstep(0.0, 0.13, noise_a(x * 2.4 + 9.0, z * 2.4 - 4.0).abs());
-            let fine = 1.0 - smoothstep(0.0, 0.09, noise_b(x * 5.5 - 13.0, z * 5.5 + 8.0).abs());
-            let col = mix3(base, lin3(p.lava_seam), seam * 0.85);
-            let col = mix3(col, lin3(p.lava_seam), fine * 0.40);
-            mix3(col, lin3(p.lava_seam_hot), seam * fine * 0.95)
-        }
         _ => base,
     }
 }
@@ -2439,7 +2323,7 @@ pub(crate) fn ground_color(x: f32, z: f32) -> [f32; 4] {
     // swamp↔grass edge over the SAME `BLEND` band the colour already blends over — instead of the
     // sheen switching hard per material sheet (grass sheet 1.0 vs the old swamp sheet 0.40), which
     // staircased the boundary into the visible tile "kwadraty" a player reported. Only the Swamp
-    // biome is wet; Blight/Lava stay matte (their sheets sit near grass roughness).
+    // biome is wet; the Blight stays matte (its sheet sits near grass roughness).
     let mut wet = 0.0f32;
     for reg in active_map().regions {
         let fray = if reg.peak > 0 { 0.0 } else { edge_fray(x, z) };
@@ -2699,7 +2583,7 @@ pub fn build_step(
         0 => bs_grass_sheet(commands, meshes, images, terrain_mats),
         1 => bs_swamp_sheet(commands, meshes, images, terrain_mats),
         2 => bs_blight_sheet(commands, meshes, images, terrain_mats),
-        3 => bs_lava_sheet(commands, meshes, images, terrain_mats),
+        // (3 was bs_lava_sheet — dropped with the Ashlands map; Home/Arena grow no lava tiles.)
         4 => bs_sea_and_boats(commands, meshes, images, std_mats, water_mats),
         5 => bs_scatter_biome(Biome::Forest, commands, meshes, std_mats, state),
         6 => bs_scatter_biome(Biome::Snow, commands, meshes, std_mats, state),
@@ -2756,7 +2640,7 @@ pub fn build_step(
 
 // ── Build phases (each one [`build_step`] arm; see the old `build` doc for the why of each) ──
 
-/// The island proper: grass blade-grain detail, all tiles that aren't Blight/Swamp/Lava.
+/// The island proper: grass blade-grain detail, all tiles that aren't Blight/Swamp.
 fn bs_grass_sheet(commands: &mut Commands, meshes: &mut Assets<Mesh>, images: &mut Assets<Image>, terrain_mats: &mut Assets<TerrainMaterial>) {
     let grass_detail = GroundDetail {
         scale: 0.18,
@@ -2770,7 +2654,7 @@ fn bs_grass_sheet(commands: &mut Commands, meshes: &mut Assets<Mesh>, images: &m
         streak: 0.5,
     };
     let ground_mat = crate::terrain::make_material(&grass_detail, 1.0, Some(rut_mask_image(images)), images, terrain_mats);
-    spawn_terrain_sheet(commands, meshes, ground_mat, |tb| tb != TB::Blight && tb != TB::Swamp && tb != TB::Lava);
+    spawn_terrain_sheet(commands, meshes, ground_mat, |tb| tb != TB::Blight && tb != TB::Swamp);
 }
 
 /// The swamp: bespoke wet blotchy mottle (not the grass blades), lower roughness for a bog sheen.
@@ -2812,27 +2696,6 @@ fn bs_blight_sheet(commands: &mut Commands, meshes: &mut Assets<Mesh>, images: &
     };
     let blight_mat = crate::terrain::make_material(&blight_detail, 0.97, Some(rut_mask_image(images)), images, terrain_mats);
     spawn_terrain_sheet(commands, meshes, blight_mat, |tb| tb == TB::Blight);
-}
-
-/// Lava field (map 2 only): basalt crust sheet; magma seams ride the vertex colour. No-op on maps
-/// without lava so the home island never builds an empty sheet.
-fn bs_lava_sheet(commands: &mut Commands, meshes: &mut Assets<Mesh>, images: &mut Assets<Image>, terrain_mats: &mut Assets<TerrainMaterial>) {
-    if !active_map().has_lava {
-        return;
-    }
-    let lava_detail = GroundDetail {
-        scale: 0.30,
-        strength: 0.55,
-        variation: 0.70,
-        seed: 13.0,
-        dark: 0x16110d,
-        base: 0x2a2421,
-        light: 0x4a3a2a,
-        grain: 0.80,
-        streak: 0.40,
-    };
-    let lava_mat = crate::terrain::make_material(&lava_detail, 0.90, Some(rut_mask_image(images)), images, terrain_mats);
-    spawn_terrain_sheet(commands, meshes, lava_mat, |tb| tb == TB::Lava);
 }
 
 /// The cart-wheel-rut mask (fragment-resolution road grooves, `roads::bake_rut_mask`) as a GPU
@@ -2925,14 +2788,8 @@ fn desert_near_rock(x: f32, z: f32) -> bool {
 fn bs_scatter_biome(biome: Biome, commands: &mut Commands, meshes: &mut Assets<Mesh>, std_mats: &mut Assets<StandardMaterial>, state: &mut BuildState) {
     let lo = -GX;
     let hi = GX; // square covers the whole grid; off-map tiles mask out
-    let mut cfg = config_for(biome);
-    // On the Ashlands reskin swap every biome's lush green cover for the dead-litter family so the
-    // scorched ground doesn't read as blooming meadow. (Trees/rocks left alone.) The arena (a green
-    // meadow like Home) keeps the biome's native cover.
-    if active_id() == MapId::Ashlands as u8 {
-        cfg.cover = frontier_cover();
-    }
-    // On a reskinned map override the per-biome HOME atmosphere with the map's own.
+    let cfg = config_for(biome);
+    // On a non-Home map override the per-biome HOME atmosphere with the map's own.
     let atmo = if active_id() == 0 {
         AtmoSample::from_config(&cfg)
     } else {
@@ -2950,14 +2807,7 @@ fn bs_scatter_biome(biome: Biome, commands: &mut Commands, meshes: &mut Assets<M
         false,
         &move |x, z| {
             let here = tile_biome_world(x, z);
-            // Lava tiles read as Swamp to gameplay but take ROCK scatter (basalt), never reeds.
-            let biome_match = if biome == Biome::Rocky {
-                here == Some(Biome::Rocky) || is_lava_world(x, z)
-            } else if biome == Biome::Swamp {
-                here == Some(Biome::Swamp) && !is_lava_world(x, z)
-            } else {
-                here == Some(biome)
-            };
+            let biome_match = here == Some(biome);
             biome_match
                 && !is_river_world(x, z) // keep props off the (sub-tile) river surface
                 && !is_pool_world(x, z) // …and off the swamp bog pools
@@ -3038,11 +2888,8 @@ fn bs_grass_cover(commands: &mut Commands, meshes: &mut Assets<Mesh>, std_mats: 
     // Per-class damp lean, in `frontier_cover()` order [grass, clover, fern, flower, mushroom]:
     // grass + sun-flowers (poppies/buttercups) take the dry/trodden sweeps, while ferns, clover
     // and mushrooms cluster in the damp green hollows — so WHICH plant you see matches the patch
-    // it grows on. The reskin's dead-litter cover is one class, so it just ignores the lean.
-    // Home + arena are lush meadows → apply the damp-affinity species lean; the Ashlands' single
-    // dead-litter cover class has no lean to apply.
-    let meadow_affinity: &[f32] =
-        if active_id() != MapId::Ashlands as u8 { &[-0.6, 0.5, 0.9, -0.15, 1.0] } else { &[] };
+    // it grows on.
+    let meadow_affinity: &[f32] = &[-0.6, 0.5, 0.9, -0.15, 1.0];
     scatter_region(
         &grass_cfg,
         commands,
@@ -3074,24 +2921,9 @@ fn config_for(b: Biome) -> BiomeConfig {
     }
 }
 
-/// Ground cover for the open frontier, chosen by the active map. The home isle gets the lush
-/// meadow (grass tufts, clover, ferns, flowers, mushrooms — all hard-coded green/floral in
-/// `groundcover.rs`); a reskinned map like Ashlands instead gets **charred ground litter** (grey
-/// pebbles, bark twigs, rust-burnt leaves, pinecones, acorns) so the cinder frontier reads as a
-/// scorched waste, not a flower lawn. (Recolouring every cover mesh per-map would be far more
-/// invasive — the litter family is already neutral/dead-toned, so we just scatter that instead.)
+/// Ground cover for the open frontier: the lush meadow (grass tufts, clover, ferns, flowers,
+/// mushrooms — all hard-coded green/floral in `groundcover.rs`).
 fn frontier_cover() -> Vec<PropClass> {
-    if active_id() == MapId::Ashlands as u8 {
-        return vec![
-            PropClass {
-                variants: (0..gc::NUM_LITTER_VARIANTS).map(|v| (gc::build_floor_litter_mesh(v), 1.0)).collect(),
-                chance: 0.26,
-                scale: (0.7, 1.35),
-                tree: false,
-                block_radius: 0.0,
-            },
-        ];
-    }
     vec![
         PropClass {
             variants: (0..gc::NUM_GRASS_VARIANTS).map(|v| (gc::build_grass_tuft_mesh(v), 1.0)).collect(),


### PR DESCRIPTION
## Summary

Replaces the process-relaunch mode switch with an in-process flip: the "Potyczka" button and skirmish pause/game-over menus now toggle the live `GameMode` resource and rebuild the world under a loading veil, keeping the window open. Previously, entering or leaving Skirmish spawned a fresh exe with/without `FOREST_RTS=1` and closed the window.

## Key Changes

- **New `ModeSwitch` system param** (`game_state.rs`): bundles the five resources (`GameMode`, `ActiveMap`, `RtsRunGen`, `RunInProgress`, `Veil`) needed for mode flips, replacing `relaunch_process()`.
  - `enter_skirmish()`: flips mode to Skirmish, points map to Arena, bumps run generation, requests fresh run.
  - `to_campaign_menu()`: flips mode back to Campaign, points map home, bumps generation, hops to start screen.

- **New `apply_mode_visibility()` system** (`game_state.rs`): reconciles on-screen presentation with live mode. Hides `CampaignOnly` entities (hero rig, campaign HUD roots, compass, quest tracker, hint root, sky clouds) in Skirmish; hides `RtsUi` entities (HUD roots, minimap, pooled bars) in Campaign. Visibility-only (no despawn), so spawn-once latches and bar pools stay valid across mode flips.

- **New `CampaignOnly` marker component** (`game_state.rs`): tags campaign-only presentation roots; visibility cascades to children.

- **New `RtsSpawned` and `RtsUi` markers** (`rts/mod.rs`): `RtsSpawned` marks all arena-world entities (units, buildings, deposits, hills, order marks) for bulk sweep between runs; `RtsUi` marks persistent RTS UI (HUD, minimap, bars, selection band).

- **New `RtsRunGen` resource** (`rts/mod.rs`): bumped on each skirmish entry and exit. Arena stagers (halls, deposits, hills, workers) re-fire when their `Local<u32>` latch trails the live generation, replacing fire-once `Local<bool>` latches. `reset_skirmish_state()` sweeps all `RtsSpawned` entities and zeros run resources (banks, pop, outcome, placement, camera focus) on generation bumps.

- **Ungated asset baking** (`rts/build.rs`, `rts/workers.rs`): `setup_build_assets()` and `init_carry_assets()` now run in EVERY boot (not just skirmish boots), so a campaign-booted process has RTS assets ready if the mode flips mid-process.

- **Ungated campaign HUD spawn** (`hud.rs`, `player/arts.rs`, `player/charge.rs`, `player/softlock.rs`, `compass.rs`, `hints.rs`, `quest.rs`, `siege.rs`): campaign UI (hero HUD chrome, ability bar, charge bar, target ring, compass, hints, quest tracker) spawns in EVERY boot and is tagged `CampaignOnly`, so `apply_mode_visibility` hides it in Skirmish. Per-frame update systems stay `in_campaign`-gated.

- **Ungated save detection** (`savegame.rs`): `detect_existing_save()` runs in EVERY boot (only checks file existence, no gameplay side effects), so a campaign-booted process can flip modes mid-process.

- **RTS camera restore** (`rts/camera.rs`): new `rts_camera_restore()` system (runs when `in_campaign`) undoes `rts_camera_boot()` after a Skirmish → Campaign flip: swaps back the authored perspective projection, re-inserts `DistanceFog`, and nudges `GraphicsSettings` to re-apply DoF/god-rays/atmospherics.

- **Shared camera defaults** (`scene.rs`): extracted `default_projection()` and `

https://claude.ai/code/session_01HVir991DeyjG14UVDTpfNY