### PR TITLE
docs(release): add v0.22.1 notes at the path CI actually reads

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -36,7 +36,16 @@ player's point of view**:
 
 1. **Pick the version.** Ask the user patch vs minor if it's not obvious (features → minor). Bump
    `version` in `Cargo.toml`.
-2. **Write release notes** to `dist-notes.md` (markdown — this becomes the GitHub-release body).
+2. **Write release notes** to **BOTH** paths — they feed two different publish routes and only
+   one of them is `dist-notes.md`:
+   - `dist-notes.md` — what `scripts/release.ps1 -NotesFile` reads on the dev-machine route. It is
+     **gitignored**, so it never reaches CI.
+   - `docs/release-notes/vX.Y.Z.md` — what `release.yml`'s "Locate handwritten release notes" step
+     looks for, and the ONLY notes CI can see. **Commit it.** Miss it and the CI route silently
+     publishes GitHub's auto-generated "What's Changed" PR list as the release body instead of your
+     notes (this is exactly what happened to v0.22.1 — fixed after the fact via the releases API).
+     This matters most on the web/cloud route, where CI is the only publisher.
+
    Use the writing guidance above. End with the self-signed-installer SmartScreen note.
 3. **Write the `site/changelog.html` entry**: insert a new `<article class="rel latest rv">` at the
    top of `<main class="log">`, and **demote the previous latest** (drop its `latest` class and
@@ -44,8 +53,9 @@ player's point of view**:
    (rel-ver / rel-badge / rel-date) · `rel-sum` · `rel-card` with `grp` blocks tagged
    `tag new` / `tag fix` / `tag perf` · `rel-foot` linking to
    `https://github.com/miskibin/warbell/releases/tag/vX`. Download links stay `Warbell-Setup.msi`.
-4. **Commit the version bump + changelog** with explicit paths (never `git add -A` — the MSI/PDB
-   are gitignored but stay explicit): `git commit -- Cargo.toml Cargo.lock site/changelog.html`
+4. **Commit the version bump + changelog + notes** with explicit paths (never `git add -A` — the
+   MSI/PDB are gitignored but stay explicit):
+   `git commit -- Cargo.toml Cargo.lock site/changelog.html docs/release-notes/vX.Y.Z.md`
    with a `chore(release): vX.Y.Z` message. Don't push yet — the script pushes `main`. (Pushing
    `main` with the changelog also triggers `pages.yml` to redeploy the site.)
 5. **Confirm with the user** before publishing — the next step is public and hard to undo.
@@ -53,7 +63,10 @@ player's point of view**:
    the exe + `Warbell-Setup.msi`, pushes `main` + the tag (→ CI canonical release + Pages redeploy),
    and creates/updates the release with our notes + the MSI attached.
 7. **Verify**:
-   - `gh release view vX.Y.Z --repo miskibin/warbell --json tagName,assets` → shows `Warbell-Setup.msi`.
+   - `gh release view vX.Y.Z --repo miskibin/warbell --json tagName,assets,body` → shows
+     `Warbell-Setup.msi` AND **your** notes in the body, not a "What's Changed" PR list. A PR list
+     means `docs/release-notes/vX.Y.Z.md` was missing at the release commit; fix the body with
+     `gh release edit vX.Y.Z --notes-file docs/release-notes/vX.Y.Z.md` and commit the file.
    - `gh release list --repo miskibin/warbell --limit 1` → the new version is `Latest` (so the
      `latest/download` link resolves).
    - `gh run list --repo miskibin/warbell --workflow release.yml --limit 1` → CI build is running.

