### PR TITLE
v0.22.1 — code-review bug fixes (RESUME wiped the run, save rewind, far-LOD collision)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5257,7 +5257,7 @@ dependencies = [
 
 [[package]]
 name = "tileworld_bevy_forest"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "bevy",
  "bevy_egui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "tileworld_bevy_forest"
 # The one source of the release version (build.rs embeds it; the MSI binds to it).
 # Bumping it on main cuts a release: .github/workflows/release-on-bump.yml tags
 # and releases any version that lands here without a matching v* tag.
-version = "0.22.0"
+version = "0.22.1"
 edition = "2024"
 
 [dependencies]

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -94,6 +94,7 @@
         <div class="grp-h"><span class="tag fix">Fixed &mdash; combat &amp; crowds</span></div>
         <ul>
           <li><strong>Orks stop circling and swinging at nothing after you kill the ones attacking you.</strong> The two you just cut down kept holding the only two attack slots for up to 2.6 seconds; those free up the moment a striker drops.</li>
+          <li><strong>Enemies and townsfolk stop walking through your castle walls.</strong> Last release's performance pass gave anyone more than ~90&nbsp;m from the hero a cheap straight-line step that skipped collision entirely &mdash; walls, gate towers, the keep, buildings and the step-height limit alike. Whenever the fighting moved away from you, bodies crossed the wall instead of threading the gate and climbed straight up cliffs. Distant movers are blocked again, at a fraction of the old cost.</li>
           <li><strong>The world stops falling apart the instant you die.</strong> Every ork, villager, worker and raider on the island &mdash; including the ones standing over your body &mdash; switched to cheap distant movement the moment the hero went down, drifting through walls in slow motion while the succession camera swung onto that exact crowd.</li>
           <li>Camps free their prisoners the moment the last ork falls, rather than waiting out the death animation. Freshly killed animals no longer howl while they topple.</li>
         </ul>

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -73,11 +73,52 @@
 
 <main class="log">
 
-  <!-- ── v0.22.0 ── -->
+  <!-- ── v0.22.1 ── -->
   <article class="rel latest rv">
     <div class="rel-head">
-      <span class="rel-ver">v0.22.0</span>
+      <span class="rel-ver">v0.22.1</span>
       <span class="rel-badge">Latest</span>
+      <span class="rel-date">September 8, 2026</span>
+    </div>
+    <p class="rel-sum">A bug-fix release — including one that could quietly destroy a run: RESUME on the title screen used to reset your game back to night one.</p>
+    <div class="rel-card">
+      <div class="grp">
+        <div class="grp-h"><span class="tag fix">Fixed &mdash; your save</span></div>
+        <ul>
+          <li><strong>RESUME no longer wipes your run.</strong> Going to the main menu mid-game and clicking <strong>RESUME</strong> dropped you back in at night one &mdash; level 1, no gold, empty satchel, upgrade tree cleared, town gone &mdash; because re-entering through the title took the same path as starting fresh. Nothing had been saved since the last dawn, so the run was simply lost.</li>
+          <li><strong>Loading a save rewinds the world properly.</strong> Loot a chest or win a landmark trial, then die and Continue from an earlier save: the loot left your satchel, but the chest stayed open and the trial stayed claimed, so that treasure and gear were gone for good. Both rewind with the save now, and the &ldquo;all landmarks found&rdquo; bonus is reachable again.</li>
+          <li>An autosave that fails to write is retried instead of silently skipped for another ten minutes.</li>
+        </ul>
+      </div>
+      <div class="grp">
+        <div class="grp-h"><span class="tag fix">Fixed &mdash; combat &amp; crowds</span></div>
+        <ul>
+          <li><strong>Orks stop circling and swinging at nothing after you kill the ones attacking you.</strong> The two you just cut down kept holding the only two attack slots for up to 2.6 seconds; those free up the moment a striker drops.</li>
+          <li><strong>The world stops falling apart the instant you die.</strong> Every ork, villager, worker and raider on the island &mdash; including the ones standing over your body &mdash; switched to cheap distant movement the moment the hero went down, drifting through walls in slow motion while the succession camera swung onto that exact crowd.</li>
+          <li>Camps free their prisoners the moment the last ork falls, rather than waiting out the death animation. Freshly killed animals no longer howl while they topple.</li>
+        </ul>
+      </div>
+      <div class="grp">
+        <div class="grp-h"><span class="tag fix">Fixed &mdash; crashes</span></div>
+        <ul>
+          <li>Several rare crashes where a frozen or poisoned enemy, a fading hit effect, a dropped item or an animal's idle call landed on the exact frame the game removed that creature or rebuilt the world.</li>
+          <li>The night director's difficulty lookup could have picked the final boss wave on day one; the first night is pinned to the first wave.</li>
+        </ul>
+      </div>
+      <div class="grp">
+        <div class="grp-h"><span class="tag perf">Under the hood</span></div>
+        <ul>
+          <li>Engine updated to Bevy 0.19.1. Three new regression tests cover the RESUME wipe and both halves of the save-rewind bug.</li>
+        </ul>
+      </div>
+      <div class="rel-foot"><a href="https://github.com/miskibin/warbell/releases/tag/v0.22.1">Release on GitHub &rarr;</a></div>
+    </div>
+  </article>
+
+  <!-- ── v0.22.0 ── -->
+  <article class="rel rv">
+    <div class="rel-head">
+      <span class="rel-ver">v0.22.0</span>
       <span class="rel-date">August 10, 2026</span>
     </div>
     <p class="rel-sum">Real save slots with a 10-minute autosave, the two ground-rendering bugs fixed for good, and a deep endgame performance pass — big sieges run light again.</p>

--- a/src/audio/animals.rs
+++ b/src/audio/animals.rs
@@ -73,7 +73,10 @@ pub(crate) fn animal_voices(
     mut commands: Commands,
     voices: Res<Voices>,
     cam: Query<&GlobalTransform, With<Camera3d>>,
-    mut q: Query<(Entity, &mut Animal, &GlobalTransform)>,
+    // `Without<Dying>`: a wolf you just killed must not howl while it topples — and the corpse is
+    // reaped mid-fade (and swept by the `BiomeEntity` world rebuild), which the child spawn below
+    // would otherwise race.
+    mut q: Query<(Entity, &mut Animal, &GlobalTransform), Without<crate::dying::Dying>>,
 ) {
     let dt = time.delta_secs();
     let Ok(cam) = cam.single() else { return };
@@ -98,20 +101,28 @@ pub(crate) fn animal_voices(
             continue;
         }
         a.call_cd = MIN_GAP;
+        if set.clips.is_empty() {
+            continue; // a species whose clip set failed to load — `len() - 1` below would underflow
+        }
         let i = (rng_range(&mut a.rng, 0.0, set.clips.len() as f32) as usize).min(set.clips.len() - 1);
         let clip = set.clips[i].clone();
         let volume = set.volume * WILDLIFE_GAIN;
-        commands.entity(e).with_children(|p| {
-            p.spawn((
-                AudioPlayer(clip),
-                PlaybackSettings {
-                    mode: PlaybackMode::Despawn,
-                    volume: Volume::Linear(volume),
-                    spatial: true,
-                    ..default()
-                },
-                Transform::default(),
-            ));
+        // `queue_silenced`, same as `ambience::attach_campfire_audio`: animals are `BiomeEntity`, so
+        // a biome swap / world rebuild can despawn this one between the query and command
+        // application — a bare `with_children` would panic there. The closure runs only if it lives.
+        commands.entity(e).queue_silenced(move |mut animal: EntityWorldMut| {
+            animal.with_children(|p| {
+                p.spawn((
+                    AudioPlayer(clip),
+                    PlaybackSettings {
+                        mode: PlaybackMode::Despawn,
+                        volume: Volume::Linear(volume),
+                        spatial: true,
+                        ..default()
+                    },
+                    Transform::default(),
+                ));
+            });
         });
     }
 }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -429,7 +429,8 @@ impl Plugin for GameAudioPlugin {
             // Fresh run: clear the once-per-run voice gates (mirrors siege's reset).
             .add_systems(
                 OnExit(crate::game_state::AppState::StartScreen),
-                (reset_hero_line_gates, reset_remark_trigger, director::reset_voices, npc::reset_villager_trigger, ork::reset_ork_trigger, rival_voice::reset_rival_trigger, advice::reset_advice),
+                (reset_hero_line_gates, reset_remark_trigger, director::reset_voices, npc::reset_villager_trigger, ork::reset_ork_trigger, rival_voice::reset_rival_trigger, advice::reset_advice)
+                    .run_if(crate::game_state::fresh_run_reset),
             )
             .add_systems(
                 OnExit(crate::game_state::AppState::GameOver),

--- a/src/blockers.rs
+++ b/src/blockers.rs
@@ -291,14 +291,15 @@ pub fn wall_between(ax: f32, az: f32, bx: f32, bz: f32) -> bool {
     false
 }
 
+/// The blocker store is a set of process-global statics, so tests that `reset()`/`add_box` must not
+/// run concurrently or they clobber each other's fixtures. Every such test — here and in `steer`,
+/// whose stepping gate consults this store — serializes on this one lock.
+#[cfg(test)]
+pub(crate) static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// The blocker store is a set of process-global statics, so tests that `reset()`/`add_box`
-    /// must not run concurrently or they clobber each other's fixtures. Serialize them on one lock.
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     /// A wall between attacker and target blocks the attack line-of-sight ([`wall_between`]),
     /// while a clear diagonal past the wall's end does not, and endpoints flush against the wall

--- a/src/boss/mod.rs
+++ b/src/boss/mod.rs
@@ -243,7 +243,7 @@ impl Plugin for BossPlugin {
             // Fresh in-process run (New Game / Restart / Play Again all exit StartScreen or GameOver
             // without a GameLoaded): rebuild the full level-1 pantheon so a warden slain in a prior
             // run isn't permanently gone (wardens aren't BiomeEntity, so the world rebuild skips them).
-            .add_systems(OnExit(AppState::StartScreen), respawn_wardens_on_new_run)
+            .add_systems(OnExit(AppState::StartScreen), respawn_wardens_on_new_run.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), respawn_wardens_on_new_run)
             // On a loaded game, remove wardens the saved hero already slew (ungated; once per load).
             .add_systems(Update, despawn_slain_wardens)
@@ -666,13 +666,17 @@ fn tick_status(
     mut commands: Commands,
     mut player: ResMut<PlayerRes>,
     mut poisoned: Query<(Entity, &Poisoned, &mut Health), Without<Dying>>,
-    slowed: Query<(Entity, &Slowed)>,
+    // `Without<Dying>` like its sibling: a chilled ork routinely dies mid-slow, and a corpse must
+    // not keep being ticked (nor have its status stripped) while it fades.
+    slowed: Query<(Entity, &Slowed), Without<Dying>>,
 ) {
     let dt = time.delta_secs().min(0.05);
     let now = time.elapsed_secs();
     for (e, p, mut h) in &mut poisoned {
         if now >= p.until {
-            commands.entity(e).remove::<Poisoned>();
+            // `try_remove`: the venom holder is an ork/animal other systems despawn outright the
+            // same frame (wave sweep on defeat/victory, rival sweep, the BiomeEntity world wipe).
+            commands.entity(e).try_remove::<Poisoned>();
             continue;
         }
         let dmg = p.dps * dt;
@@ -684,7 +688,7 @@ fn tick_status(
     }
     for (e, s) in &slowed {
         if now >= s.until {
-            commands.entity(e).remove::<Slowed>();
+            commands.entity(e).try_remove::<Slowed>(); // same race as `Poisoned` above
         }
     }
 }

--- a/src/chest.rs
+++ b/src/chest.rs
@@ -80,6 +80,14 @@ pub(crate) struct Chest {
     pub(crate) tier: ChestTier,
 }
 
+impl Chest {
+    /// A bare chest for headless tests (`savegame`'s load-reconcile tests build one of each state).
+    #[cfg(test)]
+    pub(crate) fn for_test(cache: bool, opened: bool) -> Self {
+        Chest { cache, opened, opened_at: 0.0, factor: 0.0, trophy: None, hoard: false, tier: ChestTier::Wood }
+    }
+}
+
 /// Number of scattered chests `populate_chests` places, keyed `ChestId(0..CHEST_COUNT)`.
 pub(crate) const CHEST_COUNT: usize = 24;
 

--- a/src/dof.rs
+++ b/src/dof.rs
@@ -108,7 +108,15 @@ pub fn default_dof() -> Dof {
     // frame by `scene::drive_dof_focus` (use `FOREST_FOCAL` to pin it, or `FOREST_NOBLUR` to kill
     // the pass outright). A 4th value sets `debug_view` to paint the raw CoC.
     if let Ok(s) = std::env::var("FOREST_DOF") {
-        let v: Vec<f32> = s.split(',').filter_map(|p| p.trim().parse().ok()).collect();
+        // `collect::<Option<_>>`, NOT `filter_map(..ok())`: dropping an unparseable field silently
+        // SHIFTED the rest ("44,x,200,3.5" became range=44, far_ramp=200, max_radius=3.5 with no
+        // warning). A non-finite value is rejected for the same reason — `NaN` survives `clamp` and
+        // rides straight into the shader uniform.
+        let v: Vec<f32> = s
+            .split(',')
+            .map(|p| p.trim().parse::<f32>().ok().filter(|f| f.is_finite()))
+            .collect::<Option<Vec<f32>>>()
+            .unwrap_or_default();
         if v.len() == 3 || v.len() == 4 {
             d.range = v[0];
             d.far_ramp = v[1];

--- a/src/economy.rs
+++ b/src/economy.rs
@@ -78,7 +78,7 @@ impl Plugin for EconomyPlugin {
             .init_resource::<Defenses>()
             .init_resource::<EconomyState>()
             // Fresh run wipes the economy (gold resets with PlayerRes).
-            .add_systems(OnExit(AppState::StartScreen), reset_economy)
+            .add_systems(OnExit(AppState::StartScreen), reset_economy.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_economy)
             // No OnExit(Paused) reset: pause-menu Restart resets **in-process** by routing through
             // StartScreen → Playing (see game_state::drive_fresh_run), so this OnExit(StartScreen)

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -121,6 +121,26 @@ pub struct SlotPicker(pub Option<PickerMode>);
 #[derive(Resource, Default)]
 pub struct RunInProgress(pub bool);
 
+/// Set for exactly one `StartScreen → Playing` transition: the player picked **RESUME** on the
+/// title (offered only while [`RunInProgress`]) and is dropping back into the *live, frozen* run
+/// with its world and resources intact.
+///
+/// That transition is the very one every fresh-run path is funnelled through — `OnExit(StartScreen)`
+/// is where the whole `reset_*` suite lives (see [`drive_fresh_run`]) — so without this flag a
+/// RESUME silently wiped the run back to night one (level 1, no gold, empty satchel, town
+/// despawned) with no save written since the last dawn. Every run-state reset therefore carries
+/// [`fresh_run_reset`]; the flag is cleared again `OnEnter(Playing)`, after those resets have had
+/// their chance to run.
+#[derive(Resource, Default)]
+pub struct ResumingRun(pub bool);
+
+/// Run condition for every `OnExit(AppState::StartScreen)` **run-state** reset: true on a fresh run
+/// or a load (both want the wipe — a load then overwrites from the snapshot), false on a title
+/// RESUME, which must leave the live run untouched. See [`ResumingRun`].
+pub fn fresh_run_reset(resuming: Res<ResumingRun>) -> bool {
+    !resuming.0
+}
+
 /// Marker on campaign-only presentation — the hero rig, campaign HUD roots, compass, quest
 /// tracker, hint root, sky clouds… Tag the ROOT entity (visibility cascades to children).
 /// [`apply_mode_visibility`] hides everything tagged while the live mode is Skirmish and shows it
@@ -141,6 +161,7 @@ impl Plugin for GameStatePlugin {
             .init_resource::<SlotPicker>()
             .init_resource::<ContinueInPlace>()
             .init_resource::<RunInProgress>()
+            .init_resource::<ResumingRun>()
             // Drive a pending in-process fresh run to completion (ungated — works over every screen).
             .add_systems(Update, drive_fresh_run)
             // Hide/show campaign vs RTS presentation whenever the live GameMode flips (ungated).
@@ -176,7 +197,7 @@ impl Plugin for GameStatePlugin {
             .add_systems(OnExit(AppState::GameOver), despawn_screen::<GameOverUi>)
             // Track whether a run is live, so the (now mid-run-reachable) start screen offers
             // RESUME and routes New Game correctly. See [`RunInProgress`].
-            .add_systems(OnEnter(AppState::Playing), mark_run_active)
+            .add_systems(OnEnter(AppState::Playing), (mark_run_active, clear_resuming))
             .add_systems(OnEnter(AppState::GameOver), clear_run_active)
             .add_systems(
                 Update,
@@ -306,6 +327,7 @@ fn drive_fresh_run(
     mut world_ready: ResMut<crate::biome::WorldReady>,
     mut pending_build: ResMut<crate::biome::PendingBuild>,
     mut pending_load: ResMut<crate::savegame::PendingLoad>,
+    mut resuming: ResMut<ResumingRun>,
     mut cont: ResMut<ContinueInPlace>,
     siege: Option<ResMut<crate::siege::Siege>>,
     time: Res<Time>,
@@ -317,6 +339,11 @@ fn drive_fresh_run(
         *armed = false;
         return;
     };
+    // A fresh run must NEVER inherit a pending RESUME: this path hops back through StartScreen, and
+    // a stale flag would suppress the very `reset_*` suite the hop exists to fire. (Reachable by
+    // arming a New Game and then clicking RESUME before the rebuild lands — both buttons are live
+    // on the veiled title.) The fresh run wins; RESUME has nothing to return to once it's armed.
+    resuming.0 = false;
     // Keep the cover up across the hop + the chunked rebuild (hides the start-screen flash).
     veil.raise(time.elapsed_secs());
 
@@ -499,6 +526,12 @@ fn watch_end(
 /// routes New Game through an in-process reset instead of a dirty direct start.
 fn mark_run_active(mut run: ResMut<RunInProgress>) {
     run.0 = true;
+}
+
+/// The run is live again — drop the one-shot RESUME flag. Runs `OnEnter(Playing)`, i.e. *after*
+/// the `OnExit(StartScreen)` resets it was there to suppress, so the next New Game wipes normally.
+fn clear_resuming(mut resuming: ResMut<ResumingRun>) {
+    resuming.0 = false;
 }
 
 /// The run ended (Victory/Defeat) — the start screen reached from game-over has nothing live to
@@ -1493,6 +1526,7 @@ fn start_click(
     mut fresh: ResMut<FreshRunPending>,
     mut credits: ResMut<crate::mainmenu::CreditsOpen>,
     mut gfx_menu: ResMut<crate::ui::graphics_menu::GraphicsMenuOpen>,
+    mut resuming: ResMut<ResumingRun>,
     mut exit: MessageWriter<AppExit>,
 ) {
     if confirm.0.is_some() || picker.0.is_some() {
@@ -1524,7 +1558,10 @@ fn start_click(
             }
         }
         if resume.is_some() {
-            next_app.set(AppState::Playing); // back into the live frozen run, world intact
+            // Back into the live frozen run, world intact — suppress the fresh-run reset suite that
+            // `OnExit(StartScreen)` otherwise fires on this exact transition (see `ResumingRun`).
+            resuming.0 = true;
+            next_app.set(AppState::Playing);
         }
         if cont.is_some() {
             // Same in-process load path as everywhere else (incl. the battlefield sweep).
@@ -1968,12 +2005,49 @@ mod tests {
         app
     }
 
+    /// **RESUME must not wipe the live run.** The title's RESUME re-enters `Playing` through the
+    /// very `StartScreen → Playing` edge that every fresh run uses as its reset trigger, so without
+    /// [`ResumingRun`] the whole `reset_*` suite fired and the run reverted to night one — level,
+    /// gold, satchel, upgrades and town all gone, with no save written since the last dawn.
+    #[test]
+    fn resume_from_the_title_skips_the_fresh_run_resets() {
+        #[derive(Resource, Default)]
+        struct Wiped(bool);
+
+        fn app_with(resuming: bool) -> App {
+            let mut app = booted(AppState::StartScreen);
+            app.init_resource::<Wiped>()
+                .insert_resource(ResumingRun(resuming))
+                .add_systems(
+                    OnExit(AppState::StartScreen),
+                    (|mut w: ResMut<Wiped>| w.0 = true).run_if(fresh_run_reset),
+                )
+                .add_systems(OnEnter(AppState::Playing), clear_resuming);
+            app.world_mut().resource_mut::<NextState<AppState>>().set(AppState::Playing);
+            app.update();
+            app
+        }
+
+        assert!(!app_with(true).world().resource::<Wiped>().0, "RESUME leaves the run intact");
+        assert!(app_with(false).world().resource::<Wiped>().0, "New Game / Continue still wipe");
+
+        // And the flag is one-shot: the next New Game off the same session must wipe again.
+        let mut app = app_with(true);
+        assert!(!app.world().resource::<ResumingRun>().0, "cleared once the run is live");
+        app.world_mut().resource_mut::<NextState<AppState>>().set(AppState::StartScreen);
+        app.update();
+        app.world_mut().resource_mut::<NextState<AppState>>().set(AppState::Playing);
+        app.update();
+        assert!(app.world().resource::<Wiped>().0, "a later New Game wipes normally");
+    }
+
     /// A headless app wired with just enough to exercise [`drive_fresh_run`]: the state machine,
     /// the resources it reads/writes, and the system itself. No rendering.
     fn fresh_run_app(state: AppState) -> App {
         let mut app = booted(state);
         app.init_resource::<FreshRunPending>()
             .init_resource::<ContinueInPlace>()
+            .init_resource::<ResumingRun>()
             .init_resource::<crate::loading::Veil>()
             .insert_resource(crate::biome::WorldReady(true))
             .insert_resource(crate::biome::PendingBuild(false))

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -141,7 +141,7 @@ impl Plugin for InventoryPlugin {
             .add_message::<QuickFlash>()
             .add_systems(Startup, (debug_seed, debug_equip, debug_bufftest))
             // Fresh run wipes bag, buffs and toasts (with the rest of progression).
-            .add_systems(OnExit(AppState::StartScreen), reset_inventory)
+            .add_systems(OnExit(AppState::StartScreen), reset_inventory.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_inventory)
             // Every Continue path clears transient buffs/toasts (keyed off the load event).
             .add_systems(Update, clear_transients_on_load)

--- a/src/landmarks.rs
+++ b/src/landmarks.rs
@@ -96,6 +96,23 @@ pub struct Landmark {
     shrine_ready_at: f32,
 }
 
+impl Landmark {
+    /// A bare landmark for headless tests (`savegame`'s load-reconcile tests flip its flags).
+    #[cfg(test)]
+    pub(crate) fn for_test(name: &'static str, discovered: bool, gear_claimed: bool) -> Self {
+        Landmark {
+            name,
+            lore: "",
+            buff: BuffKind::Power,
+            buff_mag: 0.0,
+            discovered,
+            gear: "",
+            gear_claimed,
+            shrine_ready_at: 0.0,
+        }
+    }
+}
+
 /// One emissive mote in a landmark's beacon column. `name` ties it to its landmark so the
 /// column despawns on discovery.
 #[derive(Component)]
@@ -324,7 +341,7 @@ impl Plugin for LandmarksPlugin {
             // Wipe the found/completed tally on a fresh run — the freshly-rebuilt `Landmark` entities
             // reset to undiscovered, but this resource is not `BiomeEntity` and otherwise leaks across
             // runs, letting the all-found +75g bonus fire early (or never) in the next run.
-            .add_systems(OnExit(AppState::StartScreen), reset_discoveries)
+            .add_systems(OnExit(AppState::StartScreen), reset_discoveries.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_discoveries)
             // Beacon drift is a visual — runs even while the world is frozen, like the particles.
             .add_systems(Update, beacon_drift)

--- a/src/lumberjack.rs
+++ b/src/lumberjack.rs
@@ -434,7 +434,8 @@ fn chop_work(
             // leg takes it — the close-in approach (`d <= 6`, where `CLOSE_GIVEUP_SECS` watches for
             // a tree stranded up a terrace lip) keeps the full fan, so that wedge detector still
             // sees real steering.
-            let near = (hero.alive && v.pos.distance(hero.pos) < crate::steer::LOD_R) || d <= 6.0;
+            // Positional only — never conjoined with `hero.alive`; see `steer::LOD_R`.
+            let near = v.pos.distance(hero.pos) < crate::steer::LOD_R || d <= 6.0;
             let advanced = steer::advance_lod(
                 near,
                 v.pos,

--- a/src/melee_ring.rs
+++ b/src/melee_ring.rs
@@ -80,6 +80,25 @@ impl MeleeRing {
     }
 }
 
+/// Hand a slain striker's token straight back to the ring.
+///
+/// [`MeleeRing::release`] is only called on *landing a blow*, and `try_claim`'s prune only drops
+/// **expired** holders — so an ork killed mid-swing kept its token for the rest of its
+/// [`TOKEN_TIME`]. With [`MELEE_CAP`] at 2, cutting down the two orks currently pressing you (the
+/// common case — they are the ones in reach) froze the whole surrounding horde out of the ring for
+/// up to 2.6s: they prowled and swung at nothing, the exact symptom the module doc says this design
+/// removed. Reaping holders that are gone or [`Dying`](crate::dying::Dying) each frame keeps the
+/// slot contestable the instant its holder drops. At most [`MELEE_CAP`] entries, so it's free.
+pub(crate) fn release_dead_holders(
+    mut ring: ResMut<MeleeRing>,
+    strikers: Query<(), (With<crate::orks::Ork>, Without<crate::dying::Dying>)>,
+) {
+    if ring.holders.is_empty() {
+        return;
+    }
+    ring.holders.retain(|e, _| strikers.contains(*e));
+}
+
 /// Steering target for a waiting ork: a point ON the ring, led ~20° along its orbit (sign fixed
 /// per-entity), so following it prowls the ork slowly AROUND the hero instead of parking it.
 pub fn hold_point(e: Entity, hero: Vec2, pos: Vec2) -> Vec2 {

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -417,7 +417,8 @@ fn pick_work(
             // ~80-lookup escape fan. Only the long A*-followed leg takes it; the close-in approach
             // (`d <= 6`, watched by `CLOSE_GIVEUP_SECS` for a rock stranded one terrace up) keeps
             // the full fan so that wedge detector still sees real steering.
-            let near = (hero.alive && v.pos.distance(hero.pos) < crate::steer::LOD_R) || d <= 6.0;
+            // Positional only — never conjoined with `hero.alive`; see `steer::LOD_R`.
+            let near = v.pos.distance(hero.pos) < crate::steer::LOD_R || d <= 6.0;
             match steer::advance_lod(near, v.pos, v.facing, step_target, v.speed * dt, v.body_r, cur_y, 3.0 * dt) {
                 Some(s) => {
                     v.facing = s.facing;

--- a/src/orbs.rs
+++ b/src/orbs.rs
@@ -59,7 +59,7 @@ impl Plugin for OrbsPlugin {
             // Fresh run (New Game / Restart / Play Again): sweep in-flight motes and drop any queued
             // bursts. They aren't `BiomeEntity` (so the world rebuild skips them) and would otherwise
             // home onto the reset hero and bank last run's gold/xp into the new run.
-            .add_systems(OnExit(AppState::StartScreen), reset_orbs)
+            .add_systems(OnExit(AppState::StartScreen), reset_orbs.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_orbs)
             .add_sim_systems(
                 (spawn_queued_orbs, step_reward_orbs)

--- a/src/ork_fortress.rs
+++ b/src/ork_fortress.rs
@@ -218,7 +218,7 @@ impl Plugin for OrkFortressPlugin {
             // again — the world rebuild respawns every fortress entity, so only these flags leak.
             .add_systems(
                 OnExit(AppState::StartScreen),
-                reset_fortress_on_new_run,
+                reset_fortress_on_new_run.run_if(crate::game_state::fresh_run_reset),
             )
             .add_systems(OnExit(AppState::GameOver), reset_fortress_on_new_run)
             // Sim carries the freeze gate, per the game_state contract.

--- a/src/orks.rs
+++ b/src/orks.rs
@@ -312,6 +312,12 @@ impl Plugin for OrksPlugin {
         // The melee attack-token ring (shared with the siege invader brain — see `melee_ring`).
         app.init_resource::<crate::melee_ring::MeleeRing>();
         app.add_systems(Update, (ork_limbs, ork_drive)); // limb anim keeps running while frozen
+        // Ungated + before both brains: hand a slain striker's token straight back, so the horde
+        // can't be frozen out of the ring for a full TOKEN_TIME (see `melee_ring`).
+        app.add_systems(
+            Update,
+            crate::melee_ring::release_dead_holders.before(ork_brain).before(crate::siege::invader_brain),
+        );
         app.add_systems(
             Update,
             (ork_brain, ork_brawl, shaman_heal).run_if(in_state(crate::game_state::Modal::None)),
@@ -367,7 +373,8 @@ fn ork_brain(
         // Hero-distance LOD, hoisted out of the rival-seek branch below because it now gates the
         // *steering* flavour too (see `steer::advance_lod`): the 9-heading escape fan is the real
         // per-ork cost, and it's wasted on a warband nobody is near enough to watch clip a rock.
-        let near = hero.alive && o.pos.distance(hero.pos) < ORK_BRAIN_LOD_R;
+        // Positional only — never conjoined with `hero.alive`; see `steer::LOD_R`.
+        let near = o.pos.distance(hero.pos) < ORK_BRAIN_LOD_R;
 
         // ── Aggro: notice the hero near the camp → chase, then stand & strike; orks far
         // from their home never engage (each warband stays local). ──

--- a/src/player/combat.rs
+++ b/src/player/combat.rs
@@ -565,7 +565,9 @@ pub fn update_fx_fades(
     for (e, mut f, mut tf) in &mut q {
         let k = (now - f.born) / f.life;
         if k >= 1.0 {
-            commands.entity(e).despawn();
+            // `try_despawn`: these quads are tagged `BiomeEntity`, so a biome swap (keys 1-5) or a
+            // New Game rebuild can wipe a still-fading decal in the same frame this reap fires.
+            commands.entity(e).try_despawn();
             mats.remove(&f.mat);
             continue;
         }

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -469,7 +469,7 @@ impl Plugin for PlayerPlugin {
             // Fresh run: wipe progression + revive the hero on a new run (NOT on un-pause).
             .add_systems(
                 OnExit(crate::game_state::AppState::StartScreen),
-                reset_player.run_if(crate::rts::in_campaign),
+                reset_player.run_if(crate::rts::in_campaign).run_if(crate::game_state::fresh_run_reset),
             )
             .add_systems(
                 OnExit(crate::game_state::AppState::GameOver),

--- a/src/quest.rs
+++ b/src/quest.rs
@@ -68,7 +68,7 @@ impl Plugin for QuestPlugin {
             // Skirmish. Everything else (reset/detect/panel) stays `in_campaign`-gated.
             .add_systems(Startup, setup_quest_root)
             // Fresh run → restart the chain (mirrors the economy/town resets).
-            .add_systems(OnExit(AppState::StartScreen), reset_quests.run_if(crate::rts::in_campaign))
+            .add_systems(OnExit(AppState::StartScreen), reset_quests.run_if(crate::rts::in_campaign).run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_quests.run_if(crate::rts::in_campaign))
             // Opening the upgrade tree is a state transition, not a Modal::None event.
             .add_systems(OnEnter(Modal::UpgradeTree), detect_war_table.run_if(crate::rts::in_campaign))

--- a/src/rival.rs
+++ b/src/rival.rs
@@ -1390,7 +1390,8 @@ fn rival_raid_brain(
         }
         let cur_y = crate::steer::footing(vpos.x, vpos.y).unwrap_or(tf.translation.y);
         // Steering LOD for the long march in from the desert (see `step_toward`).
-        let near = hero.alive && vpos.distance(hero.pos) < crate::steer::LOD_R;
+        // Positional only — never conjoined with `hero.alive`; see `steer::LOD_R`.
+        let near = vpos.distance(hero.pos) < crate::steer::LOD_R;
         let turn = RAIDER_TURN * 2.0 * dt;
         // The keep-assault distance: a swordsman batters the wall, a bowman volleys from a bowshot.
         let keep_range = if is_archer { RAIDER_KEEP_RANGE_BOW } else { RAIDER_KEEP_RANGE };
@@ -1584,7 +1585,7 @@ impl Plugin for RivalPlugin {
         app.init_resource::<RivalState>()
             // Fresh run wipes the rival's economy + reaps its raised buildings (the static fort,
             // built from `worldmap::build_step`, persists).
-            .add_systems(OnExit(crate::game_state::AppState::StartScreen), reset_rival)
+            .add_systems(OnExit(crate::game_state::AppState::StartScreen), reset_rival.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(crate::game_state::AppState::GameOver), reset_rival)
             // Tax + paced building, garrison upkeep, and the soldier combat brain (frozen with the
             // sim under any panel / pause).

--- a/src/savegame.rs
+++ b/src/savegame.rs
@@ -70,6 +70,9 @@ pub const SLOT_COUNT: usize = MANUAL_SLOTS + 1;
 /// Seconds of **play** time ([`Playtime`], which freezes with the sim) between periodic autosaves.
 pub const AUTOSAVE_INTERVAL: f64 = 600.0;
 
+/// Seconds of **play** time to wait before retrying an owed autosave whose write failed.
+pub const AUTOSAVE_RETRY: f64 = 30.0;
+
 /// The full snapshot of a run, taken at dawn. One JSON object = one save slot.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct SaveData {
@@ -204,11 +207,15 @@ pub struct Playtime(pub f64);
 pub struct AutosaveTimer {
     pub next_at: f64,
     pub pending: bool,
+    /// Earliest [`Playtime`] a *failed* owed autosave may be retried. A write can fail for reasons
+    /// that persist (read-only save dir, full disk); the owed save is kept rather than dropped, but
+    /// it backs off to [`AUTOSAVE_RETRY`] instead of hammering the disk (and the log) every frame.
+    pub retry_at: f64,
 }
 
 impl Default for AutosaveTimer {
     fn default() -> Self {
-        Self { next_at: AUTOSAVE_INTERVAL, pending: false }
+        Self { next_at: AUTOSAVE_INTERVAL, pending: false, retry_at: 0.0 }
     }
 }
 
@@ -245,7 +252,7 @@ impl Plugin for SaveGamePlugin {
             .add_systems(OnEnter(AppState::StartScreen), rescan_slots)
             // A fresh run restarts the play clock + the periodic-autosave countdown. Same hooks as
             // every other `reset_*` — a Continue then overwrites them in `apply_pending_load`.
-            .add_systems(OnExit(AppState::StartScreen), reset_run_clocks)
+            .add_systems(OnExit(AppState::StartScreen), reset_run_clocks.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_run_clocks)
             // Pause-aware play clock + the snapshots it drives. Gated like the rest of the sim, and
             // chained so a dawn write always precedes (and re-arms) the periodic one.
@@ -584,13 +591,22 @@ fn autosave_tick(
         timer.pending = true;
         timer.next_at = ctx.playtime.0 + AUTOSAVE_INTERVAL;
     }
-    if !timer.pending || ctx.siege.phase != GamePhase::Prep || assault.breached {
+    if !timer.pending
+        || ctx.siege.phase != GamePhase::Prep
+        || assault.breached
+        || ctx.playtime.0 < timer.retry_at
+    {
         return;
     }
-    timer.pending = false;
+    // Clear `pending` only once the write actually LANDS. Clearing it up-front dropped an owed
+    // autosave silently whenever the write failed (disk full, read-only save dir), costing the
+    // player a whole interval; now it stays owed and retries on an `AUTOSAVE_RETRY` back-off.
     if flush_save(0, &ctx.snapshot(), &mut slots) {
+        timer.pending = false;
         notice.push("Autosaved.", time.elapsed_secs_f64());
         info!("periodic autosave at {:.0} min of play", ctx.playtime.0 / 60.0);
+    } else {
+        timer.retry_at = ctx.playtime.0 + AUTOSAVE_RETRY;
     }
 }
 
@@ -744,18 +760,24 @@ fn apply_pending_load(
 
 /// Re-mark discovered landmarks on a load (entity flags; the tally is restored as a resource in
 /// [`apply_pending_load`]). Their beacons are snuffed by `landmarks::snuff_found_beacons`.
+///
+/// Each flag is set to **exactly** what the snapshot says — including back to `false`. A load
+/// rewinds the run, but the world entities are never rebuilt on a same-map Continue, so only
+/// ever setting the flags *true* let the abandoned run's progress leak into the resumed one: a
+/// rune trial won and then lost to a defeat stayed `gear_claimed`, so `start_rune_trial` skipped
+/// the landmark forever while the gear itself had rolled out of the restored satchel. The
+/// discovery tally has the same shape — `Discoveries::found` rewinds to the saved (lower) count
+/// while the extra landmarks stayed `discovered`, stranding `found` below `total` and putting the
+/// all-found bonus permanently out of reach.
 pub(crate) fn restore_discovered_landmarks(
     mut ev: MessageReader<GameLoaded>,
     mut landmarks: Query<&mut Landmark>,
 ) {
     let Some(GameLoaded(data)) = ev.read().last() else { return };
     for mut lm in &mut landmarks {
-        if data.discovered_landmarks.iter().any(|n| n == lm.name) {
-            lm.set_discovered(true);
-        }
-        if data.claimed_landmark_gear.iter().any(|n| n == lm.name) {
-            lm.set_gear_claimed(true);
-        }
+        let name = lm.name;
+        lm.set_discovered(data.discovered_landmarks.iter().any(|n| n == name));
+        lm.set_gear_claimed(data.claimed_landmark_gear.iter().any(|n| n == name));
     }
 }
 
@@ -783,7 +805,15 @@ pub(crate) fn restore_active_map(
     veil.raise(time.elapsed_secs());
 }
 
-/// Re-open looted treasure chests on a load (entity flag + lid pose), keyed by `ChestId`.
+/// Restore one-shot treasure chests to their saved state on a load (entity flag + lid pose),
+/// keyed by `ChestId`.
+///
+/// Sets `opened` to **exactly** the saved flag, both ways. Only ever setting it `true` leaked the
+/// abandoned run's looting into the resumed one: loot a chest on night 5, die, Continue from the
+/// night-4 autosave — the haul correctly rolled out of the satchel, but the chest entity stayed
+/// `opened` (a same-map Continue never rebuilds the world), and `chest_interact` skips opened
+/// chests, so that loot was gone for the rest of the process. Caches are left alone: they respawn
+/// on their own dawn cycle and are deliberately not persisted.
 pub(crate) fn restore_opened_chests(
     mut ev: MessageReader<GameLoaded>,
     mut chests: Query<(&mut Chest, &ChestId, &Children)>,
@@ -791,12 +821,19 @@ pub(crate) fn restore_opened_chests(
 ) {
     let Some(GameLoaded(data)) = ev.read().last() else { return };
     for (mut chest, id, children) in &mut chests {
-        if !chest.cache && data.opened_chests.get(id.0).copied().unwrap_or(false) {
-            chest.opened = true;
-            for &c in children {
-                if let Ok(mut lt) = lids.get_mut(c) {
-                    lt.rotation = Quat::from_rotation_x(CHEST_LID_OPEN);
-                }
+        if chest.cache {
+            continue;
+        }
+        let opened = data.opened_chests.get(id.0).copied().unwrap_or(false);
+        if chest.opened == opened {
+            continue;
+        }
+        chest.opened = opened;
+        // Snap the lid (no swing on load, same as the open path's restore contract).
+        let angle = if opened { CHEST_LID_OPEN } else { 0.0 };
+        for &c in children {
+            if let Ok(mut lt) = lids.get_mut(c) {
+                lt.rotation = Quat::from_rotation_x(angle);
             }
         }
     }
@@ -945,6 +982,65 @@ mod tests {
             w.resource::<PendingLoad>().0.is_none(),
             "PendingLoad drained — apply runs exactly once"
         );
+    }
+
+    /// A load must roll world-entity flags **back**, not just forward. Loot a chest, then resume a
+    /// save taken before that loot: the bag rewinds, so the chest has to re-close or its haul is
+    /// unreachable for the rest of the process (a same-map Continue never rebuilds the world).
+    /// Caches are exempt — they respawn on their own dawn cycle and aren't persisted.
+    #[test]
+    fn load_reopens_and_recloses_chests_to_match_the_snapshot() {
+        let mut app = App::new();
+        app.add_message::<GameLoaded>().add_systems(Update, restore_opened_chests);
+
+        // 0: saved as opened, currently shut  → must open.
+        // 1: saved as shut, currently OPENED  → must re-close (the bug this pins).
+        // 2: a cache, currently opened        → untouched.
+        let ids: Vec<Entity> = [
+            (0usize, false, false),
+            (1, false, true),
+            (2, true, true),
+        ]
+        .into_iter()
+        .map(|(id, cache, opened)| {
+            let lid = app.world_mut().spawn((ChestLid, Transform::default())).id();
+            app.world_mut()
+                .spawn((Chest::for_test(cache, opened), ChestId(id)))
+                .add_child(lid)
+                .id()
+        })
+        .collect();
+
+        let mut data = sample();
+        data.opened_chests = vec![true, false, false];
+        app.world_mut().write_message(GameLoaded(data));
+        app.update();
+
+        let w = app.world();
+        assert!(w.get::<Chest>(ids[0]).unwrap().opened, "saved-open chest re-opens");
+        assert!(!w.get::<Chest>(ids[1]).unwrap().opened, "chest looted after the save re-closes");
+        assert!(w.get::<Chest>(ids[2]).unwrap().opened, "caches are left alone");
+    }
+
+    /// Same rule for landmark flags: a rune trial won *after* the save must un-claim on load, or
+    /// `start_rune_trial` skips that landmark forever while its gear has rolled out of the satchel.
+    #[test]
+    fn load_rewinds_landmark_discovery_and_gear_flags() {
+        let mut app = App::new();
+        app.add_message::<GameLoaded>().add_systems(Update, restore_discovered_landmarks);
+
+        let saved = app.world_mut().spawn(Landmark::for_test("The Old Mill", false, false)).id();
+        let after = app.world_mut().spawn(Landmark::for_test("Sunken Shrine", true, true)).id();
+
+        // `sample()` carries The Old Mill as both discovered and gear-claimed, and nothing else.
+        app.world_mut().write_message(GameLoaded(sample()));
+        app.update();
+
+        let w = app.world();
+        assert!(w.get::<Landmark>(saved).unwrap().is_discovered(), "saved landmark re-marks");
+        assert!(w.get::<Landmark>(saved).unwrap().is_gear_claimed(), "saved gear stays claimed");
+        assert!(!w.get::<Landmark>(after).unwrap().is_discovered(), "post-save discovery rewinds");
+        assert!(!w.get::<Landmark>(after).unwrap().is_gear_claimed(), "post-save trial re-arms");
     }
 
     /// Slot 0 is the autosave and `1..=MANUAL_SLOTS` the manual slots — each with its own file.

--- a/src/siege.rs
+++ b/src/siege.rs
@@ -246,7 +246,10 @@ pub fn step_wave_director(input: &WaveStepInput) -> WaveStepResult {
             // fixed count of nights. Past the WAVES table the index clamps to the last (hardest)
             // wave, which replays with the ECS-side hero-level HP escalation, while `wave_index`
             // keeps climbing so the "Night N" counter still rises.
-            let i = (input.wave_index as usize).min(WAVES.len() - 1);
+            // Clamp BEFORE the cast, like `night_dmg_scale`: `wave_index` is an `i32` whose
+            // documented day-one value is `-1`, and `-1 as usize` saturates, so `.min()` would then
+            // pick the LAST (boss) row rather than wave 0.
+            let i = input.wave_index.clamp(0, WAVES.len() as i32 - 1) as usize;
             let def = &WAVES[i];
             let count = effective_count(i, input.mods);
             // Spawn on interval until the wave's quota is met.
@@ -580,7 +583,7 @@ impl Plugin for SiegePlugin {
         app
             // Fresh run: reset on leaving the start screen or game-over (NOT on un-pausing,
             // which is a Playing↔Paused transition and never touches these).
-            .add_systems(OnExit(AppState::StartScreen), reset_siege.run_if(crate::rts::in_campaign))
+            .add_systems(OnExit(AppState::StartScreen), reset_siege.run_if(crate::rts::in_campaign).run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_siege.run_if(crate::rts::in_campaign));
         // No OnExit(Paused) reset: pause-menu Restart resets in-process by routing through
         // StartScreen → Playing (see game_state::drive_fresh_run), so OnExit(StartScreen) covers it.
@@ -949,7 +952,7 @@ fn run_director(
 /// strays into range, batter the keep (or the hero) on the strike cooldown, and reap if stuck
 /// far out. Reuses the camp ork's tuning + steering; distinct from the leashed [`orks::ork_brain`].
 #[allow(clippy::too_many_arguments)]
-fn invader_brain(
+pub(crate) fn invader_brain(
     time: Res<Time>,
     game: Res<GameTime>,
     hero: Res<HeroState>,
@@ -1179,7 +1182,8 @@ fn invader_brain(
             // path, so a far invader threads the gates exactly as before. Anything INSIDE the wall
             // ring keeps the full fan regardless of hero distance — that's the tight, prop-dense
             // ground where clipping a wall or the keep would actually be visible and unfair.
-            let near = (hero.alive && hero_d < steer::LOD_R) || in_yard;
+            // Positional only — never conjoined with `hero.alive`; see `steer::LOD_R`.
+            let near = hero_d < steer::LOD_R || in_yard;
             match steer::advance_lod(near, o.pos, o.facing, step_target, speed * dt, o.body_r, cur_y, orks::ORK_MAX_TURN * 1.6 * dt) {
                 Some(s) => {
                     o.facing = s.facing;
@@ -1480,6 +1484,21 @@ mod tests {
         assert_eq!(effective_count(0, mods_for(Difficulty::Hard)), 6); // round(5·1.25=6.25)=6
         let boss = WAVES.len() - 1; // count 1; easy round(0.8)=1 floored, never 0
         assert_eq!(effective_count(boss, mods_for(Difficulty::Easy)), 1);
+    }
+
+
+    /// `wave_index` is an `i32` whose documented day-one value is `-1`. Casting it to `usize`
+    /// before the clamp saturates, and `.min(len - 1)` then picks the LAST (boss) row — the hardest
+    /// wave — instead of wave 0. Clamp first, like `night_dmg_scale` does.
+    #[test]
+    fn day_one_wave_index_selects_the_first_wave_not_the_boss() {
+        assert_ne!(
+            WAVES[0].count,
+            WAVES[WAVES.len() - 1].count,
+            "the table's first and last rows must differ"
+        );
+        let i = (-1i32).clamp(0, WAVES.len() as i32 - 1) as usize;
+        assert_eq!(i, 0, "a -1 wave_index resolves to the first wave");
     }
 
     #[test]

--- a/src/steer.rs
+++ b/src/steer.rs
@@ -135,22 +135,38 @@ pub fn advance(
 }
 
 /// Cheap fallback for [`advance`] when the mover is far from the hero/camera (ambient wildlife or
-/// camp orks beyond their LOD radius): a straight line toward the goal with the same turn-rate
-/// cap, but NO obstacle-fan scan or footing/blocker checks. `advance`'s 9-direction escape-fan
-/// alone costs up to ~80 terrain/blocker lookups per call (`step_clear` → `can_stand`'s 5
-/// `footing()` samples × up to 3 `blockers::is_blocked` checks, × 9 candidate headings) — measured
-/// (segmented `Instant` timing inside `wildlife::animal_brain`, after gating the predator/prey
-/// search itself turned out to be a near-zero-cost no-op) as ~99% of the wildlife brain's real
-/// per-frame cost. Wholly wasted on an actor nobody's near enough to see clip through a rock.
-/// Never boxed-in (no obstacle-fan to fail), but it DOES keep a single centre-footing gate: the
-/// step is refused if the new centre has no footing (open water / void). Without it a far animal
-/// walks straight onto a carved river — the render then has no ground to sit on and falls back to
-/// its stale Y, so it visibly FLOATS over the water ("bears floating next to rivers"). One
-/// `footing()` sample per frame, vs the ~80 the full `advance` fan costs, so LOD savings stand.
+/// camp orks beyond their LOD radius): a straight line toward the goal with the same turn-rate cap
+/// and the same one [`step_clear`] gate, but **no 9-heading escape fan**. The fan is what costs:
+/// up to ~80 terrain/blocker lookups per call (`step_clear` → `can_stand`'s 5 `footing()` samples ×
+/// up to 3 `blockers::is_blocked` checks, × 9 candidate headings) — measured (segmented `Instant`
+/// timing inside `wildlife::animal_brain`, after gating the predator/prey search itself turned out
+/// to be a near-zero-cost no-op) as ~99% of the wildlife brain's real per-frame cost. Dropping the
+/// fan to a single `step_clear` keeps ~90% of that saving.
+///
+/// **It keeps the full `step_clear` gate on purpose — do not thin it back to a bare `footing()`
+/// sample.** `step_clear` is the *only* thing that consults [`crate::blockers`], so a centre-only
+/// footing test didn't just trade away prop clipping (the documented, accepted cost): it dropped
+/// wall segments, gate towers, the keep box and every building, plus the [`MAX_STEP`] height cap.
+/// A far mover then walked THROUGH the castle wall instead of threading its gate and stepped
+/// straight up a mesa face — both plainly visible whenever the fight moved away from the hero (a
+/// guard chasing an invader out past the wall ring, a rival raid marching the length of the
+/// island). Being footing-gated also still stops the "bears floating next to rivers" case, where a
+/// far animal walked onto a carved river and the render fell back to its stale Y.
+///
+/// Never boxed-in (no fan to fail) — a blocked step pivots in place toward the goal and reports
+/// `moving: false`, which is what the callers' stall/wedge clocks read to re-plan.
 ///
 /// Prefer [`advance_lod`] at a call site that wants the LOD split — it keeps the branch (and its
 /// rationale) in one place.
-pub fn advance_direct(pos: Vec2, facing: f32, goal: Vec2, step_dist: f32, max_turn_dt: f32) -> Step {
+pub fn advance_direct(
+    pos: Vec2,
+    facing: f32,
+    goal: Vec2,
+    step_dist: f32,
+    body_r: f32,
+    cur_y: f32,
+    max_turn_dt: f32,
+) -> Step {
     let to = goal - pos;
     let dist = to.length();
     if dist < 1e-4 {
@@ -159,10 +175,10 @@ pub fn advance_direct(pos: Vec2, facing: f32, goal: Vec2, step_dist: f32, max_tu
     let want = to.x.atan2(to.y);
     let new_facing = facing + wrap_pi(want - facing).clamp(-max_turn_dt, max_turn_dt);
     let fdir = Vec2::new(new_facing.sin(), new_facing.cos());
-    let np = pos + fdir * step_dist;
-    // Only step where there's ground to stand on; else pivot in place (turn toward goal, don't move).
-    if footing(np.x, np.y).is_some() {
-        Step { facing: new_facing, pos: np, moving: true }
+    // Same gate as the near path — ground, step height AND props/walls/buildings; else pivot in
+    // place (turn toward the goal, don't move) so the caller's stall clock can notice and re-plan.
+    if step_clear(pos, fdir, step_dist, body_r, cur_y) {
+        Step { facing: new_facing, pos: pos + fdir * step_dist, moving: true }
     } else {
         Step { facing: new_facing, pos, moving: false }
     }
@@ -188,9 +204,10 @@ pub fn advance_direct(pos: Vec2, facing: f32, goal: Vec2, step_dist: f32, max_tu
 pub const LOD_R: f32 = 90.0;
 
 /// [`advance`] with the shared distance LOD applied: a `near` mover pays the full escape-fan; a far
-/// one gets [`advance_direct`]'s straight line (still footing-gated, so it can't walk onto water —
-/// but no prop/cliff fan). A far mover therefore never reports "boxed in" (`None`), which is
-/// correct: with no fan there is nothing to be boxed in by.
+/// one gets [`advance_direct`]'s straight line — same `step_clear` gate (ground, step height,
+/// props, walls, buildings), just no fan to steer around what it hits. A far mover therefore never
+/// reports "boxed in" (`None`), which is correct: with no fan there is nothing to be boxed in by;
+/// it pivots in place with `moving: false` until its caller re-plans or the hero comes near.
 ///
 /// **The LOD swaps the local-avoidance flavour only — never the route.** A caller following an A*
 /// [`crate::navgrid::NavPath`] keeps feeding its next waypoint as `goal`, so a far invader still
@@ -210,6 +227,40 @@ pub fn advance_lod(
     if near {
         advance(pos, facing, goal, step_dist, body_r, cur_y, max_turn_dt)
     } else {
-        Some(advance_direct(pos, facing, goal, step_dist, max_turn_dt))
+        Some(advance_direct(pos, facing, goal, step_dist, body_r, cur_y, max_turn_dt))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The far LOD path must still respect blockers.** The v0.22.0 perf pass gave
+    /// [`advance_direct`] a bare centre-`footing` gate, which reads terrain only — [`step_clear`] is
+    /// the sole caller of [`crate::blockers`]. A far mover therefore walked straight through wall
+    /// segments, gate towers, the keep box and every building, wherever the fight moved away from
+    /// the hero. Pin that the direct step refuses a blocked heading while the identical unblocked
+    /// step advances.
+    #[test]
+    fn the_far_path_refuses_a_blocked_step() {
+        let _g = crate::blockers::TEST_LOCK.lock().unwrap();
+        crate::blockers::reset();
+
+        // The castle sits at the origin on force-flattened grass, so this is stable open ground.
+        let pos = Vec2::new(0.0, 0.0);
+        let cur_y = footing(pos.x, pos.y).expect("the castle grass must have footing");
+        let goal = Vec2::new(0.0, 6.0); // due +Z, i.e. facing 0
+        let (step, body_r, turn) = (0.5, 0.4, 1.0);
+
+        let clear = advance_direct(pos, 0.0, goal, step, body_r, cur_y, turn);
+        assert!(clear.moving, "open ground must advance");
+
+        // Drop a wall across the path, one step ahead.
+        crate::blockers::add_box(0.0, 0.6, 3.0, 0.3);
+        let blocked = advance_direct(pos, 0.0, goal, step, body_r, cur_y, turn);
+        assert!(!blocked.moving, "a wall across the path must refuse the far step too");
+        assert_eq!(blocked.pos, pos, "a refused step pivots in place, it does not phase through");
+
+        crate::blockers::reset();
     }
 }

--- a/src/steer.rs
+++ b/src/steer.rs
@@ -178,6 +178,13 @@ pub fn advance_direct(pos: Vec2, facing: f32, goal: Vec2, step_dist: f32, max_tu
 /// fan scan it saves is ~80 terrain/blocker lookups per mover per frame, i.e. the single biggest
 /// per-agent CPU cost in an endgame frame (120–150 live agents: a big ork wave + the militia + the
 /// town + wildlife).
+///
+/// **The ring is purely positional — never conjoin it with `HeroState::alive`.** `alive` goes false
+/// for the whole down/succession window, so `hero.alive && d < LOD_R` collapsed the LOD for *every*
+/// actor on the map the instant the hero was killed — including the orks standing on the corpse —
+/// dropping them all to the fan-free [`advance_direct`] just as `succession` slow-mos the world and
+/// swings the camera onto that exact crowd. `HeroState::pos` keeps mirroring the body while down,
+/// so measuring against it is both correct and still cheap.
 pub const LOD_R: f32 = 90.0;
 
 /// [`advance`] with the shared distance LOD applied: a `near` mover pays the full escape-fan; a far

--- a/src/succession.rs
+++ b/src/succession.rs
@@ -85,7 +85,7 @@ impl Plugin for SuccessionPlugin {
         // in the RTS. Resources stay registered; every system is gated.
         app.init_resource::<Lives>()
             .init_resource::<Succession>()
-            .add_systems(OnExit(AppState::StartScreen), reset_lives.run_if(crate::rts::in_campaign))
+            .add_systems(OnExit(AppState::StartScreen), reset_lives.run_if(crate::rts::in_campaign).run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(AppState::GameOver), reset_lives.run_if(crate::rts::in_campaign))
             // `OnExit(GameOver)` fires on an in-process Continue (fresh runs relaunch instead);
             // `reset_lives` clears the defeat flag before `apply_pending_load` restores the save.

--- a/src/town.rs
+++ b/src/town.rs
@@ -239,7 +239,7 @@ impl Plugin for TownPlugin {
             // START_WOOD grant must come last or it gets wiped (system-order race).
             .add_systems(
                 OnExit(AppState::StartScreen),
-                reset_town.after(crate::economy::reset_economy),
+                reset_town.after(crate::economy::reset_economy).run_if(crate::game_state::fresh_run_reset),
             )
             .add_systems(
                 OnExit(AppState::GameOver),

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -1553,7 +1553,9 @@ fn ground_pickup(
             && try_grant(&mut inv.0, &mut toasts.0, d.item_id, 1, now)
         {
             cues.write(AudioCue::UiSelect);
-            commands.entity(e).despawn();
+            // `try_despawn`: drops are `BiomeEntity`, so the world-rebuild wipe can beat this reap
+            // when the hero happens to be standing on one as a biome swap / New Game fires.
+            commands.entity(e).try_despawn();
         }
     }
 }

--- a/src/villagers.rs
+++ b/src/villagers.rs
@@ -405,7 +405,7 @@ impl Plugin for VillagersPlugin {
                 Update,
                 disband_on_load.after(rally_follow).before(guard_combat),
             )
-            .add_systems(OnExit(crate::game_state::AppState::StartScreen), reset_rescues)
+            .add_systems(OnExit(crate::game_state::AppState::StartScreen), reset_rescues.run_if(crate::game_state::fresh_run_reset))
             .add_systems(OnExit(crate::game_state::AppState::GameOver), reset_rescues)
             .add_systems(
                 Update,
@@ -870,7 +870,10 @@ fn camp_rescue(
     time: Res<Time>,
     mut town: ResMut<crate::town::TownRes>,
     mut rescued: ResMut<RescuedCamps>,
-    orks: Query<&crate::orks::Ork, Without<crate::orks::WaveInvader>>,
+    // `Without<Dying>` like the two systems this was cloned from (`ork_fortress::blight_rescue`,
+    // `camps::respawn_warbands`): without it a camp's fading corpses read as a live warband, so the
+    // cage stayed shut and the "+N townsfolk" payoff lagged the killing blow by the full 1.4s fade.
+    orks: Query<&crate::orks::Ork, (Without<crate::orks::WaveInvader>, Without<crate::dying::Dying>)>,
     cages_q: Query<(&crate::camps::Cage, &Transform)>,
     mut doors_q: Query<&mut crate::camps::CageDoor>,
     caged_q: Query<(Entity, &Captive)>,
@@ -1013,7 +1016,8 @@ fn villager_brain(
                     // that clips a house corner from 90u away is invisible, and `step_clear` waives
                     // the prop test for a mover already inside a blocker, so one that ends up in a
                     // wall simply walks back out when the hero returns.
-                    let near = hero.alive && v.pos.distance(hero.pos) < crate::steer::LOD_R;
+                    // Positional only — never conjoined with `hero.alive`; see `steer::LOD_R`.
+                    let near = v.pos.distance(hero.pos) < crate::steer::LOD_R;
                     match steer::advance_lod(near, v.pos, v.facing, v.target, v.speed * dt, v.body_r, cur_y, VIL_MAX_TURN * dt) {
                         Some(s) => {
                             v.facing = s.facing;

--- a/src/wildlife.rs
+++ b/src/wildlife.rs
@@ -387,18 +387,26 @@ fn animal_brain(
                     a.moving = false;
                 } else {
                     let spd = if a.mode == Mode::Flee { a.speed } else { a.wander_speed };
-                    // Far from the hero: skip the obstacle-aware fan-scan entirely (see
-                    // `steer::advance_direct` — this IS the real cost this whole LOD pass was
-                    // chasing, not the predator/prey search). A distant animal clipping a rock
-                    // nobody's near enough to see is a non-issue; the cheap direct line is enough
-                    // to keep it visibly wandering.
+                    // Far from the hero: skip the 9-heading escape fan (see `steer::advance_direct`
+                    // — the fan IS the real cost this whole LOD pass was chasing, not the
+                    // predator/prey search). The step is still fully gated on ground, step height
+                    // and blockers, so a distant animal can't walk through a wall or up a cliff;
+                    // it just doesn't steer *around* what it bumps into.
+                    let cur_y = footing(a.pos.x, a.pos.y).unwrap_or(tf.translation.y);
                     if !near {
-                        let s = steer::advance_direct(a.pos, a.facing, a.target, spd * dt, MAX_TURN * dt);
+                        let s = steer::advance_direct(
+                            a.pos,
+                            a.facing,
+                            a.target,
+                            spd * dt,
+                            a.body_r,
+                            cur_y,
+                            MAX_TURN * dt,
+                        );
                         a.facing = s.facing;
                         a.pos = s.pos;
                         a.moving = s.moving;
                     } else {
-                        let cur_y = footing(a.pos.x, a.pos.y).unwrap_or(tf.translation.y);
                         // Shared local steering (escape-fan + continuity bias + turn-rate cap) —
                         // the anti-flicker logic, identical for orks (see `steer.rs`).
                         match steer::advance(a.pos, a.facing, a.target, spd * dt, a.body_r, cur_y, MAX_TURN * dt) {

--- a/src/wildlife.rs
+++ b/src/wildlife.rs
@@ -247,7 +247,8 @@ fn animal_brain(
         // never lets them leave that state once the search is gated on it — a ratchet that stayed
         // permanently open. Instead, explicitly snap a distant chase back to Graze the moment it's
         // out of LOD range: nobody's watching a wolf run down a deer 150 world-units away anyway.
-        let near = hero.alive && a.pos.distance(hero.pos) < BRAIN_LOD_R;
+        // Positional only — never conjoined with `hero.alive`; see `steer::LOD_R`.
+        let near = a.pos.distance(hero.pos) < BRAIN_LOD_R;
         if !near {
             if matches!(a.mode, Mode::Hunt | Mode::Flee) {
                 a.mode = Mode::Graze;


### PR DESCRIPTION
A code-review pass over the v0.22.0 work, plus the version bump that cuts the release.
`cargo test` green (121 passed, up from 116 — four new regression tests).

## The run-losing one

**RESUME on the title screen wiped the live run.** RESUME (offered once a run is live, via the
pause menu's MAIN MENU) re-enters `Playing` through the exact `StartScreen → Playing` edge that
every fresh-run path is funnelled through — and `OnExit(StartScreen)` is where the whole `reset_*`
suite lives. So resuming ran the full wipe: level 1, no gold, empty satchel, upgrade tree cleared,
town buildings despawned, wardens respawned. Nothing restored afterwards, and no save had been
written since the last dawn, so the run was simply gone.

A one-shot `ResumingRun` flag now gates all fifteen run-state resets behind
`game_state::fresh_run_reset`. New Game and Continue still wipe (Continue then overwrites from the
snapshot); an armed fresh run always clears a stale flag, so the New Game path can't inherit one.

## Save/load

- **A load only ever advanced world-entity flags, never rolled them back.** A same-map Continue
  never rebuilds the world, so a chest looted (or a rune trial won) *after* the save survived the
  load while the loot itself rolled out of the satchel — the chest stayed shut to `chest_interact`,
  the trial stayed claimed, both unreachable for the rest of the process, and `Discoveries::found`
  could never reach `total` again. Chest and landmark restores now mirror the snapshot in both
  directions.
- A failed periodic autosave cleared `pending` before the write landed, silently discarding the
  owed save. It now stays owed and retries on an `AUTOSAVE_RETRY` back-off.

## Combat & crowds

- **The melee ring starved after a kill.** `MeleeRing::release` only fires on landing a blow, and
  `try_claim`'s prune only drops *expired* holders — so an ork killed mid-swing kept its token for
  the rest of its 2.6s. With `MELEE_CAP` at 2, killing the two orks pressing you froze the whole
  surrounding horde out of the ring: they prowled and swung at nothing, the exact symptom the
  module doc says the design removed. Slain holders are reaped each frame.
- **The steering LOD collapsed the moment the hero died.** Six brains derived `near` as
  `hero.alive && d < LOD_R`, and `HeroState::alive` is false for the whole down/succession window —
  so every ork, invader, villager, worker and raider on the map, *including the ones standing on
  the corpse*, dropped to the fan-free `advance_direct` just as succession slow-mos the world and
  swings the camera onto that crowd. The ring is positional now; `hero.pos` keeps mirroring the
  body while down.
- **The far LOD path skipped collision entirely.** `advance_direct` was given a bare centre-`footing`
  gate, and `step_clear` is the only caller of `blockers` — so the trade wasn't just "a distant body
  clips a rock": wall segments, gate towers, the keep box and every building stopped blocking far
  movers, and `MAX_STEP` stopped capping their step height. Anywhere the fight moved away from the
  hero, bodies crossed the wall ring instead of threading its gate and stepped up mesa faces. It now
  runs the same single `step_clear`, still without the 9-heading escape fan — ~8 lookups instead of
  ~80, so ~90% of the LOD saving stands. A blocked far step reports `moving: false`, which also
  re-enables the callers' stall/wedge clocks (previously unreachable, since the old path always
  reported movement).
- `camp_rescue` counted fading corpses as a live warband, withholding the rescue payoff for the full
  1.4s death fade. Its two sibling systems already filter `Dying`.

## Crash races

- `boss::tick_status` iterated corpses for `Slowed` and used bare `remove` for both status
  components — a status expiring on the frame another system reaps the entity panicked.
- Fading combat decals (`FxFade`) and ground loot drops are tagged `BiomeEntity`, so the
  world-rebuild wipe raced their bare `despawn`.
- Animal idle calls fired from corpses and attached children with a bare command (now
  `queue_silenced`, matching `ambience::attach_campfire_audio`); an empty clip set also underflowed
  `len() - 1`.
- `step_wave_director` cast `wave_index` to `usize` before clamping, so the documented `-1` day-one
  value would have selected the boss wave. Now clamps first, like `night_dmg_scale`.
- `FOREST_DOF` dropped unparseable fields instead of failing, silently shifting the rest, and
  accepted `NaN` straight into the shader uniform.

## Release

Bumps `Cargo.toml` to **0.22.1** and adds the `site/changelog.html` entry (demoting v0.22.0), so
merging this fires `release-on-bump.yml` → tag `v0.22.1`, Windows/Linux builds + MSI, the GitHub
release, the itch.io push and the Pages redeploy. Player-facing notes are in `dist-notes.md`.
Content is bug fixes plus the Bevy 0.19.1 engine bump — no new features, hence a patch.

## Tests

`cargo test` → 121 passed / 0 failed. New:

- `game_state::resume_from_the_title_skips_the_fresh_run_resets`
- `savegame::load_reopens_and_recloses_chests_to_match_the_snapshot`
- `savegame::load_rewinds_landmark_discovery_and_gear_flags`
- `steer::the_far_path_refuses_a_blocked_step` (verified failing against the old gate)
- `siege::day_one_wave_index_selects_the_first_wave_not_the_boss`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nwv382kh88JtaDgdNaqFrN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwv382kh88JtaDgdNaqFrN)_