### PR TITLE
Fix integrated-GPU startup crash (#67) + cut release v0.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "tileworld_bevy_forest"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bevy",
  "bevy_egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "tileworld_bevy_forest"
 # The one source of the release version (build.rs embeds it; the MSI binds to it).
 # Bumping it on main cuts a release: .github/workflows/release-on-bump.yml tags
 # and releases any version that lands here without a matching v* tag.
-version = "0.20.0"
+version = "0.21.0"
 edition = "2024"
 
 [dependencies]

--- a/docs/release-notes/v0.21.0.md
+++ b/docs/release-notes/v0.21.0.md
@@ -1,0 +1,22 @@
+## New
+
+- **Potyczka — a brand-new RTS skirmish mode.** A whole second way to play, chosen from the **"Potyczka"** button on the start screen: a top-down, isometric real-time-strategy battle with no hero — you command a whole town against a mirrored desert-faction AI on a purpose-built arena, and win by razing the enemy town hall.
+  - **Build a base, Stronghold-style.** Lay down a Town Hall, Barracks, Walls, a Watchtower and a Market — pay the cost and each building raises itself over a few seconds, no builder to babysit. Repeat-place buildings and **drag to lay long stretches of wall**, all on a clean build grid with ghost previews and a build-territory radius.
+  - **Four-resource economy.** Workers haul **wood, stone, gold and food** from tree groves, stone outcrops, iron-ore mountains and gold veins back to your hall, with a live worker/population readout so you can see who's idle.
+  - **Train and command an army.** Queue soldiers and archers from the Barracks in batches, **box-select** your units, and give Move / Stop / Attack orders (with attack-move and on-screen order markers). Archers form up behind your line, melee troops hold a loose ring, and everything paths across the arena to assault the enemy base.
+  - **A real opponent.** The AI rival grows its own economy, trains armies, **defends its town, and sends attack waves** at yours.
+  - **Made to feel like an RTS.** Oblique iso camera with WASD + screen-edge panning, wheel zoom and Q/E / middle-mouse rotation; a **click-to-move minimap**; team-colour selection rings and unit/building HP bars; a fast, responsive hardware cursor; and a full combat/voice/ambient audio pass that only plays sounds happening on-screen.
+
+## Fixed
+
+- **The game no longer crashes on startup on integrated graphics (Intel/AMD laptops).** On many built-in-graphics machines the opening scene would stutter hard for a few seconds and then crash before you could do anything — a lost-GPU-device error deep in the renderer. The culprit was a heavy per-frame lighting readback; it's now skipped on integrated graphics, so those machines boot straight into a stable, smoother game. Discrete GPUs are unaffected. *(Reported in [#67](https://github.com/miskibin/warbell/issues/67).)*
+
+## Also in this release
+
+- Polished the **first-person view** — cleaner weapon swings, a better-placed shield, and framing that keeps towering foes on screen.
+- Tidied world collision so you snag less on camp and castle clutter, with a gentle assist around obstacles.
+- Retired the experimental second campaign map; the Green Isle campaign and the new Arena (skirmish) remain.
+
+---
+
+*The Windows installer is self-signed, so SmartScreen shows "Unknown Publisher" — click **More info → Run anyway**.*

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -73,11 +73,42 @@
 
 <main class="log">
 
-  <!-- ── v0.20.0 ── -->
+  <!-- ── v0.21.0 ── -->
   <article class="rel latest rv">
     <div class="rel-head">
-      <span class="rel-ver">v0.20.0</span>
+      <span class="rel-ver">v0.21.0</span>
       <span class="rel-badge">Latest</span>
+      <span class="rel-date">July 20, 2026</span>
+    </div>
+    <p class="rel-sum">A whole new way to play — <strong>Potyczka</strong>, a top-down RTS skirmish mode — plus a fix for the startup crash on integrated-graphics laptops.</p>
+    <div class="rel-card">
+      <div class="grp">
+        <div class="grp-h"><span class="tag new">New</span></div>
+        <ul>
+          <li><strong>Potyczka — a brand-new RTS skirmish mode.</strong> Pick it from the start screen for a hero-free, top-down isometric strategy battle: command a whole town against a mirrored desert-faction AI on a purpose-built arena, and win by razing the enemy town hall.</li>
+          <li><strong>Build a base, Stronghold-style.</strong> Town Hall, Barracks, Walls, a Watchtower and a Market — pay the cost and each raises itself, no builder to babysit. Repeat-place buildings and drag to lay long stretches of wall on a clean build grid with ghost previews.</li>
+          <li><strong>Four-resource economy.</strong> Workers haul wood, stone, gold and food from groves, outcrops, iron-ore mountains and gold veins, with a live idle-worker readout.</li>
+          <li><strong>Train and command an army.</strong> Queue soldiers and archers in batches, box-select your units, and give Move / Stop / Attack orders (with attack-move and order markers). Archers form up behind, melee holds the line, everything paths across the arena to assault the enemy.</li>
+          <li><strong>A real opponent.</strong> The AI rival grows its own economy, trains armies, defends its town and sends attack waves at yours.</li>
+          <li><strong>Made to feel like an RTS.</strong> Iso camera with WASD + edge panning, wheel zoom and Q/E / middle-mouse rotation; a click-to-move minimap; team-colour selection rings and HP bars; a snappy hardware cursor; and audio that only plays what's happening on screen.</li>
+        </ul>
+      </div>
+      <div class="grp">
+        <div class="grp-h"><span class="tag fix">Fixed</span></div>
+        <ul>
+          <li><strong>No more startup crash on integrated graphics.</strong> On many Intel/AMD-graphics laptops the opening scene stuttered hard and then crashed before you could play — a lost-GPU-device error deep in the renderer. The heavy per-frame lighting readback behind it is now skipped on integrated graphics, so those machines boot straight into a stable, smoother game. Discrete GPUs are unaffected.</li>
+          <li>Polished the first-person view — cleaner weapon swings, a better-placed shield, and framing that keeps towering foes on screen.</li>
+          <li>Tidied world collision so you snag less on camp and castle clutter.</li>
+        </ul>
+      </div>
+      <div class="rel-foot"><a href="https://github.com/miskibin/warbell/releases/tag/v0.21.0">Release on GitHub →</a></div>
+    </div>
+  </article>
+
+  <!-- ── v0.20.0 ── -->
+  <article class="rel rv">
+    <div class="rel-head">
+      <span class="rel-ver">v0.20.0</span>
       <span class="rel-date">July 8, 2026</span>
     </div>
     <p class="rel-sum">The game finds its voice — dozens of new spoken lines for the moments that mattered — plus attacks that respect walls and a much clearer view across the island.</p>

--- a/src/quality.rs
+++ b/src/quality.rs
@@ -31,6 +31,7 @@
 use bevy::anti_alias::smaa::{Smaa, SmaaPreset};
 use bevy::camera::MainPassResolutionOverride;
 use bevy::core_pipeline::prepass::{DepthPrepass, NormalPrepass};
+use bevy::light::cluster::GlobalClusterSettings;
 use bevy::light::{CascadeShadowConfig, DirectionalLight, DirectionalLightShadowMap};
 use bevy::pbr::{ContactShadows, ScreenSpaceAmbientOcclusion, ScreenSpaceAmbientOcclusionQualityLevel};
 use bevy::post_process::bloom::Bloom;
@@ -312,6 +313,9 @@ impl Plugin for QualityPlugin {
             // inserted RenderAdapterInfo into the main world. Overwrites the default only when no
             // env override / saved config locked the preset and the adapter is a weak device type.
             .add_systems(Startup, detect_adapter_quality)
+            // Weak-GPU stability: drop Bevy 0.19's GPU light-clustering readback (crash-prone under
+            // device loss + a per-frame GPU→CPU stall). Runs before the first render extract.
+            .add_systems(Startup, disable_gpu_clustering_on_weak_gpu)
             .add_systems(Update, debug_qswitch) // FOREST_QSWITCH=<preset>: flip preset at t≈4s (crash repro)
             .add_systems(Update, debug_mbtoggle) // FOREST_MBTOGGLE=1: flip motion-blur at t≈4s (crash repro)
             .add_systems(
@@ -409,6 +413,66 @@ fn detect_adapter_quality(
             info.0.device_type
         );
         *quality = GraphicsQuality::Low;
+    }
+}
+
+/// Bevy 0.19 added **GPU-driven light clustering**: a per-frame compute pass whose results are read
+/// back to the CPU (`map_buffer_on_submit` → `get_mapped_range`) every frame. On weak integrated
+/// GPUs that readback is doubly bad:
+///
+/// 1. **Performance** — it forces a hard GPU→CPU sync every frame, stalling the pipeline on exactly
+///    the tiled/integrated GPUs least able to afford it (the reporter's "the game is very lag").
+/// 2. **Stability** — the readback path is *not* crash-safe. If the device is ever lost (a driver
+///    timeout under load — precisely what a struggling iGPU hits), the map callback panics on the
+///    now-invalid staging buffer, poisons its `Mutex`, and the next frame's
+///    `readback_data.lock().unwrap()` brings the whole process down. That is issue #67: an Intel
+///    iGPU reports `DeviceLost`, then `bevy_pbr::cluster::gpu` panics with a `PoisonError`.
+///
+/// Falling back to **CPU clustering** (the pre-0.19 path, `gpu_clustering = None`) removes the
+/// readback machinery entirely — Bevy's render error handler then rides out transient device errors
+/// instead of hard-crashing. Our scene only ever has dozens of lights, so CPU clustering costs us
+/// nothing. Applied to integrated / virtual / CPU adapters (same weak set as the quality default);
+/// `FOREST_GPUCLUSTER=on|off` force-overrides either way (testing / a mis-classified adapter).
+fn disable_gpu_clustering_on_weak_gpu(
+    adapter_info: Option<Res<RenderAdapterInfo>>,
+    cluster: Option<ResMut<GlobalClusterSettings>>,
+) {
+    let Some(mut cluster) = cluster else { return };
+    // Device didn't support the GPU path in the first place — already on stable CPU clustering.
+    if cluster.gpu_clustering.is_none() {
+        return;
+    }
+
+    // Env escape hatch wins (headless testing, or a user on an adapter we classify wrong).
+    let forced = std::env::var("FOREST_GPUCLUSTER").ok().and_then(|s| {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "1" | "on" | "true" | "yes" => Some(true),
+            "0" | "off" | "false" | "no" => Some(false),
+            _ => None,
+        }
+    });
+
+    let keep_gpu = match forced {
+        Some(k) => k,
+        None => {
+            // Default: keep GPU clustering only on discrete (and unknown "Other") adapters; drop it
+            // on the weak set that hits the readback stall + DeviceLost crash.
+            let Some(info) = adapter_info.as_ref() else { return };
+            use wgpu::DeviceType;
+            !matches!(
+                info.0.device_type,
+                DeviceType::IntegratedGpu | DeviceType::VirtualGpu | DeviceType::Cpu
+            )
+        }
+    };
+
+    if !keep_gpu {
+        let name = adapter_info.as_ref().map(|i| i.0.name.clone()).unwrap_or_default();
+        info!(
+            "Disabling GPU light clustering (adapter: {name:?}) — falling back to stable CPU \
+             clustering to avoid the per-frame readback stall and the DeviceLost crash (issue #67)."
+        );
+        cluster.gpu_clustering = None;
     }
 }
 