--- a/docs/release-notes/v0.22.1.md
+++ b/docs/release-notes/v0.22.1.md
@@ -1,0 +1,57 @@
+A bug-fix release. One of these could quietly destroy a run, so it's worth updating even if
+nothing here sounds dramatic.
+
+## Fixed — your save
+
+- **RESUME on the title screen no longer wipes your run.** Going to the main menu mid-game and
+  clicking **RESUME** dropped you back into the world at *night one* — level 1, no gold, empty
+  satchel, upgrade tree cleared, town buildings gone. Re-entering the world through the title took
+  the same code path as starting a fresh run, so the game reset everything on the way in, and since
+  nothing had been saved since the last dawn, the run was simply lost. RESUME now returns you to the
+  run exactly as you left it.
+- **Loading a save properly rewinds the world.** Loot a treasure chest (or win a landmark's
+  Hold-the-Rune trial), then die and Continue from an earlier save: the loot correctly disappeared
+  from your satchel, but the chest stayed open and the trial stayed claimed — so that treasure and
+  that gear were gone for good until you restarted the game. Chests and landmarks now rewind with
+  the rest of the save, and the "all landmarks found" bonus is reachable again.
+- **An autosave that fails to write is retried** instead of silently skipped for another ten minutes.
+
+## Fixed — combat & crowds
+
+- **Orks stop circling and swinging at nothing after you kill the ones attacking you.** Only two orks
+  may press you at once; the two you just cut down were still holding those slots for up to 2.6
+  seconds, so the horde around you prowled instead of stepping in. The slots free up the moment a
+  striker drops.
+- **Enemies and townsfolk stop walking through your castle walls.** Last release's performance pass
+  gave anyone more than ~90 m from the hero a cheap straight-line step that skipped collision
+  entirely — not just brushing past rocks, but wall segments, gate towers, the keep and every
+  building, plus the limit on how high a step can be. Whenever the fighting moved away from you —
+  a guard chasing a raider out past the wall ring, a rival war party marching across the island —
+  bodies crossed the wall instead of threading the gate and climbed straight up cliff faces.
+  Distant movers are properly blocked again, and still cost a fraction of the old full check.
+- **The world stops falling apart the instant you die.** Every ork, invader, villager, worker and
+  raider on the island switched to cheap "far away" movement the moment the hero went down —
+  including the ones standing over your body — so they drifted through walls and houses in slow
+  motion while the succession camera swung onto exactly that crowd.
+- **Camps free their prisoners the moment the last ork falls**, instead of waiting out the death
+  animation first.
+- Freshly killed animals no longer bark or howl while they topple.
+
+## Fixed — crashes
+
+- Several rare crashes where a frozen or poisoned enemy, a fading hit effect, a dropped item or an
+  animal's idle call landed on the exact frame the game removed that creature or rebuilt the world
+  (a biome swap or a New Game).
+- The night director's difficulty lookup could have selected the final boss wave on day one; the
+  first night is pinned to the first wave.
+
+## Under the hood
+
+- Engine updated to Bevy 0.19.1.
+- Three new regression tests cover the RESUME wipe and both halves of the save-rewind bug, so none
+  of them can come back unnoticed.
+
+---
+
+**Windows note:** the installer is self-signed, so SmartScreen may show an "Unknown Publisher"
+warning — click *More info → Run anyway*.


### PR DESCRIPTION
Follow-up to #70 — docs only, no code, no version change.

`release.yml`'s "Locate handwritten release notes" step reads `docs/release-notes/<tag>.md`.
`dist-notes.md` is the input to `scripts/release.ps1` on the dev-machine route and is
**gitignored**, so it never reaches CI. #70 wrote only the latter, so v0.22.1 published with
GitHub's auto-generated "What's Changed" PR list as its release body instead of the player-facing
notes.

- Adds `docs/release-notes/v0.22.1.md` (the notes verbatim).
- Teaches `.claude/skills/release/SKILL.md` that the two paths are different and both are
  required — the web/cloud route has CI as its only publisher, so missing the committed one
  silently degrades the release body. The verify step now checks `body` too, not just the assets.

The published release's body is refreshed by re-dispatching `release.yml` for the existing
`v0.22.1` tag once this lands; `action-gh-release` updates the body from `body_path` and
re-uploads the same assets. `Cargo.toml` is untouched, so `release-on-bump.yml` will not fire a
second release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nwv382kh88JtaDgdNaqFrN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwv382kh88JtaDgdNaqFrN)_