### PR DESCRIPTION
## What this does

Fixes the startup crash reported in #67 and cuts the **v0.21.0** release (which also ships the Potyczka RTS skirmish mode that has accumulated on `main` since v0.20.0).

## The fix (issue #67)

On an Intel integrated GPU the game stuttered for a few seconds on the opening scene and then hard-crashed — a `DeviceLost` followed by a `PoisonError` panic in `bevy_pbr::cluster::gpu`.

Root cause: **Bevy 0.19's new GPU-driven light clustering** runs a per-frame compute pass whose results are read back to the CPU every frame (`map_buffer_on_submit` → `get_mapped_range`). On a weak integrated GPU that readback:
1. is a hard GPU→CPU sync that tanks the frame rate (the reporter's "very lag"), and
2. is **not crash-safe** — when the device is lost under load, the map callback panics on the now-invalid staging buffer, poisons its mutex, and the next frame's `readback_data.lock().unwrap()` brings the whole process down.

The fix forces the stable pre-0.19 **CPU clustering** path (`GlobalClusterSettings.gpu_clustering = None`) on integrated / virtual / CPU adapters, removing the readback machinery entirely. Our scene only ever carries dozens of lights, so CPU clustering costs nothing. Discrete GPUs keep the GPU path. `FOREST_GPUCLUSTER=on|off` force-overrides either way.

**Verified** headless on the llvmpipe software adapter (a `Cpu` device): the game logs the fallback and renders past world-gen — the exact point it crashed before — with no clustering panic.

## Release v0.21.0

- Bumps `Cargo.toml` / `Cargo.lock` to `0.21.0` (merging to `main` triggers `release-on-bump` → `release.yml`, which builds the Windows/Linux/MSI artifacts and publishes the tag; `pages.yml` redeploys the site).
- Adds `docs/release-notes/v0.21.0.md` (the GitHub-release body) covering the new RTS skirmish mode + this crash fix.
- Adds the `site/changelog.html` entry and demotes v0.20.0 from "Latest".

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mbj3dSgfs8PmgeLwbZ1Amz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mbj3dSgfs8PmgeLwbZ1Amz)_